### PR TITLE
Refactor ldap user searching.

### DIFF
--- a/config/local_settings.py.sample
+++ b/config/local_settings.py.sample
@@ -106,22 +106,15 @@ EXTRA_AUTHENTICATION_BACKENDS = []
 # EXTRA_AUTHENTICATION_BACKENDS += ['django_su.backends.SuBackend',]
 
 #------------------------------------------------------------------------------
-# Enable LDAP user searches. This will be used when searching users to add to
-# projects/subscriptions.
-#------------------------------------------------------------------------------
-# AUTH_LDAP_SERVER_URI = 'ldap://localhost'
-# AUTH_LDAP_USER_SEARCH_BASE = 'cn=users,cn=accounts,dc=localhost,dc=localdomain'
-# AUTH_LDAP_START_TLS = True
-# ADDITIONAL_USER_SEARCH_CLASSES = ['extra.djangoapps.ldap_user_search.utils.LDAPUserSearch',]
-
-#------------------------------------------------------------------------------
-# Enable LDAP user authentication. This will enable LDAP user/password logins.
-# This also requires the above settings for user search to be set as well.
+# Example config for enabling LDAP user authentication using django-auth-ldap.
+# This will enable LDAP user/password logins.
 #------------------------------------------------------------------------------
 # import ldap
 # from django_auth_ldap.config import GroupOfNamesType, LDAPSearch
 #
-# EXTRA_AUTHENTICATION_BACKENDS += ['django_auth_ldap.backend.LDAPBackend',]
+# AUTH_LDAP_SERVER_URI = 'ldap://localhost'
+# AUTH_LDAP_USER_SEARCH_BASE = 'cn=users,cn=accounts,dc=localhost,dc=localdomain'
+# AUTH_LDAP_START_TLS = True
 # AUTH_LDAP_BIND_AS_AUTHENTICATING_USER=True
 # AUTH_LDAP_MIRROR_GROUPS = True
 # AUTH_LDAP_USER_SEARCH = LDAPSearch(
@@ -136,6 +129,8 @@ EXTRA_AUTHENTICATION_BACKENDS = []
 #     'last_name': 'sn',
 #     'email': 'mail',
 # }
+#
+# EXTRA_AUTHENTICATION_BACKENDS += ['django_auth_ldap.backend.LDAPBackend',]
 
 
 #===============================================================================
@@ -169,12 +164,15 @@ EXTRA_AUTHENTICATION_BACKENDS = []
 
 
 #------------------------------------------------------------------------------
-# Enable freeipa app
+# Enable FreeIPA app for updating group membership and user search
 #------------------------------------------------------------------------------
 # EXTRA_APPS += [
 #     'extra.djangoapps.freeipa',
 # ]
 # FREEIPA_KTNAME = '/path/to/user.keytab'
+# FREEIPA_SERVER = 'freeipa.localhost.localdomain'
+# FREEIPA_USER_SEARCH_BASE = 'cn=users,cn=accounts,dc=example,dc=edu'
+# ADDITIONAL_USER_SEARCH_CLASSES = ['extra.djangoapps.freeipa.search.LDAPUserSearch',]
 
 #------------------------------------------------------------------------------
 # Enable Mokey/Hydra OpenID Connect Authentication Backend

--- a/extra/djangoapps/freeipa/README.md
+++ b/extra/djangoapps/freeipa/README.md
@@ -8,7 +8,8 @@ app enabled, when a user is added/removed from a subscription, they are also
 added/removed from any configured FreeIPA unix groups. If a host has the
 appropriate HBAC rule in place to restrict access to only allowed groups then
 this can provide a way for PI's in Coldfront to manage access to their
-resources.
+resources. This app also provides searching FreeIPA LDAP when adding users to
+projects and subscriptions.
 
 ## Design
 
@@ -45,6 +46,9 @@ local\_settings.py file:
     ]
     FREEIPA_KTNAME = '/path/to/user.keytab'
     FREEIPA_GROUP_ATTRIBUTE_NAME = 'freeipa_group' 
+    FREEIPA_SERVER = 'freeipa.localhost.localdomain'
+    FREEIPA_USER_SEARCH_BASE = 'cn=users,cn=accounts,dc=example,dc=edu'
+    ADDITIONAL_USER_SEARCH_CLASSES = ['extra.djangoapps.freeipa.search.LDAPUserSearch',]
 ```
 
 The "FREEIPA\_KTNAME" should be the path to the keytab file for a user in

--- a/extra/djangoapps/ldap_user_search/README.md
+++ b/extra/djangoapps/ldap_user_search/README.md
@@ -1,8 +1,11 @@
-# LDAP user search for Coldfront
+# Example custom LDAP user search for Coldfront
 
 Coldfront django extra app providing user searching using LDAP. When adding
 users to a subscription or a project, Coldfront will by default look in the
-local database only. This app enables searching an LDAP directory.
+local database only. This app enables searching an LDAP directory. This is just
+an example and the code will most likely need to be adapted to your particular
+LDAP schema. See the code in utils.py and modify accordingly. Also see the
+search.py code in the FreeIPA extra app.
 
 ## Design
 


### PR DESCRIPTION
- LDAP user searching is very much schema specific so this functionality has
  been moved to the freeipa app. ldap_user_search is being left as an example
  only.
- Add support for Kerberos SASL/GSSAPI authenticated binds to allow email
  addresses to be returned in searches.
- Limit searches to only active users.
- Update documentation