### PR TITLE
Refactor slurm_check.

### DIFF
--- a/coldfront/plugins/slurm/associations.py
+++ b/coldfront/plugins/slurm/associations.py
@@ -25,6 +25,15 @@ class SlurmBase:
         self.name = name
         self.specs = specs
 
+    def spec_list(self):
+        """Return unique list of Slurm Specs"""
+        items = []
+        for s in self.specs:
+            for i in s.split(':'):
+                items.append(i)
+
+        return list(set(items))
+
     def format_specs(self):
         """Format unique list of Slurm Specs"""
         items = []
@@ -32,7 +41,7 @@ class SlurmBase:
             for i in s.split(':'):
                 items.append(i)
 
-        return ':'.join([x for x in list(set(items))])
+        return ':'.join([x for x in self.spec_list()])
 
     def _write(self, out, data):
         try:
@@ -125,7 +134,7 @@ class SlurmCluster(SlurmBase):
         if not name:
             name = 'root'
 
-        logger.info("Adding allocation name=%s specs=%s user_specs=%s", name, specs, user_specs)
+        logger.debug("Adding allocation name=%s specs=%s user_specs=%s", name, specs, user_specs)
         account = self.accounts.get(name, SlurmAccount(name))
         account.add_allocation(allocation, user_specs=user_specs)
         account.specs += specs

--- a/coldfront/plugins/slurm/utils.py
+++ b/coldfront/plugins/slurm/utils.py
@@ -12,6 +12,7 @@ SLURM_SPECS_ATTRIBUTE_NAME = import_from_settings('SLURM_SPECS_ATTRIBUTE_NAME', 
 SLURM_USER_SPECS_ATTRIBUTE_NAME = import_from_settings('SLURM_USER_SPECS_ATTRIBUTE_NAME', 'slurm_user_specs')
 SLURM_SACCTMGR_PATH = import_from_settings('SLURM_SACCTMGR_PATH', '/usr/bin/sacctmgr')
 SLURM_CMD_REMOVE_USER = SLURM_SACCTMGR_PATH + ' -Q -i delete user where name={} cluster={} account={}'
+SLURM_CMD_REMOVE_QOS = SLURM_SACCTMGR_PATH + ' -Q -i modify user where name={} cluster={} account={} set {}'
 SLURM_CMD_REMOVE_ACCOUNT = SLURM_SACCTMGR_PATH + ' -Q -i delete account where name={} cluster={}'
 SLURM_CMD_ADD_ACCOUNT = SLURM_SACCTMGR_PATH + ' -Q -i create account name={} cluster={}'
 SLURM_CMD_ADD_USER = SLURM_SACCTMGR_PATH + ' -Q -i create user name={} cluster={} account={}'
@@ -52,6 +53,10 @@ def _run_slurm_cmd(cmd, noop=True):
 
 def slurm_remove_assoc(user, cluster, account, noop=False):
     cmd = SLURM_CMD_REMOVE_USER.format(shlex.quote(user), shlex.quote(cluster), shlex.quote(account))
+    _run_slurm_cmd(cmd, noop=noop)
+
+def slurm_remove_qos(user, cluster, account, qos, noop=False):
+    cmd = SLURM_CMD_REMOVE_QOS.format(shlex.quote(user), shlex.quote(cluster), shlex.quote(account), shlex.quote(qos))
     _run_slurm_cmd(cmd, noop=noop)
 
 def slurm_remove_account(cluster, account, noop=False):


### PR DESCRIPTION
- The sacctmgr load command detects *addition* changes to associations but does
not detect when something is removed

- The slurm_check coldfront command now only checks for deletions. i.e. if an
account or user has been removed.

- slurm_check also looks for any QOS specs that have been removed from
coldfront but are still in slurm.