### PR TITLE
[fix] Close vulnerability by adding `rel="noopener"`

### DIFF
--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -308,7 +308,7 @@ Project Detail
         <tbody>
           {% for publication in publications %}
           <tr>
-            <td><strong>Title: </strong>{{ publication.title }} <a target="_blank" href="{{publication.source.url}}{{publication.unique_id}}"><i class="fas fa-external-link-alt"></i></a> 
+            <td><strong>Title: </strong>{{ publication.title }} <a target="_blank" rel="noopener" href="{{publication.source.url}}{{publication.unique_id}}"><i class="fas fa-external-link-alt"></i></a> 
               <br><strong>Author: </strong>{{ publication.author}}</td>
             <td style="white-space:nowrap;">{{ publication.year }}</td>
           </tr>


### PR DESCRIPTION
External URLs with `target="_blank"` should have either `rel="noopener"`
or `rel="noreferrer"` to prevent malicious use of `window.opener`

Refs: https://developers.google.com/web/tools/lighthouse/audits/noopener