### PR TITLE
[fix] Display form validation errors

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -747,7 +747,11 @@ class AllocationAddUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
                                                   allocation_user_pk=allocation_user_obj.pk)
             messages.success(
                 request, 'Added {} users to allocation.'.format(users_added_count))
-            return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
+        else:
+            for error in formset.errors:
+                messages.error(request, error)
+
+        return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
 
 
 class AllocationRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
@@ -856,7 +860,11 @@ class AllocationRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, Templat
 
             messages.success(
                 request, 'Removed {} users from allocation.'.format(remove_users_count))
-            return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
+        else:
+            for error in formset.errors:
+                messages.error(request, error)
+
+        return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
 
 
 class AllocationAttributeCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
@@ -969,7 +977,11 @@ class AllocationAttributeDeleteView(LoginRequiredMixin, UserPassesTestMixin, Tem
 
             messages.success(request, 'Deleted {} attributes from allocation.'.format(
                 attributes_deleted_count))
-            return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
+        else:
+            for error in formset.errors:
+                messages.error(request, error)
+
+        return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
 
 
 class AllocationRequestListView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
@@ -1296,7 +1308,11 @@ class AllocationRenewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView)
                 )
 
             messages.success(request, 'Allocation renewed successfully')
-            return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': allocation_obj.project.pk}))
+        else:
+            if not formset.is_valid():
+                for error in formset.errors:
+                    messages.error(request, error)
+        return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': allocation_obj.project.pk}))
 
 
 class AllocationInvoiceListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
@@ -1367,7 +1383,10 @@ class AllocationInvoiceDetailView(LoginRequiredMixin, UserPassesTestMixin, Templ
             allocation_obj.status = form_data.get('status')
             allocation_obj.save()
             messages.success(request, 'Allocation updated!')
-            return HttpResponseRedirect(reverse('allocation-invoice-detail', kwargs={'pk': pk}))
+        else:
+            for error in form.errors:
+                messages.error(request, error)
+        return HttpResponseRedirect(reverse('allocation-invoice-detail', kwargs={'pk': pk}))
 
 
 class AllocationAddInvoiceNoteView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
@@ -1478,6 +1497,9 @@ class AllocationDeleteInvoiceNoteView(LoginRequiredMixin, UserPassesTestMixin, T
                     note_obj = AllocationUserNote.objects.get(
                         pk=note_form_data.get('pk'))
                     note_obj.delete()
+        else:
+            for error in formset.errors:
+                messages.error(request, error)
 
         return HttpResponseRedirect(reverse_lazy('allocation-invoice-detail', kwargs={'pk': allocation_obj.pk}))
 

--- a/coldfront/core/grant/views.py
+++ b/coldfront/core/grant/views.py
@@ -171,7 +171,11 @@ class GrantDeleteGrantsView(LoginRequiredMixin, UserPassesTestMixin, TemplateVie
                     grants_deleted_count += 1
 
             messages.success(request, 'Deleted {} grants from project.'.format(grants_deleted_count))
-            return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_obj.pk}))
+        else:
+            for error in formset.errors:
+                messages.error(request, error)
+
+        return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_obj.pk}))
 
     def get_success_url(self):
         return reverse('project-detail', kwargs={'pk': self.object.project.id})

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -669,7 +669,16 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
 
             messages.success(
                 request, 'Added {} users to project.'.format(added_users_count))
-            return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': pk}))
+        else:
+            if not formset.is_valid():
+                for error in formset.errors:
+                    messages.error(request, error)
+
+            if not allocation_form.is_valid():
+                for error in allocation_form.errors:
+                    messages.error(request, error)
+
+        return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': pk}))
 
 
 class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
@@ -775,7 +784,11 @@ class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
 
             messages.success(
                 request, 'Removed {} users from project.'.format(remove_users_count))
-            return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': pk}))
+        else:
+            for error in formset.errors:
+                messages.error(request, error)
+
+        return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': pk}))
 
 
 class ProjectUserDetail(LoginRequiredMixin, UserPassesTestMixin, TemplateView):

--- a/coldfront/core/publication/views.py
+++ b/coldfront/core/publication/views.py
@@ -215,7 +215,11 @@ class PublicationAddView(LoginRequiredMixin, UserPassesTestMixin, View):
                     ', '.join(publications_skipped))
 
             messages.success(request, msg)
-            return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_pk}))
+        else:
+            for error in formset.errors:
+                messages.error(request, error)
+
+        return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_pk}))
 
 
 class PublicationDeletePublicationsView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
@@ -294,7 +298,11 @@ class PublicationDeletePublicationsView(LoginRequiredMixin, UserPassesTestMixin,
 
             messages.success(request, 'Deleted {} publications from project.'.format(
                 publications_deleted_count))
-            return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_obj.pk}))
+        else:
+            for error in formset.errors:
+                messages.error(request, error)
+
+        return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_obj.pk}))
 
     def get_success_url(self):
         return reverse('project-detail', kwargs={'pk': self.object.project.id})


### PR DESCRIPTION
When form validation fails, the method would not return a (required)
`HttpResponse`. This moves the `return` outside of the `if` statement
and pushes form validation errors to the message stack.

Refs: https://github.com/ubccr/coldfront/commit/22c0c8c9ebac62399df3029d1f9256e4db8f827f