### PR TITLE
View all publications option from project detail page - issue #248

### DIFF
--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -416,8 +416,8 @@ Project Detail
 
     $('#publication-table').DataTable({
       "aLengthMenu": [
-        [1, 25, 50, 100, -1],
-        [1, 25, 50, 100, "All"]],
+        [10, 25, 50, 100, -1],
+        [10, 25, 50, 100, "All"]],
       "iDisplayLength": 25,
       "bSortClasses": false,
       "order": [[ 1, "desc" ]]

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -316,7 +316,7 @@ Project Detail
     {% endif %}
   </div>
 </div>
-<!-- End Project Grants -->
+<!-- End Project Publications -->
 
 
 <!-- Start Project ResearchOutputs -->
@@ -392,6 +392,7 @@ Project Detail
     {% endif %}
   </div>
 </div>
+<!-- End Admin Messages -->
 
 <script>
   function getCookie(name) {

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -415,6 +415,9 @@ Project Detail
     $('[data-toggle="popover"]').popover();
 
     $('#publication-table').DataTable({
+      "aLengthMenu": [
+        [1, 25, 50, 100, -1],
+        [1, 25, 50, 100, "All"]],
       "iDisplayLength": 25,
       "bSortClasses": false,
       "order": [[ 1, "desc" ]]


### PR DESCRIPTION
re: Issue #248 

<img width="1144" alt="Screenshot 2020-11-18 at 17 24 04" src="https://user-images.githubusercontent.com/43602931/99586367-659d4080-29c6-11eb-84fe-59fd1f2359b2.png">

looks like publications query in context builder is not limited, so the user should now have access to all publications if they select this option via dropdown.

Line 123-124: core/project/views.py

```python
context['publications'] = Publication.objects.filter(
    project=self.object, status='Active').order_by('-year')
```
