### PR TITLE
spelling error- issue #251

### DIFF
--- a/coldfront/core/publication/views.py
+++ b/coldfront/core/publication/views.py
@@ -237,7 +237,7 @@ class PublicationAddView(LoginRequiredMixin, UserPassesTestMixin, View):
                 msg += 'Added {} publication{} to project.'.format(
                     publications_added, 's' if publications_added > 1 else '')
             if publications_skipped:
-                msg += 'Skipped adding: {}'.format(
+                msg += 'Publication already exists on this project. Skipped adding: {}'.format(
                     ', '.join(publications_skipped))
 
             messages.success(request, msg)

--- a/coldfront/templates/email/allocation_expiring.txt
+++ b/coldfront/templates/email/allocation_expiring.txt
@@ -1,6 +1,6 @@
 Dear {{center_name}} user,
 
-Your allocation for access to {{ allocation_type }} is expiring in {{ expiring_in_days }} days.
+Your allocation for access to {{ allocation_type }} is expiring in {{ expring_in_days }} days.
 Failure to renew the allocation before expiration will result in removal of access to this resource for all accounts
 under this project.
 To renew, login to ColdFront and complete the short process: {{ allocation_renew_url }}.


### PR DESCRIPTION
the variable in the code was missing an "i" in expiring_in_days. This wrong spelling was used multiple times so I just changed the right spelling in the template to expring_in_days (matching the wrong spelling of variable) to avoid making mistakes. 