### PR TITLE
Fix year validation bug.

### DIFF
--- a/coldfront/core/publication/forms.py
+++ b/coldfront/core/publication/forms.py
@@ -6,7 +6,7 @@ from coldfront.core.publication.models import PublicationSource
 class PublicationAddForm(forms.Form):
     title = forms.CharField(max_length=1024, required=True)
     author = forms.CharField(max_length=1024, required=True)
-    year = forms.CharField(max_length=4, required=True)
+    year = forms.IntegerField(min_value=1500, max_value=2090, required=True)
     journal = forms.CharField(max_length=1024, required=True)
     source = forms.CharField(widget=forms.HiddenInput())  # initialized by view
 

--- a/coldfront/core/publication/templates/publication/publication_add_publication_manually.html
+++ b/coldfront/core/publication/templates/publication/publication_add_publication_manually.html
@@ -11,11 +11,17 @@ Add Publication to Project Manually
 {% block content %}
 <h2>Add publication to project: {{project.title}}</h2> <hr>
 
+{% if form.non_field_errors %}
+  <div class="alert alert-danger" role="alert">
+    {{ form.non_field_errors }}
+  </div>
+{% endif %}
+
 <div class="row">
   <div class="col">
-    <form action="{% url 'add-publication-manually' project_pk %}" method="post">
+    <form method="post">
       {% csrf_token %}
-      {{ publication_add_form|crispy }}
+      {{ form|crispy }}
       <div>
         <button type="submit" class="btn btn-primary"><i class="fas fa-plus" aria-hidden="true"></i> Add Publication</button>
       </div>
@@ -29,10 +35,10 @@ Add Publication to Project Manually
   <div class="col">
     <div class="card border-light">
       <div class="card-body">
-        <a class="btn btn-info" href="{% url 'publication-search' project_pk %}" role="button">
+        <a class="btn btn-info" href="{% url 'publication-search' project.pk %}" role="button">
           <i class="fas fa-search" aria-hidden="true"></i> Back to Search
         </a>
-        <a class="btn btn-secondary" href="{% url 'project-detail' project_pk %}" role="button">
+        <a class="btn btn-secondary" href="{% url 'project-detail' project.pk %}" role="button">
           <i class="fas fa-long-arrow-left" aria-hidden="true"></i> Back to Project
         </a>
       </div>

--- a/coldfront/core/publication/views.py
+++ b/coldfront/core/publication/views.py
@@ -1,7 +1,5 @@
-import hashlib
-import json
 import re
-
+import uuid
 import requests
 import os
 import io
@@ -16,6 +14,7 @@ from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.views.generic import DetailView, ListView, TemplateView, View
+from django.views.generic.edit import FormView
 from django.views.static import serve
 
 from coldfront.core.project.models import Project
@@ -247,8 +246,8 @@ class PublicationAddView(LoginRequiredMixin, UserPassesTestMixin, View):
 
         return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_pk}))
 
-
-class PublicationAddManuallyView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
+class PublicationAddManuallyView(LoginRequiredMixin, UserPassesTestMixin, FormView):
+    form_class = PublicationAddForm
     template_name = 'publication/publication_add_publication_manually.html'
 
     def test_func(self):
@@ -256,8 +255,7 @@ class PublicationAddManuallyView(LoginRequiredMixin, UserPassesTestMixin, Templa
         if self.request.user.is_superuser:
             return True
 
-        project_obj = get_object_or_404(
-            Project, pk=self.kwargs.get('project_pk'))
+        project_obj = get_object_or_404(Project, pk=self.kwargs.get('project_pk'))
 
         if project_obj.pi == self.request.user:
             return True
@@ -265,62 +263,44 @@ class PublicationAddManuallyView(LoginRequiredMixin, UserPassesTestMixin, Templa
         if project_obj.projectuser_set.filter(user=self.request.user, role__name='Manager', status__name='Active').exists():
             return True
 
+        messages.error(self.request, 'You do not have permission to add a new publication to this project.')
+
     def dispatch(self, request, *args, **kwargs):
-        project_obj = get_object_or_404(
-            Project, pk=self.kwargs.get('project_pk'))
+        project_obj = get_object_or_404(Project, pk=self.kwargs.get('project_pk'))
         if project_obj.status.name not in ['Active', 'New', ]:
-            messages.error(
-                request, 'You cannot add publications to an archived project.')
+            messages.error(request, 'You cannot add publications to an archived project.')
             return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_obj.pk}))
         else:
             return super().dispatch(request, *args, **kwargs)
 
+    def get_initial(self):
+        initial = super().get_initial()
+        initial['source'] = MANUAL_SOURCE
+        return initial
+
+    def form_valid(self, form):
+        form_data = form.cleaned_data
+        project_obj = get_object_or_404(Project, pk=self.kwargs.get('project_pk'))
+        pub_obj = Publication.objects.create(
+            project=project_obj,
+            title=form_data.get('title'),
+            author=form_data.get('author'),
+            year=form_data.get('year'),
+            journal=form_data.get('journal'),
+            unique_id=uuid.uuid4(),
+            source=PublicationSource.objects.get(name=MANUAL_SOURCE),
+        )
+
+        return super().form_valid(form)
+
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
-        context['publication_add_form'] = PublicationAddForm(
-            initial={'source': MANUAL_SOURCE})
-        context['project'] = Project.objects.get(
-            pk=self.kwargs.get('project_pk'))
+        context['project'] = Project.objects.get(pk=self.kwargs.get('project_pk'))
         return context
 
-    def post(self, request, *args, **kwargs):
-        project_pk = self.kwargs.get('project_pk')
-        project_obj = get_object_or_404(Project, pk=project_pk)
-
-        # a single, manual pub is being sent
-        client_pub = {
-            key: request.POST[key] for key in (
-                'title',
-                'author',
-                'year',
-                'journal',
-            )
-        }
-        # although not perfect, use a low-collision hash for unique id in the database
-        stable_hash = hashlib.sha256(
-            json.dumps(client_pub, sort_keys=True).encode()
-        ).hexdigest()
-        client_pub['unique_id'] = stable_hash
-        client_pub['source'] = PublicationSource.objects.get(name=MANUAL_SOURCE)
-
-        publication_obj, created = Publication.objects.get_or_create(
-            project=project_obj,
-            **client_pub,
-        )
-        if created:
-            msg = 'Added publication to project.'
-        else:
-            # since we don't have a sensible unique_id here, we need to have
-            # something sensible to display to the user
-            user_friendly_publication_info = '[{} ({}) by {}]'.format(
-                client_pub['title'],
-                client_pub['year'],
-                client_pub['author'],
-            )
-            msg = 'Skipped adding: {}'.format(user_friendly_publication_info)
-
-        messages.success(request, msg)
-        return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_pk}))
+    def get_success_url(self):
+        messages.success(self.request, 'Added a publication.')
+        return reverse('project-detail', kwargs={'pk': self.kwargs.get('project_pk')})
 
 
 class PublicationDeletePublicationsView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):

--- a/coldfront/templates/403.html
+++ b/coldfront/templates/403.html
@@ -1,0 +1,18 @@
+{% extends "common/base.html" %}
+{% load static %}
+
+
+{% block title %}
+ColdFront - Unauthorized
+{% endblock %}
+
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-lg-6 col-xs-12">
+        <div class="alert alert-danger" role="alert">
+          <i class="fas fa-user-lock" aria-hidden="true"></i> You are not authorized to view this page. 
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This fixes #258. Add better form validation for manual publication entry. Change to using uuid4 instead of sha256 hash for unique ids. The issue is when manually entering a publication, we do not ask for a DOI as it may not have one. As a doi uniquely identifies a publication, we simply use a randomly generated uuid4 as the unique id.