### PR TITLE
Multiple Allocations on a project for the same resource can be differentiated

### DIFF
--- a/coldfront/config/core.py
+++ b/coldfront/config/core.py
@@ -41,6 +41,11 @@ SETTINGS_EXPORT += [
 ADMIN_COMMENTS_SHOW_EMPTY = ENV.bool('ADMIN_COMMENTS_SHOW_EMPTY', default=True)
 
 #------------------------------------------------------------------------------
+# List of Allocation Attributes to display on view page
+#------------------------------------------------------------------------------
+ALLOCATION_ATTRIBUTE_VIEW_LIST = ENV.list('ALLOCATION_ATTRIBUTE_VIEW_LIST', default=['slurm_account_name', 'freeipa_group', 'Cloud Account Name', ])
+
+#------------------------------------------------------------------------------
 # Enable invoice functionality
 #------------------------------------------------------------------------------
 INVOICE_ENABLED = ENV.bool('INVOICE_ENABLED', default=True)

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -106,6 +106,14 @@ class Allocation(TimeStampedModel):
                 html_string += '%s: %s <br>' % (
                     attribute.allocation_attribute_type.name, attribute.value)
 
+            if attribute.allocation_attribute_type.name == "freeipa_group":
+                html_string += '%s: %s <br>' % (
+                    attribute.allocation_attribute_type.name, attribute.value)
+
+            if attribute.allocation_attribute_type.name == "Cloud Account Name":
+                html_string += '%s: %s <br>' % (
+                    attribute.allocation_attribute_type.name, attribute.value)
+
             if hasattr(attribute, 'allocationattributeusage'):
                 try:
                     percent = round(float(attribute.allocationattributeusage.value) /

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -18,15 +18,10 @@ from coldfront.core.utils.common import import_from_settings
 
 logger = logging.getLogger(__name__)
 
-
+ALLOCATION_ATTRIBUTE_VIEW_LIST = import_from_settings(
+    'ALLOCATION_ATTRIBUTE_VIEW_LIST', [])
 ALLOCATION_FUNCS_ON_EXPIRE = import_from_settings(
     'ALLOCATION_FUNCS_ON_EXPIRE', [])
-SLURM_ACCOUNT_ATTRIBUTE_NAME = import_from_settings(
-    'SLURM_ACCOUNT_ATTRIBUTE_NAME', 'slurm_account_name')
-XDMOD_CLOUD_PROJECT_ATTRIBUTE_NAME = import_from_settings(
-    'XDMOD_CLOUD_PROJECT_ATTRIBUTE_NAME', 'Cloud Account Name')
-UNIX_GROUP_ATTRIBUTE_NAME = import_from_settings(
-    'FREEIPA_GROUP_ATTRIBUTE_NAME', 'freeipa_group')
 
 
 class AllocationStatusChoice(TimeStampedModel):
@@ -105,8 +100,7 @@ class Allocation(TimeStampedModel):
     def get_information(self):
         html_string = ''
         for attribute in self.allocationattribute_set.all():
-
-            if attribute.allocation_attribute_type.name in [SLURM_ACCOUNT_ATTRIBUTE_NAME, UNIX_GROUP_ATTRIBUTE_NAME, XDMOD_CLOUD_PROJECT_ATTRIBUTE_NAME,]:
+            if attribute.allocation_attribute_type.name in ALLOCATION_ATTRIBUTE_VIEW_LIST:
                 html_string += '%s: %s <br>' % (
                     attribute.allocation_attribute_type.name, attribute.value)
 

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -23,6 +23,10 @@ ALLOCATION_FUNCS_ON_EXPIRE = import_from_settings(
     'ALLOCATION_FUNCS_ON_EXPIRE', [])
 SLURM_ACCOUNT_ATTRIBUTE_NAME = import_from_settings(
     'SLURM_ACCOUNT_ATTRIBUTE_NAME', 'slurm_account_name')
+XDMOD_CLOUD_PROJECT_ATTRIBUTE_NAME = import_from_settings(
+    'XDMOD_CLOUD_PROJECT_ATTRIBUTE_NAME', 'Cloud Account Name')
+UNIX_GROUP_ATTRIBUTE_NAME = import_from_settings(
+    'FREEIPA_GROUP_ATTRIBUTE_NAME', 'freeipa_group')
 
 
 class AllocationStatusChoice(TimeStampedModel):
@@ -102,15 +106,7 @@ class Allocation(TimeStampedModel):
         html_string = ''
         for attribute in self.allocationattribute_set.all():
 
-            if attribute.allocation_attribute_type.name in [SLURM_ACCOUNT_ATTRIBUTE_NAME, ]:
-                html_string += '%s: %s <br>' % (
-                    attribute.allocation_attribute_type.name, attribute.value)
-
-            if attribute.allocation_attribute_type.name == "freeipa_group":
-                html_string += '%s: %s <br>' % (
-                    attribute.allocation_attribute_type.name, attribute.value)
-
-            if attribute.allocation_attribute_type.name == "Cloud Account Name":
+            if attribute.allocation_attribute_type.name in [SLURM_ACCOUNT_ATTRIBUTE_NAME, UNIX_GROUP_ATTRIBUTE_NAME, XDMOD_CLOUD_PROJECT_ATTRIBUTE_NAME,]:
                 html_string += '%s: %s <br>' % (
                     attribute.allocation_attribute_type.name, attribute.value)
 

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -181,7 +181,11 @@ Project Detail
             <tr>
               <td>{{ allocation.get_parent_resource.name }}</td>
               <td>{{ allocation.get_parent_resource.resource_type.name }}</td>
+              {% if allocation.get_information != '' %}
               <td class="text-nowrap">{{allocation.get_information}}</td>
+              {% else %}
+              <td class="text-nowrap">{{allocation.description}}</td>
+              {% endif %}
               {% if allocation.status.name == 'Active' %}
                 <td class="text-success">{{ allocation.status.name }}</td>
               {% elif  allocation.status.name == 'Expired' or allocation.status.name == 'Denied' %}


### PR DESCRIPTION
Resolves #193. In the allocation section of a project, the information column for an entry will display its slurm_account_name, freeipa_group name, Cloud Account Name and/or its Cloud Storage Quota. If an entry does not have any of these attributes, its description will be used to fill out the information column instead.