### PR TITLE
Prevent allocation renewal setting

### DIFF
--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -81,13 +81,15 @@ Allocation Detail
               {% else %}
                 {{ allocation.end_date }}
               {% endif %}
-
-              {% if is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
+              {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
+              <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
+                Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}}
+              </span>
+              {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
                 <a href="{% url 'allocation-renew' allocation.pk %}">
-                  <span class="badge badge-warning">
-                    <i class="fas fa-redo-alt" aria-hidden="true"></i>
-                    Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} - click to renew
-                  </span>
+                <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
+                Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Click to renew
+                </span>
                 </a>
               {% endif %}
             </td>

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -83,12 +83,12 @@ Allocation Detail
               {% endif %}
               {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
               <span class="badge badge-warning"><i class="far fa-clock" aria-hidden="true"></i>
-                Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} - not renewable
+                Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} - Not renewable
               </span>
               {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
                 <a href="{% url 'allocation-renew' allocation.pk %}">
                 <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Click to renew
+                Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} - Click to renew
                 </span>
                 </a>
               {% endif %}

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -82,8 +82,8 @@ Allocation Detail
                 {{ allocation.end_date }}
               {% endif %}
               {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
-              <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}}
+              <span class="badge badge-warning"><i class="far fa-clock" aria-hidden="true"></i>
+                Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} - not renewable
               </span>
               {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
                 <a href="{% url 'allocation-renew' allocation.pk %}">

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -194,7 +194,7 @@ Project Detail
                 <a href="{% url 'allocation-detail' allocation.pk %}"><i class="far fa-folder-open" aria-hidden="true"></i><span class="sr-only">Details</span></a>
                 {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
                 <span class="badge badge-warning"><i class="far fa-clock" aria-hidden="true"></i>
-                  Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} - not renewable
+                  Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Not renewable
                 </span>
                 {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
                   <a href="{% url 'allocation-renew' allocation.pk %}">

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -192,7 +192,11 @@ Project Detail
               <td>{{allocation.end_date|date:"Y-m-d"}}</td>
               <td>
                 <a href="{% url 'allocation-detail' allocation.pk %}"><i class="far fa-folder-open" aria-hidden="true"></i><span class="sr-only">Details</span></a>
-                {% if is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
+                {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
+                <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
+                  Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}}
+                </span>
+                {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
                   <a href="{% url 'allocation-renew' allocation.pk %}">
                   <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
                   Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Click to renew

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -193,8 +193,8 @@ Project Detail
               <td>
                 <a href="{% url 'allocation-detail' allocation.pk %}"><i class="far fa-folder-open" aria-hidden="true"></i><span class="sr-only">Details</span></a>
                 {% if allocation.is_locked and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
-                <span class="badge badge-warning"><i class="fas fa-redo-alt" aria-hidden="true"></i>
-                  Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}}
+                <span class="badge badge-warning"><i class="far fa-clock" aria-hidden="true"></i>
+                  Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} - not renewable
                 </span>
                 {% elif is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
                   <a href="{% url 'allocation-renew' allocation.pk %}">


### PR DESCRIPTION
Resolves issue #203. When an allocation is locked in the ColdFront Administration Portal by an admin, the allocation can no longer be renewed. When an allocation is locked, the "renew now" banners change to only show the number of days an allocation has until it expires. It says "not renewable" instead of "renew now", and is no longer clickable. 