### PR TITLE
Update docs with correct username of PI#1 and center director

### DIFF
--- a/docs/pages/install.md
+++ b/docs/pages/install.md
@@ -128,8 +128,8 @@ $ coldfront load_test_data
 ```
 
 - You can log in as `admin` with password `test1234`.
-- You can log in as a PI using username `ccollins` with password `test1234`.
-- You can log in as center director using username `michardson` with password `test1234`.
+- You can log in as a PI using username `cgray` with password `test1234`.
+- You can log in as center director using username `csimmons` with password `test1234`.
 - Password for all users is also `test1234`.
 
 !!! danger "Danger"


### PR DESCRIPTION
Hello

I think ccollins and michardson must have been from an older version so I have updated the docs to reflect the users currently in [load_test_data.py](https://github.com/Iain-S/coldfront/blob/7130334c96b263c3c48b6844b6dad6e6b811c827/coldfront/core/utils/management/commands/load_test_data.py)