### PR TITLE
allow logout redirect URL to be configured

### DIFF
--- a/coldfront/config/auth.py
+++ b/coldfront/config/auth.py
@@ -10,14 +10,14 @@ AUTHENTICATION_BACKENDS += [
 
 LOGIN_URL = '/user/login'
 LOGIN_REDIRECT_URL = '/'
-LOGOUT_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = ENV.str('LOGOUT_REDIRECT_URL', LOGIN_URL)
 
 SU_LOGIN_CALLBACK = "coldfront.core.utils.common.su_login_callback"
 SU_LOGOUT_REDIRECT_URL = "/admin/auth/user/"
 
 SESSION_COOKIE_AGE = 60 * 15
 SESSION_SAVE_EVERY_REQUEST = True
-SESSION_COOKIE_SAMESITE  = 'Strict'
+SESSION_COOKIE_SAMESITE = 'Strict'
 SESSION_COOKIE_SECURE = True
 
 #------------------------------------------------------------------------------

--- a/coldfront/core/user/urls.py
+++ b/coldfront/core/user/urls.py
@@ -15,10 +15,7 @@ urlpatterns = [
              redirect_authenticated_user=True),
          name='login'
          ),
-    path('logout',
-         LogoutView.as_view(next_page=reverse_lazy('login')),
-         name='logout'
-         ),
+    path('logout', LogoutView.as_view(), name='logout'),
     path('user-profile/', user_views.UserProfile.as_view(), name='user-profile'),
     path('user-profile/<str:viewed_username>', user_views.UserProfile.as_view(), name='user-profile'),
     path('user-projects-managers/', user_views.UserProjectsManagersView.as_view(), name='user-projects-managers'),


### PR DESCRIPTION
I need to be able to configure the LOGOUT_REDIRECT_URL to perform OIDC IdP logout.

Note that the default behavior of LogoutView.as_view() is to use the LOGOUT_REDIRECT_URL (thus the change from specifying the redirect to using the default in the user/urls.py causes the redirect to use the LOGOUT_REDIRECT_URL value).