### PR TITLE
Update docs and config with default Postgres port number

### DIFF
--- a/coldfront/config/database.py
+++ b/coldfront/config/database.py
@@ -12,7 +12,7 @@ from coldfront.config.env import ENV
 #  DB_URL=mysql://user:password@127.0.0.1:3306/database
 #
 # Postgresql:
-#  DB_URL=psql://user:password@127.0.0.1:8458/database
+#  DB_URL=psql://user:password@127.0.0.1:5432/database
 #------------------------------------------------------------------------------
 DATABASES = {
     'default': ENV.db_url(

--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -105,7 +105,7 @@ Examples:
 
 ```
 DB_URL=mysql://user:password@127.0.0.1:3306/database
-DB_URL=psql://user:password@127.0.0.1:8458/database
+DB_URL=psql://user:password@127.0.0.1:5432/database
 DB_URL=sqlite:////usr/share/coldfront/coldfront.db
 ```
 


### PR DESCRIPTION
Even thought the Django-environ [docs](https://django-environ.readthedocs.io/en/latest/) use 8458, the default PostgreSQL port number is 5432. Using this in the coldfront docs may avoid confusion.