### PR TITLE
Add ColdFront command to dump user information for import into XDMoD.

### DIFF
--- a/coldfront/plugins/xdmod/README.md
+++ b/coldfront/plugins/xdmod/README.md
@@ -4,13 +4,17 @@ ColdFront django plugin providing Open XDMoD integration for ColdFront.  [Open
 XDMoD](https://open.xdmod.org) is an open source tool to facilitate the
 management of high performance computing resources and provides monitoring of
 standard metrics such as utilization. This plugin syncs utilization data with
-ColdFront allocation attributes.
+ColdFront allocation attributes and also provides a dump command to export
+metadata about users to Open XDMoD.
 
 ## Design
 
 Open XDMoD provides reporting on a rich set of metrics. Currently, this plugin
 supports 2 metrics in Open XDMoD focused on reporting usage data for HPC Jobs and
 Cloud core time.
+
+The export function provides an automatable mechanism to synchronize user information
+such as name and PI status from ColdFront to Open XDMoD.
 
 ## Usage
 
@@ -27,4 +31,14 @@ To sync usage data from XDMoD to ColdFront:
 
 ```
     $ coldfront xdmod_usage -x -m cloud_core_time -v 0 -s
+```
+
+To export user information from ColdFront to Open XDMoD:
+```
+    $ coldfront xdmod_dump -o /output_dir
+```
+
+You can then load this file into Open XDMoD (>= 10.0) with the following command:
+```
+    $ xdmod-load-json -f coldfront -i /output_dir/names.json
 ```

--- a/coldfront/plugins/xdmod/management/commands/xdmod_dump.py
+++ b/coldfront/plugins/xdmod/management/commands/xdmod_dump.py
@@ -1,0 +1,61 @@
+""" Exports user information in a format that can be imported
+    into  Open XDMoD """
+import logging
+import os
+import json
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    """ Output user information for all users """
+    help = 'Export ColdFront data to XDMoD'
+
+    def add_arguments(self, parser):
+        parser.add_argument("-o", "--output", help="Path to output directory")
+
+    def handle(self, *args, **options):
+        verbosity = int(options['verbosity'])
+        root_logger = logging.getLogger('')
+        if verbosity == 0:
+            root_logger.setLevel(logging.ERROR)
+        elif verbosity == 2:
+            root_logger.setLevel(logging.INFO)
+        elif verbosity == 3:
+            root_logger.setLevel(logging.DEBUG)
+        else:
+            root_logger.setLevel(logging.WARN)
+
+        out_dir = None
+        if options['output']:
+            out_dir = options['output']
+            if not os.path.isdir(out_dir):
+                os.mkdir(out_dir, 0o0700)
+
+            logger.warning("Writing output to directory: %s", out_dir)
+
+        data = [['username', 'first_name', 'last_name', 'email', 'is_pi']]
+        for user in User.objects.all():
+            if user:
+                data.append([
+                    user.username,
+                    user.first_name,
+                    user.last_name,
+                    user.email,
+                    user.userprofile.is_pi
+                ])
+
+        output = {
+           'schema_version': 1,
+           'datasource': 'coldfront ' + settings.VERSION,
+           'data': data
+        }
+
+        if out_dir:
+            with open(os.path.join(out_dir, 'names.json'), 'w') as filep:
+                json.dump(output, filep, indent=4, separators=(",", ": "))
+        else:
+            print(json.dumps(output, indent=4, separators=(",", ": ")))


### PR DESCRIPTION
This adds a `coldfront xdmod_dump` command that outputs user information in json format. Note that XDMoD 9.5 has no mechanism to import this data. I plan to travel to the future to ensure that XDMoD 10.0 can read this file format and set the
names and PI status appropriately.

The command-line name and arguments look-and-feel were chosen to be the same
as the `coldfront slurm_dump` command from the slurm plugin. I assume that this is the informal standard.