### PR TITLE
environ import (plus some pep8)

### DIFF
--- a/coldfront/config/auth.py
+++ b/coldfront/config/auth.py
@@ -24,6 +24,6 @@ SESSION_COOKIE_SECURE = True
 # Enable administrators to login as other users
 #------------------------------------------------------------------------------
 if ENV.bool('ENABLE_SU', default=True):
-    AUTHENTICATION_BACKENDS += ['django_su.backends.SuBackend',]
+    AUTHENTICATION_BACKENDS += ['django_su.backends.SuBackend', ]
     INSTALLED_APPS.insert(0, 'django_su')
     TEMPLATES[0]['OPTIONS']['context_processors'].extend(['django_su.context_processors.is_su', ])

--- a/coldfront/config/core.py
+++ b/coldfront/config/core.py
@@ -76,6 +76,6 @@ Phone: (xxx) xxx-xxx
 """
 
 ACCOUNT_CREATION_TEXT = '''University faculty can submit a help ticket to request an account.
-Please see <a href="#">instructions on our website</a>. Staff, students, and external collaborators must 
+Please see <a href="#">instructions on our website</a>. Staff, students, and external collaborators must
 request an account through a university faculty member.
 '''

--- a/coldfront/config/database.py
+++ b/coldfront/config/database.py
@@ -4,7 +4,7 @@ from coldfront.config.env import ENV
 #------------------------------------------------------------------------------
 # Database settings
 #------------------------------------------------------------------------------
-# Set this using the DB_URL env variable. Defaults to sqlite. 
+# Set this using the DB_URL env variable. Defaults to sqlite.
 #
 # Examples:
 #
@@ -17,7 +17,7 @@ from coldfront.config.env import ENV
 DATABASES = {
     'default': ENV.db_url(
         var='DB_URL',
-        default='sqlite:///'+os.path.join(os.getcwd(), 'coldfront.db')
+        default='sqlite:///' + os.path.join(os.getcwd(), 'coldfront.db')
     )
 }
 

--- a/coldfront/config/env.py
+++ b/coldfront/config/env.py
@@ -19,4 +19,3 @@ for e in env_paths:
         ENV.read_env(e())
     except FileNotFoundError:
         pass
-

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -1,5 +1,4 @@
 import environ
-import os
 from split_settings.tools import optional, include
 from coldfront.config.env import ENV, PROJECT_ROOT
 
@@ -38,10 +37,10 @@ local_configs = [
     # Local settings relative to coldfront.config package
     'local_settings.py',
 
-     # System wide settings for production deployments
+    # System wide settings for production deployments
     '/etc/coldfront/local_settings.py',
 
-    # Local settings relative to coldfront project root 
+    # Local settings relative to coldfront project root
     PROJECT_ROOT('local_settings.py')
 ]
 

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -1,3 +1,4 @@
+import environ
 import os
 from split_settings.tools import optional, include
 from coldfront.config.env import ENV, PROJECT_ROOT


### PR DESCRIPTION
I should probably have done this as 2 PRs:

See 9a5b1d2 for the main change (setting COLDFRONT_CONFIG causes an error because `environ` had not been imported into settings.py).

I then ran flake8 on the config files and fixed most of the errors (I did not address line-length errors or any files under `config/plugins/`).