### PR TITLE
Allow site-level control of how Resources ordered within an Allocation

### DIFF
--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -22,6 +22,9 @@ ALLOCATION_ATTRIBUTE_VIEW_LIST = import_from_settings(
     'ALLOCATION_ATTRIBUTE_VIEW_LIST', [])
 ALLOCATION_FUNCS_ON_EXPIRE = import_from_settings(
     'ALLOCATION_FUNCS_ON_EXPIRE', [])
+ALLOCATION_RESOURCE_ORDERING = import_from_settings(
+    'ALLOCATION_RESOURCE_ORDERING',
+    ['-is_allocatable', 'name'])
 
 
 class AllocationStatusChoice(TimeStampedModel):
@@ -125,14 +128,20 @@ class Allocation(TimeStampedModel):
 
     @property
     def get_resources_as_string(self):
-        return ', '.join([ele.name for ele in self.resources.all().order_by('-is_allocatable')])
+        return ', '.join([ele.name for ele in self.resources.all().order_by(
+            *ALLOCATION_RESOURCE_ORDERING)])
 
     @property
     def get_parent_resource(self):
         if self.resources.count() == 1:
             return self.resources.first()
         else:
-            return self.resources.filter(is_allocatable=True).first()
+            parent = self.resources.order_by(
+                *ALLOCATION_RESOURCE_ORDERING).first()
+            if parent:
+                return parent
+            # Fallback
+            return self.resources.first()
 
     def get_attribute(self, name):
         attr = self.allocationattribute_set.filter(

--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -87,6 +87,7 @@ The following settings are ColdFront specific settings related to the core appli
 | ALLOCATION_ENABLE_ALLOCATION_RENEWAL   | Enable or disable allocation renewals. Default True |
 | ALLOCATION_DEFAULT_ALLOCATION_LENGTH   | Default number of days an allocation is active for. Default 365 |
 | ALLOCATION_ACCOUNT_ENABLED             | Allow user to select account name for allocation. Default False |
+| ALLOCATION_RESOURCE_ORDERING           | Controls the ordering of parent resources for an allocation (if allocation has multiple resources).  Should be a list of field names suitable for Django QuerySet order_by method.  Default is ['-is_allocatable', 'name']; i.e. prefer Resources with is_allocatable field set, ordered by name of the Resource.|
 | INVOICE_ENABLED                        | Enable or disable invoices. Default True       |
 | ONDEMAND_URL                           | The URL to your Open OnDemand installation     |
 | LOGIN_FAIL_MESSAGE                     | Custom message when user fails to login. Here you can paint a custom link to your user account portal |


### PR DESCRIPTION
See #334
This modifies the methods get_resources_as_string() and get_parent_resource() of the Allocation class, specifically it modifies how those routines order the resources attached to the allocation for display, etc.

The modifications cause both of these methods to order the resources by
the value of the setting ALLOCATION_RESOURCE_ORDERING.  This should be a
list ref of arguments to pass to the Django QuerySet order_by() method.  The
default value is [ '-is_allocatable', 'name' ], which means that Resources
which are allocatable (is_allocatable==Yes) will come before non-allocatable
resources, and among Resources of the same allocatability, the Resources will
be ordered by name.

This should result in get_parent_resource returning the same resource as
before (as it previously used the default 'name' ordering from Resource and
then filtered/selected only allocatable Resources when the Allocation was
associated with more than one Resource); except in the abnormal case wherein
an Allocation has more than one Resource and none are allocatable (the old
behavior returned None, which could result in various issues; the new behavior
is to return one of the non-allocatable Resources).

The result of get_resources_as_string may change, as previously it only
ordered by '-is_allocatable', so the ordering of allocatable resources is
presumably up to the database backend (???).  The new behavior is consistent
with get_parent_resource(), i.e. the Resource returned by get_parent_resource()
will now always be the first Resource listed in get_resources_as_string().

Added documentation for ALLOCATION_RESOURCE_ORDERING under config page.