### PR TITLE
Fix for #336 - Divide-by-zero error for Attrib value=0 and has_usage

### DIFF
--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -112,6 +112,10 @@ class Allocation(TimeStampedModel):
                     percent = 'Invalid Value'
                     logger.error("Allocation attribute '%s' is not an int but has a usage",
                                  attribute.allocation_attribute_type.name)
+                except ZeroDivisionError:
+                    percent = 100
+                    logger.error("Allocation attribute '%s' == 0 but has a usage",
+                                 attribute.allocation_attribute_type.name)
 
                 string = '{}: {}/{} ({} %) <br>'.format(
                     attribute.allocation_attribute_type.name,

--- a/coldfront/core/allocation/utils.py
+++ b/coldfront/core/allocation/utils.py
@@ -20,6 +20,8 @@ def generate_guauge_data_from_usage(name, value, usage):
         percent = (usage/value)*100
     except ZeroDivisionError:
         percent = 100
+    except ValueError:
+        percent = 100
 
     if percent < 80:
         color = "#6da04b"

--- a/coldfront/core/allocation/utils.py
+++ b/coldfront/core/allocation/utils.py
@@ -16,7 +16,10 @@ def generate_guauge_data_from_usage(name, value, usage):
 
     label = "%s: %.2f of %.2f" % (name, usage, value)
 
-    percent = (usage/value)*100
+    try:
+        percent = (usage/value)*100
+    except ZeroDivisionError:
+        percent = 100
 
     if percent < 80:
         color = "#6da04b"


### PR DESCRIPTION


This adds a try/except block in generate_guauge_data_from_usage() (why
the misspelling?) to catch for divide by zero errors.  If value=0, we
set the percent used to 100% (arbitrary, but better than an exception)