### PR TITLE
Ported Allocation Change Request features to Allocation Requests

### DIFF
--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -67,6 +67,7 @@ class AllocationUpdateForm(forms.Form):
     description = forms.CharField(max_length=512,
                                   label='Description',
                                   required=False)
+    is_locked = forms.BooleanField(required=False)
     is_changeable = forms.BooleanField(required=False)
 
     def clean(self):

--- a/coldfront/core/allocation/templates/allocation/allocation_change_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_change_detail.html
@@ -93,12 +93,12 @@ Allocation Change Detail
               <td>{{ allocation_change.allocation.description }}</td>
             </tr>
             <tr>
-              <th scope="row" class="text-nowrap">Created:</th>
-              <td>{{ allocation_change.allocation.created|date:"M. d, Y" }}</td>
+              <th scope="row" class="text-nowrap">Change Requested:</th>
+              <td>{{ allocation_change.created|date:"M. d, Y" }}</td>
             </tr>
             <tr>
-              <th scope="row" class="text-nowrap">Last Modified:</th>
-              <td>{{ allocation_change.allocation.modified|date:"M. d, Y" }}</td>
+              <th scope="row" class="text-nowrap">Change Last Modified:</th>
+              <td>{{ allocation_change.modified|date:"M. d, Y" }}</td>
             </tr>
             <tr>
               {% if allocation_change.allocation.is_locked %}

--- a/coldfront/core/allocation/templates/allocation/allocation_change_list.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_change_list.html
@@ -12,6 +12,14 @@ Allocation Review New and Pending Change Requests
 {% block content %}
 <h2>Allocation Change Requests</h2>
 
+<hr>
+
+<p class="text-justify"> 
+  For each allocation change request below, there is the option to activate the allocation request and to view the allocation change's detail page.
+  If a change request is only for an extension to the allocation, they can be approved on this page. However if the change request includes changes to
+  the allocation's attributes, the request must be reviewed and acted upon in its detail page.
+</p>
+
 {% if allocation_change_list %}
   <div class="table-responsive">
     <table class="table table-sm">
@@ -30,7 +38,7 @@ Allocation Review New and Pending Change Requests
         {% for change in allocation_change_list %}
           <tr>
             <td>{{change.pk}}</td>
-            <td>{{ change.modified|date:"M. d, Y" }}</td>
+            <td>{{ change.created|date:"M. d, Y" }}</td>
             <td><a href="{% url 'project-detail' change.allocation.project.pk %}">{{change.allocation.project.title|truncatechars:50}}</a></td>
             <td>{{change.allocation.project.pi.first_name}} {{change.allocation.project.pi.last_name}}
               ({{change.allocation.project.pi.username}})</td>

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -127,17 +127,24 @@ Allocation Detail
             <td>{{ allocation.modified|date:"M. d, Y" }}</td>
           </tr>
           <tr>
-            {% if allocation.is_locked %}
-              <th scope="row" class="text-nowrap">Locked</th>
-              <td><i class="fas fa-lock" aria-hidden="true"></i></td>
+            {% if request.user.is_superuser or request.user.is_staff %}
+              <th scope="row" class="text-nowrap">Lock/Unlock Allocation:</th>
+              <td>
+                {{ form.is_locked }}
+              </td>
             {% else %}
-              <th scope="row" class="text-nowrap">Unlocked</th>
-              <td><i class="fas fa-lock-open" aria-hidden="true"></i></td>
+              {% if allocation.is_locked %}
+                <th scope="row" class="text-nowrap">Locked</th>
+                <td><i class="fas fa-lock" aria-hidden="true"></i></td>
+              {% else %}
+                <th scope="row" class="text-nowrap">Unlocked</th>
+                <td><i class="fas fa-lock-open" aria-hidden="true"></i></td>
+              {% endif %}
             {% endif %}
           </tr>
           {% if request.user.is_superuser or request.user.is_staff %}
             <tr>
-              <th scope="row" class="text-nowrap">Allow Change Requests</th>
+              <th scope="row" class="text-nowrap">Allow Change Requests:</th>
               <td>
                 {{ form.is_changeable }}
               </td>
@@ -146,8 +153,14 @@ Allocation Detail
         </table>
       </div>
       {% if request.user.is_superuser %}
-        <button type="submit" class="btn btn-success float-right"><i class="fas fa-sync" aria-hidden="true"></i> Update</button>
+      <div class="float-right">
+        {% if allocation.status.name == 'New' or allocation.status.name == 'Renewal Requested' %}
+          <a href="{% url 'allocation-activate-request' allocation.pk %}" class="btn btn-success mr-1 confirm-activate">Approve</a>
+          <a href="{% url 'allocation-deny-request' allocation.pk %}" class="btn btn-danger mr-1 confirm-deny">Deny</a>
+        {% endif %}
+        <button type="submit" class="btn btn-primary"><i class="fas fa-sync" aria-hidden="true"></i> Update</button>
       {% endif %}
+    </div>
     </form>
   </div>
 </div>
@@ -234,7 +247,7 @@ Allocation Detail
           <tbody>
             {% for change_request in allocation_changes %}
                 <tr>
-                  <td>{{ change_request.modified|date:"M. d, Y" }}</td>
+                  <td>{{ change_request.created|date:"M. d, Y" }}</td>
                   {% if change_request.status.name == 'Approved' %}
                     <td class="text-success">{{ change_request.status.name }}</td>
                   {% elif change_request.status.name == 'Denied' %}
@@ -318,6 +331,13 @@ Allocation Detail
   <div class="card-header">
     <h3 class="d-inline"><i class="fas fa-users" aria-hidden="true"></i> Notifications</h3>
     <span class="badge badge-secondary">{{notes.count}}</span>
+    <div class="float-right">
+      {% if request.user.is_superuser %}
+        <a class="btn btn-success" href="{% url 'allocation-note-add' allocation.pk %}" role="button">
+          <i class="fas fa-plus" aria-hidden="true"></i> Add Notification
+        </a>
+      {% endif %}
+    </div>
   </div>
   <div class="card-body">
     {% if notes %}
@@ -382,5 +402,17 @@ Allocation Detail
     }
   }
   $(".datepicker").datepicker({ dateFormat: 'yy-mm-dd' });
+  $(document).on('click', '.confirm-activate', function(){
+    var attributes_num = {{ attributes | length }};
+    if (attributes_num == 0) {
+      return confirm('Are you sure you want to activate this allocation request without setting any allocation attributes?');
+    }
+  })
+  $(document).on('click', '.confirm-deny', function(){
+    var notes_num = {{ notes | length }};
+    if (notes_num == 0) {
+      return confirm('Are you sure you want to deny this allocation request without setting a notification?');
+    }
+  })
 </script>
 {% endblock %}

--- a/coldfront/core/allocation/templates/allocation/allocation_note_create.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_note_create.html
@@ -5,12 +5,12 @@
 
 
 {% block title %}
-Add Allocation Note
+Add Allocation Notification
 {% endblock %}
 
 
 {% block content %}
-<h2>Adding note to {{allocation.get_parent_resource}} for PI {{ allocation.project.pi.first_name }}
+<h2>Adding notification to {{allocation.get_parent_resource}} for PI {{ allocation.project.pi.first_name }}
   {{ allocation.project.pi.last_name }} ({{ allocation.project.pi.username }})</h2>
 
 <form method="post">

--- a/coldfront/core/allocation/templates/allocation/allocation_note_create.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_note_create.html
@@ -1,0 +1,23 @@
+{% extends "common/base.html" %}
+{% load crispy_forms_tags %}
+{% load common_tags %}
+{% load static %}
+
+
+{% block title %}
+Add Allocation Note
+{% endblock %}
+
+
+{% block content %}
+<h2>Adding note to {{allocation.get_parent_resource}} for PI {{ allocation.project.pi.first_name }}
+  {{ allocation.project.pi.last_name }} ({{ allocation.project.pi.username }})</h2>
+
+<form method="post">
+  {% csrf_token %}
+  {{form |crispy}}
+  <input class="btn btn-success" type="submit" value="Add" />
+  <a class="btn btn-secondary" href="{% url 'allocation-detail' allocation.pk %}" role="button">Back to
+    Allocation</a><br>
+</form>
+{% endblock %}

--- a/coldfront/core/allocation/templates/allocation/allocation_request_list.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_request_list.html
@@ -12,13 +12,23 @@ Allocation Review New and Pending Requests
 {% block content %}
 <h2>Allocation Requests</h2>
 
+<hr>
+
+<p class="text-justify"> 
+  For each allocation request below, there is the option to activate the allocation request and to view the allocation's detail page.
+</p>
+
+<p class="text-justify"> 
+  By default, activating an allocation will make it active for {{ ALLOCATION_DEFAULT_ALLOCATION_LENGTH }} days.
+</p>
+
 {% if allocation_list %}
   <div class="table-responsive">
     <table class="table table-sm">
       <thead>
         <tr>
           <th scope="col">#</th>
-          <th scope="col">Date Requested/<br>Last Modified</th>
+          <th scope="col">Requested</th>
           <th scope="col">Project Title</th>
           <th scope="col">PI</th>
           <th scope="col">Resource</th>
@@ -26,14 +36,14 @@ Allocation Review New and Pending Requests
             <th scope="col" class="text-nowrap">Project Review Status</th>
           {% endif %}
           <th scope="col">Status</th>
-          <th scope="col">Allocation Actions</th>
+          <th scope="col">Actions</th>
         </tr>
       </thead>
       <tbody>
         {% for allocation in allocation_list %}
           <tr>
-            <td><a href="{% url 'allocation-detail' allocation.pk %}">{{allocation.pk}}</a></td>
-            <td>{{ allocation.modified|date:"M. d, Y" }}</td>
+            <td>{{allocation.pk}}</td>
+            <td>{{ allocation.created|date:"M. d, Y" }}</td>
             <td><a href="{% url 'project-detail' allocation.project.pk %}">{{allocation.project.title|truncatechars:50}}</a></td>
             <td>{{allocation.project.pi.first_name}} {{allocation.project.pi.last_name}}
               ({{allocation.project.pi.username}})</td>
@@ -43,8 +53,13 @@ Allocation Review New and Pending Requests
             {% endif %}
             <td>{{allocation.status}}</td>
             <td class="text-nowrap">
-              <a href="{% url 'allocation-activate-request' allocation.pk %}" class="btn btn-success mr-1">Activate</a>
-              <a href="{% url 'allocation-deny-request' allocation.pk %}" class="btn btn-danger mr-1">Deny</a>
+              {% if allocation.get_information == '' %}
+                <a href="{% url 'allocation-activate-request' allocation.pk %}" class="btn btn-success mr-1 confirm-activate" aria-disabled="true">Approve</a>
+                <a href="{% url 'allocation-detail' allocation.pk %}" class="btn btn-primary mr-1">Details</a>
+              {% else %}
+                  <a href="{% url 'allocation-activate-request' allocation.pk %}" class="btn btn-success mr-1">Activate</a>
+                  <a href="{% url 'allocation-detail' allocation.pk %}" class="btn btn-primary mr-1">Details</a>
+              {% endif %}
             </td>
           </tr>
         {% endfor %}
@@ -61,5 +76,8 @@ Allocation Review New and Pending Requests
   $("#navbar-main > ul > li.active").removeClass("active");
   $("#navbar-admin").addClass("active");
   $("#navbar-allocation-requests").addClass("active");
+  $(document).on('click', '.confirm-activate', function(){
+      return confirm('Are you sure you want to activate this allocation request without setting any allocation attributes?');
+  })
 </script>
 {% endblock %}

--- a/coldfront/core/allocation/urls.py
+++ b/coldfront/core/allocation/urls.py
@@ -36,6 +36,8 @@ urlpatterns = [
          allocation_views.AllocationChangeView.as_view(), name='allocation-change'),
     path('<int:pk>/allocationattribute/delete',
          allocation_views.AllocationAttributeDeleteView.as_view(), name='allocation-attribute-delete'),
+    path('<int:pk>/allocationnote/add',
+         allocation_views.AllocationNoteCreateView.as_view(), name='allocation-note-add'),
     path('allocation-invoice-list', allocation_views.AllocationInvoiceListView.as_view(),
          name='allocation-invoice-list'),
     path('<int:pk>/invoice/', allocation_views.AllocationInvoiceDetailView.as_view(),

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -206,6 +206,7 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             'end_date': allocation_obj.end_date,
             'start_date': allocation_obj.start_date,
             'description': allocation_obj.description,
+            'is_locked': allocation_obj.is_locked,
             'is_changeable': allocation_obj.is_changeable,
         }
 
@@ -230,6 +231,7 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             'end_date': allocation_obj.end_date,
             'start_date': allocation_obj.start_date,
             'description': allocation_obj.description,
+            'is_locked': allocation_obj.is_locked,
             'is_changeable': allocation_obj.is_changeable,
         }
         form = AllocationUpdateForm(request.POST, initial=initial_data)
@@ -239,6 +241,7 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             end_date = form_data.get('end_date')
             start_date = form_data.get('start_date')
             description = form_data.get('description')
+            is_locked = form_data.get('is_locked')
             is_changeable = form_data.get('is_changeable')
 
             allocation_obj.description = description
@@ -256,6 +259,7 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             new_status = form_data.get('status').name
 
             allocation_obj.status = form_data.get('status')
+            allocation_obj.is_locked = is_locked
             allocation_obj.is_changeable = is_changeable
             allocation_obj.save()
 
@@ -1020,6 +1024,48 @@ class AllocationAttributeDeleteView(LoginRequiredMixin, UserPassesTestMixin, Tem
         return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
 
 
+class AllocationNoteCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
+    model = AllocationUserNote
+    fields = '__all__'
+    template_name = 'allocation/allocation_note_create.html'
+
+    def test_func(self):
+        """ UserPassesTestMixin Tests"""
+
+        if self.request.user.is_superuser:
+            return True
+        else:
+            messages.error(
+                self.request, 'You do not have permission to add allocation notes.')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        pk = self.kwargs.get('pk')
+        allocation_obj = get_object_or_404(Allocation, pk=pk)
+        context['allocation'] = allocation_obj
+        return context
+
+    def get_initial(self):
+        initial = super().get_initial()
+        pk = self.kwargs.get('pk')
+        allocation_obj = get_object_or_404(Allocation, pk=pk)
+        author = self.request.user
+        initial['allocation'] = allocation_obj
+        initial['author'] = author
+        return initial
+
+    def get_form(self, form_class=None):
+        """Return an instance of the form to be used in this view."""
+        form = super().get_form(form_class)
+        form.fields['allocation'].widget = forms.HiddenInput()
+        form.fields['author'].widget = forms.HiddenInput()
+        form.order_fields([ 'allocation', 'author', 'note', 'is_private' ])
+        return form
+
+    def get_success_url(self):
+        return reverse('allocation-detail', kwargs={'pk': self.kwargs.get('pk')})
+
+
 class AllocationRequestListView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
     template_name = 'allocation/allocation_request_list.html'
     login_url = '/'
@@ -1042,6 +1088,7 @@ class AllocationRequestListView(LoginRequiredMixin, UserPassesTestMixin, Templat
             status__name__in=['New', 'Renewal Requested', 'Paid', ])
         context['allocation_list'] = allocation_list
         context['PROJECT_ENABLE_PROJECT_REVIEW'] = PROJECT_ENABLE_PROJECT_REVIEW
+        context['ALLOCATION_DEFAULT_ALLOCATION_LENGTH'] = ALLOCATION_DEFAULT_ALLOCATION_LENGTH
         return context
 
 
@@ -1115,7 +1162,10 @@ class AllocationActivateRequestView(LoginRequiredMixin, UserPassesTestMixin, Vie
                 email_receiver_list
             )
 
-        return HttpResponseRedirect(reverse('allocation-request-list'))
+        if 'request-list' in request.path:
+            return HttpResponseRedirect(reverse('allocation-request-list'))
+        else:
+            return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
 
 
 class AllocationDenyRequestView(LoginRequiredMixin, UserPassesTestMixin, View):
@@ -1184,7 +1234,11 @@ class AllocationDenyRequestView(LoginRequiredMixin, UserPassesTestMixin, View):
                 EMAIL_SENDER,
                 email_receiver_list
             )
-        return HttpResponseRedirect(reverse('allocation-request-list'))
+        if 'request-list' in request.path:
+            return HttpResponseRedirect(reverse('allocation-request-list'))
+        else:
+            return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
+
 
 
 class AllocationRenewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):


### PR DESCRIPTION
Resolves issue #341. Added a number of features to the Allocation Request workflow that were introduced in the Allocation Change Request workflow to create a more cohesive experience. Updates include: 

Allocation detail page:

    Expose button to add 'notifications' so admin can include details about allocation request
    Allow 'lock/unlock' to be set here like the 'allow change requests'

Allocation request list:

    Change 'Date Requested/Last Modified' to 'Last Modified'
    Change 'Allocation Actions' to 'Actions'
    Add 'Details' button to get to Allocation detail page
    Unlink ID number as this will now be the 'Details' button
    Grey out 'Activate' if allocation is new - this is because allocation attributes need to be added to new allocations before allocation is approved
    Remove 'Deny' button and require admin to use 'Details' to specify a reason for denying an allocation