### PR TITLE
Allocation Change Flow Bug Fixes

### DIFF
--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -236,7 +236,7 @@ class AllocationChangeForm(forms.Form):
     justification = forms.CharField(
         label='Justification for Changes',
         widget=forms.Textarea,
-        required=False,
+        required=True,
         help_text='Justification for requesting this allocation change request.')
 
     def __init__(self, *args, **kwargs):

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -28,7 +28,7 @@ Allocation Detail
 
 <div class="card mb-3">
   <div class="card-header">
-    {% if allocation.is_changeable and is_allowed_to_update_project %}
+    {% if allocation.is_changeable and not allocation.is_locked and is_allowed_to_update_project and allocation.status.name in 'Active, Renewal Requested, Payment Pending, Payment Requested, Paid' %}
     <div class="row">
       <div class="col">
         <h3><i class="fas fa-list" aria-hidden="true"></i> Allocation Information</h3>

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1757,7 +1757,7 @@ class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormVi
         allocation_change_form.fields['justification'].disabled = True
         if allocation_change_obj.status.name != 'Pending': 
             allocation_change_form.fields['end_date_extension'].disabled = True
-        if allocation_change_obj.allocation.project.pi == self.request.user:
+        if not self.request.user.is_staff and not self.request.user.is_superuser:
             allocation_change_form.fields['end_date_extension'].disabled = True
 
         note_form = AllocationChangeNoteForm(
@@ -1781,6 +1781,7 @@ class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormVi
         allocation_change_form = AllocationChangeForm(request.POST,
             initial={'justification': allocation_change_obj.justification,
                      'end_date_extension': allocation_change_obj.end_date_extension})
+        allocation_change_form.fields['justification'].required = False
 
         allocation_attributes_to_change = self.get_allocation_attributes_to_change(
             allocation_change_obj)

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -2137,8 +2137,8 @@ class AllocationChangeView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                 request, 'You cannot request a change to a locked allocation.')
             return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': allocation_obj.pk}))
 
-        if allocation_obj.status.name not in ['Active', 'New', 'Renewal Requested', 'Payment Pending', 'Payment Requested', 'Paid']:
-            messages.error(request, 'You cannot request a change to an allocation with status {}.'.format(
+        if allocation_obj.status.name not in ['Active', 'Renewal Requested', 'Payment Pending', 'Payment Requested', 'Paid']:
+            messages.error(request, 'You cannot request a change to an allocation with status "{}".'.format(
                 allocation_obj.status.name))
             return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': allocation_obj.pk}))
 
@@ -2238,7 +2238,29 @@ class AllocationChangeView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                             )
                     messages.success(
                         request, 'Allocation change request successfully submitted.')
-                    
+
+                    pi_name = '{} {} ({})'.format(allocation_obj.project.pi.first_name,
+                                                allocation_obj.project.pi.last_name, allocation_obj.project.pi.username)
+                    resource_name = allocation_obj.get_parent_resource
+                    domain_url = get_domain_url(self.request)
+                    url = '{}{}'.format(domain_url, reverse('allocation-change-list'))
+
+                    if EMAIL_ENABLED:
+                        template_context = {
+                            'pi': pi_name,
+                            'resource': resource_name,
+                            'url': url
+                        }
+
+                        send_email_template(
+                            'New Allocation Change Request: {} - {}'.format(
+                                pi_name, resource_name),
+                            'email/new_allocation_change_request.txt',
+                            template_context,
+                            EMAIL_SENDER,
+                            [EMAIL_TICKET_SYSTEM_ADDRESS, ]
+                        )
+
                     return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
 
                 else:
@@ -2273,7 +2295,29 @@ class AllocationChangeView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                         )
                     messages.success(
                         request, 'Allocation change request successfully submitted.')
-                    
+
+                pi_name = '{} {} ({})'.format(allocation_obj.project.pi.first_name,
+                                            allocation_obj.project.pi.last_name, allocation_obj.project.pi.username)
+                resource_name = allocation_obj.get_parent_resource
+                domain_url = get_domain_url(self.request)
+                url = '{}{}'.format(domain_url, reverse('allocation-change-list'))
+
+                if EMAIL_ENABLED:
+                    template_context = {
+                        'pi': pi_name,
+                        'resource': resource_name,
+                        'url': url
+                    }
+
+                    send_email_template(
+                        'New Allocation Change Request: {} - {}'.format(
+                            pi_name, resource_name),
+                        'email/new_allocation_change_request.txt',
+                        template_context,
+                        EMAIL_SENDER,
+                        [EMAIL_TICKET_SYSTEM_ADDRESS, ]
+                    )
+
                     return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))
 
                 else:

--- a/coldfront/templates/email/new_allocation_change_request.txt
+++ b/coldfront/templates/email/new_allocation_change_request.txt
@@ -1,0 +1,2 @@
+An allocation change request for has been made for {{pi}} - {{resource}}. Please review the change request:
+{{url}}


### PR DESCRIPTION
Resolves issue #355. 

- Justifications are now required again for any allocation change request that is submitted.
- Users (non-managers) can no longer see the date drop down in a pending allocation change request. 