### PR TITLE
Fix IntegrityError when publications have same UniqeID and Project

### DIFF
--- a/coldfront/core/publication/views.py
+++ b/coldfront/core/publication/views.py
@@ -221,12 +221,14 @@ class PublicationAddView(LoginRequiredMixin, UserPassesTestMixin, View):
                         pk=form_data.get('source_pk'))
                     publication_obj, created = Publication.objects.get_or_create(
                         project=project_obj,
-                        title=form_data.get('title'),
-                        author=form_data.get('author'),
-                        year=form_data.get('year'),
-                        journal=form_data.get('journal'),
                         unique_id=form_data.get('unique_id'),
-                        source=source_obj
+                        defaults = {
+                            'title':form_data.get('title'),
+                            'author':form_data.get('author'),
+                            'year':form_data.get('year'),
+                            'journal':form_data.get('journal'),
+                            'source':source_obj                            
+                        }                        
                     )
                     if created:
                         publications_added += 1


### PR DESCRIPTION
but different other fields, like source or for example abbreviation changes in names etc. Instead of  meaningful info, IntegrityError is raised while Django tries to insert a new record.

get_or_create uses all fields in select, defaults are used instead for new records.