### PR TITLE
Project Detail Page: Users can see all their allocations (regardless of status)

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -212,6 +212,9 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
         }
 
         form = AllocationUpdateForm(initial=initial_data)
+        if not self.request.user.is_superuser:
+            form.fields['is_locked'].disabled = True
+            form.fields['is_changeable'].disabled = True
 
         context = self.get_context_data()
         context['form'] = form

--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -49,7 +49,8 @@ class ProjectAddUsersToAllocationForm(forms.Form):
         project_obj = get_object_or_404(Project, pk=project_pk)
 
         allocation_query_set = project_obj.allocation_set.filter(
-            status__name__in=['Active', 'New', 'Renewal Requested', ], resources__is_allocatable=True, is_locked=False)
+            resources__is_allocatable=True, is_locked=False).exclude(status__name__in=['Denied', 'Expired', 'Payment Declined', 'Revoked', 'Unpaid',])
+        print(allocation_query_set)
         allocation_choices = [(allocation.id, "%s (%s) %s" % (allocation.get_parent_resource.name, allocation.get_parent_resource.resource_type.name,
                                                               allocation.description if allocation.description else '')) for allocation in allocation_query_set]
         allocation_choices.insert(0, ('__select_all__', 'Select All'))

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -111,10 +111,6 @@ class ProjectDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
                     Q(project=self.object) &
                     Q(project__projectuser__user=self.request.user) &
                     Q(project__projectuser__status__name__in=['Active', ]) &
-                    Q(status__name__in=['Active', 'Expired',
-                                        'New', 'Renewal Requested',
-                                        'Payment Pending', 'Payment Requested',
-                                        'Payment Declined', 'Paid','Denied']) &
                     Q(allocationuser__user=self.request.user) &
                     Q(allocationuser__status__name__in=['Active', ])
                 ).distinct().order_by('-end_date')


### PR DESCRIPTION
Resolves issue #292

- On an active Project's detail page users are now able to view all the allocations they have access to, regardless of their current status. 
- Also fixed a minor UI bug on Allocation Detail Pages where staff users used to get active checkbox fields for the "Lock/Unlock Allocation" and "Allow Change Requests" fields. Those are now disabled for them.


