### PR TITLE
Bug Fix: Publications can be added to projects no matter how many authors they have

### DIFF
--- a/coldfront/core/publication/forms.py
+++ b/coldfront/core/publication/forms.py
@@ -22,7 +22,7 @@ class PublicationSearchForm(forms.Form):
 
 class PublicationResultForm(forms.Form):
     title = forms.CharField(max_length=1024, disabled=True)
-    author = forms.CharField(max_length=1024, disabled=True)
+    author = forms.CharField(disabled=True)
     year = forms.CharField(max_length=4, disabled=True)
     journal = forms.CharField(max_length=1024, disabled=True)
     unique_id = forms.CharField(max_length=255, disabled=True)

--- a/coldfront/core/publication/views.py
+++ b/coldfront/core/publication/views.py
@@ -219,12 +219,14 @@ class PublicationAddView(LoginRequiredMixin, UserPassesTestMixin, View):
                 if form_data['selected']:
                     source_obj = PublicationSource.objects.get(
                         pk=form_data.get('source_pk'))
+                    author = form_data.get('author')
+                    if len(author) > 1024: author = author[:1024]
                     publication_obj, created = Publication.objects.get_or_create(
                         project=project_obj,
                         unique_id=form_data.get('unique_id'),
                         defaults = {
                             'title':form_data.get('title'),
-                            'author':form_data.get('author'),
+                            'author':author,
                             'year':form_data.get('year'),
                             'journal':form_data.get('journal'),
                             'source':source_obj                            


### PR DESCRIPTION
Resolves issue #283
* If a publication is searched for by its ID in order to be added to a project, it will now be successfully added no matter how long its author field is.
* Publications like this will have its author field truncated down to 1024 characters.