### PR TITLE
Export Specific Grants

### DIFF
--- a/coldfront/core/grant/forms.py
+++ b/coldfront/core/grant/forms.py
@@ -28,3 +28,25 @@ class GrantDeleteForm(forms.Form):
         max_length=30, required=False, disabled=True)
     grant_end = forms.CharField(max_length=150, required=False, disabled=True)
     selected = forms.BooleanField(initial=False, required=False)
+
+
+class GrantDownloadForm(forms.Form):
+    pk = forms.IntegerField(required=False, disabled=True)
+    title = forms.CharField(required=False, disabled=True)
+    project_pk = forms.IntegerField(required=False, disabled=True)
+    pi_first_name = forms.CharField(required=False, disabled=True)
+    pi_last_name = forms.CharField(required=False, disabled=True)
+    role = forms.CharField(required=False, disabled=True)
+    grant_pi = forms.CharField(required=False, disabled=True)
+    total_amount_awarded = forms.FloatField(required=False, disabled=True)
+    funding_agency = forms.CharField(required=False, disabled=True)
+    grant_number = forms.CharField(required=False, disabled=True)
+    grant_start = forms.DateField(required=False, disabled=True)
+    grant_end = forms.DateField(required=False, disabled=True)
+    percent_credit = forms.FloatField(required=False, disabled=True)
+    direct_funding = forms.FloatField(required=False, disabled=True)
+    selected = forms.BooleanField(initial=False, required=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['pk'].widget = forms.HiddenInput()

--- a/coldfront/core/grant/templates/grant/grant_report_list.html
+++ b/coldfront/core/grant/templates/grant/grant_report_list.html
@@ -14,14 +14,17 @@ Grants Report
 <div class="card">
   <div class="card-header">
     <h4 class="d-inline"><i class="fas fa-trophy" aria-hidden="true"></i> Grants</h4>
-    <a class="btn btn-success float-right" href="{% url 'grant-download' %}" role="button"><i class="fas fa-download" aria-hidden="true"></i> Export to CSV</a>
+    <button type="submit" form="download_form" class="btn btn-success float-right"><i class="fas fa-download" aria-hidden="true"></i> Export to CSV</button>
   </div>
   <div class="card-body">
-    {% if grant_list %}
+    {% if formset %}
+    <form id="download_form" action="{% url 'grant-report' %}" method="post">
+      {% csrf_token %}
       <div class="table-responsive">
         <table id="grants-table" class="table table-hover table-sm">
           <thead>
             <tr>
+              <th scope="col"><input type="checkbox" class="check" id="selectAll"></th>
               <th scope="col">Grant Title</th>
               <th scope="col">Project PI</th>
               <th scope="col">Faculty Role</th>
@@ -36,24 +39,27 @@ Grants Report
             </tr>
           </thead>
           <tbody>
-            {% for grant in grant_list %}
+            {% for form in formset %}
               <tr>
-                <td style="min-width: 400px">{{ grant.title }}</td>
-                <td class="text-nowrap"><a href="{% url 'project-detail' grant.project.pk %}">{{ grant.project.pi.first_name }} {{ grant.project.pi.last_name }}</a></td>
-                <td class="text-nowrap">{{ grant.role }}</td>
-                <td class="text-nowrap">{{ grant.grant_pi }}</td>
-                <td class="text-nowrap">{{ grant.total_amount_awarded|intcomma }}</td>
-                <td class="text-nowrap">{{ grant.funding_agency }}</td>
-                <td class="text-nowrap">{{ grant.grant_number }}</td>
-                <td class="text-nowrap">{{ grant.grant_start|date:"M. d, Y" }}</td>
-                <td class="text-nowrap">{{ grant.grant_end|date:"M. d, Y" }}</td>
-                <td>{{ grant.percent_credit }}</td>
-                <td>{{ grant.direct_funding|intcomma }}</td>
+                <td>{{ form.selected }}</td>
+                <td style="min-width: 400px">{{ form.title.value }}</td>
+                <td class="text-nowrap"><a href="{% url 'project-detail' form.project_pk.value %}">{{ form.pi_first_name.value }} {{ form.pi_last_name.value }}</a></td>
+                <td class="text-nowrap">{{ form.role.value }}</td>
+                <td class="text-nowrap">{{ form.grant_pi.value }}</td>
+                <td class="text-nowrap">{{ form.total_amount_awarded.value|intcomma }}</td>
+                <td class="text-nowrap">{{ form.funding_agency.value }}</td>
+                <td class="text-nowrap">{{ form.grant_number.value }}</td>
+                <td class="text-nowrap">{{ form.grant_start.value|date:"M. d, Y" }}</td>
+                <td class="text-nowrap">{{ form.grant_end.value|date:"M. d, Y" }}</td>
+                <td>{{ form.percent_credit.value }}</td>
+                <td>{{ form.direct_funding.value|intcomma }}</td>
               </tr>
             {% endfor %}
           </tbody>
         </table>
       </div>
+      {{ formset.management_form }}
+    </form>
     {% else %}
       <div class="alert alert-info" role="alert"><i class="fas fa-info-circle" aria-hidden="true"></i> There are no grants to display.</div>
     {% endif %}
@@ -70,8 +76,21 @@ Grants Report
     $('#grants-table').DataTable({
       "iDisplayLength": 50,
       "bSortClasses": false,
-      "order": [[ 4, "desc" ]]
+      "order": [[ 4, "desc" ]],
+      "columnDefs": [{ 'orderable': false, 'targets': 0 }],
+      "aaSorting": [[1, 'asc']] 
     });
+  });
+
+  $("#selectAll").click(function () {
+    $("input[name^='grantdownloadform-']").prop('checked', $(this).prop('checked'));
+  });
+
+  $("input[name^='grantdownloadform-']").click(function (ele) {
+    var id = $(this).attr('id');
+    if (id != "selectAll") {
+      $("#selectAll").prop('checked', false);
+    }
   });
 </script>
 {% endblock %}

--- a/coldfront/core/grant/templates/grant/grant_report_list.html
+++ b/coldfront/core/grant/templates/grant/grant_report_list.html
@@ -76,7 +76,7 @@ Grants Report
     $('#grants-table').DataTable({
       "iDisplayLength": 50,
       "bSortClasses": false,
-      "order": [[ 4, "desc" ]],
+      "order": [[ 5, "desc" ]],
       "columnDefs": [{ 'orderable': false, 'targets': 0 }],
       "aaSorting": [[1, 'asc']] 
     });

--- a/coldfront/core/grant/views.py
+++ b/coldfront/core/grant/views.py
@@ -11,7 +11,7 @@ from django.views.generic import DetailView, FormView, ListView, TemplateView
 from django.views.generic.edit import CreateView, UpdateView
 
 from coldfront.core.utils.common import Echo
-from coldfront.core.grant.forms import GrantDeleteForm, GrantForm
+from coldfront.core.grant.forms import GrantDeleteForm, GrantDownloadForm, GrantForm
 from coldfront.core.grant.models import (Grant, GrantFundingAgency,
                                          GrantStatusChoice)
 from coldfront.core.project.models import Project
@@ -182,9 +182,7 @@ class GrantDeleteGrantsView(LoginRequiredMixin, UserPassesTestMixin, TemplateVie
 
 
 class GrantReportView(LoginRequiredMixin, UserPassesTestMixin, ListView):
-    model = Grant
     template_name = 'grant/grant_report_list.html'
-    context_object_name = 'grant_list'
 
     def test_func(self):
         """ UserPassesTestMixin Tests"""
@@ -195,6 +193,119 @@ class GrantReportView(LoginRequiredMixin, UserPassesTestMixin, ListView):
             return True
 
         messages.error(self.request, 'You do not have permission to view all grants.')
+
+
+    def get_grants(self):
+        grants = Grant.objects.prefetch_related(
+            'project', 'project__pi').all().order_by('-total_amount_awarded')
+        grants= [
+
+            {'pk': grant.pk,
+            'title': grant.title,
+            'project_pk': grant.project.pk,
+            'pi_first_name': grant.project.pi.first_name,
+            'pi_last_name':grant.project.pi.last_name,
+            'role': grant.role,
+            'grant_pi': grant.grant_pi,
+            'total_amount_awarded': grant.total_amount_awarded,
+            'funding_agency': grant.funding_agency,
+            'grant_number': grant.grant_number,
+            'grant_start': grant.grant_start,
+            'grant_end': grant.grant_end,
+            'percent_credit': grant.percent_credit,
+            'direct_funding': grant.direct_funding,
+            }
+            for grant in grants
+        ]
+
+        return grants
+
+
+    def get(self, request, *args, **kwargs):
+        context = {}
+        grants = self.get_grants()
+
+        if grants:
+            formset = formset_factory(GrantDownloadForm, max_num=len(grants))
+            formset = formset(initial=grants, prefix='grantdownloadform')
+            context['formset'] = formset
+        return render(request, self.template_name, context)
+
+
+    def post(self, request, *args, **kwargs):
+        grants = self.get_grants()
+
+        formset = formset_factory(GrantDownloadForm, max_num=len(grants))
+        formset = formset(request.POST, initial=grants, prefix='grantdownloadform')
+
+        header = [
+            'Grant Title',
+            'Project PI',
+            'Faculty Role',
+            'Grant PI',
+            'Total Amount Awarded',
+            'Funding Agency',
+            'Grant Number',
+            'Start Date',
+            'End Date',
+            'Percent Credit',
+            'Direct Funding',
+        ]
+        rows = []
+        grants_selected_count = 0
+
+        if formset.is_valid():
+            for form in formset:
+                form_data = form.cleaned_data
+                if form_data['selected']:
+                    grant = get_object_or_404(Grant, pk=form_data['pk'])
+
+                    row = [
+                        grant.title,
+                        ' '.join((grant.project.pi.first_name, grant.project.pi.last_name)),
+                        grant.role,
+                        grant.grant_pi_full_name,
+                        grant.total_amount_awarded,
+                        grant.funding_agency,
+                        grant.grant_number,
+                        grant.grant_start,
+                        grant.grant_end,
+                        grant.percent_credit,
+                        grant.direct_funding,
+                    ]
+
+                    rows.append(row)
+                    grants_selected_count += 1
+
+            if grants_selected_count == 0:
+                grants = Grant.objects.prefetch_related('project', 'project__pi').all().order_by('-total_amount_awarded')
+                for grant in grants:
+                    row = [
+                        grant.title,
+                        ' '.join((grant.project.pi.first_name, grant.project.pi.last_name)),
+                        grant.role,
+                        grant.grant_pi_full_name,
+                        grant.total_amount_awarded,
+                        grant.funding_agency,
+                        grant.grant_number,
+                        grant.grant_start,
+                        grant.grant_end,
+                        grant.percent_credit,
+                        grant.direct_funding,
+                    ]
+                    rows.append(row)
+
+            rows.insert(0, header)
+            pseudo_buffer = Echo()
+            writer = csv.writer(pseudo_buffer)
+            response = StreamingHttpResponse((writer.writerow(row) for row in rows),
+                                            content_type="text/csv")
+            response['Content-Disposition'] = 'attachment; filename="grants.csv"'
+            return response
+        else:
+            for error in formset.errors:
+                messages.error(request, error)
+            return HttpResponseRedirect(reverse('grant-report'))
 
 
 class GrantDownloadView(LoginRequiredMixin, UserPassesTestMixin, View):

--- a/coldfront/core/resource/admin.py
+++ b/coldfront/core/resource/admin.py
@@ -53,6 +53,7 @@ class ResourceAdmin(SimpleHistoryAdmin):
     list_filter = ('resource_type__name', 'is_allocatable', 'is_available', 'is_public', 'requires_payment' )
     inlines = [ResourceAttributeInline, ]
     filter_horizontal = ['allowed_groups', 'allowed_users', 'linked_resources', ]
+    save_as = True
 
     def resource_type_name(self, obj):
         return obj.resource_type.name


### PR DESCRIPTION
Resolves issue #222

- Each grant on the 'Grant Resource' page now has a checkbox that can be used to export specific resources.
- Resources can now be duplicated in the Django Admin portal through the use of a 'Save as new' button.