### PR TITLE
Allocation request approval redirects back to the page which it was approved

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1171,8 +1171,7 @@ class AllocationActivateRequestView(LoginRequiredMixin, UserPassesTestMixin, Vie
                 EMAIL_SENDER,
                 email_receiver_list
             )
-
-        if 'request-list' in request.path:
+        if 'request-list' in request.META.get('HTTP_REFERER'):
             return HttpResponseRedirect(reverse('allocation-request-list'))
         else:
             return HttpResponseRedirect(reverse('allocation-detail', kwargs={'pk': pk}))


### PR DESCRIPTION
Currently a user can approval an allocation on either its detail page or the 'Allocation Requests' page. The approval process now redirects a user back to the page they came from.