### PR TITLE
Bug Fix: Users can no longer be added to inactive allocations when being added to a Project

### DIFF
--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -49,8 +49,7 @@ class ProjectAddUsersToAllocationForm(forms.Form):
         project_obj = get_object_or_404(Project, pk=project_pk)
 
         allocation_query_set = project_obj.allocation_set.filter(
-            resources__is_allocatable=True, is_locked=False).exclude(status__name__in=['Denied', 'Expired', 'Payment Declined', 'Revoked', 'Unpaid',])
-        print(allocation_query_set)
+            resources__is_allocatable=True, is_locked=False, status__name__in=['Active', 'New', 'Renewal Requested', 'Payment Pending', 'Payment Requested', 'Paid'])
         allocation_choices = [(allocation.id, "%s (%s) %s" % (allocation.get_parent_resource.name, allocation.get_parent_resource.resource_type.name,
                                                               allocation.description if allocation.description else '')) for allocation in allocation_query_set]
         allocation_choices.insert(0, ('__select_all__', 'Select All'))


### PR DESCRIPTION
Resolves issue #386 

- When a PI tries to add a user to a Project, they now can only add the user to Project allocations of the following statuses: Active, New, Renewal Requested, Payment Pending, Payment Requested, Paid