### PR TITLE
SLURM_NOOP should be a bool

### DIFF
--- a/coldfront/config/plugins/slurm.py
+++ b/coldfront/config/plugins/slurm.py
@@ -6,6 +6,6 @@ INSTALLED_APPS += [
 ]
 
 SLURM_SACCTMGR_PATH = ENV.str('SLURM_SACCTMGR_PATH', default='/usr/bin/sacctmgr')
-SLURM_NOOP = ENV.str('SLURM_NOOP', False)
+SLURM_NOOP = ENV.bool('SLURM_NOOP', False)
 SLURM_IGNORE_USERS = ENV.list('SLURM_IGNORE_USERS', default=['root'])
 SLURM_IGNORE_ACCOUNTS = ENV.list('SLURM_IGNORE_ACCOUNTS', default=[])


### PR DESCRIPTION
SLURM_NOOP should be a bool. "if self.noop" resolves as true even if self.noop is "False" because it is a non-empty string. Noticed this because slurm_check was responding as NOOP even when using --sync.