### PR TITLE
Resolved #387: Fixed bug that would only update allocation statuses o…

### DIFF
--- a/coldfront/core/allocation/tasks.py
+++ b/coldfront/core/allocation/tasks.py
@@ -31,7 +31,7 @@ def update_statuses():
     expired_status_choice = AllocationStatusChoice.objects.get(
         name='Expired')
     allocations_to_expire = Allocation.objects.filter(
-        status__name='Active', end_date__lt=datetime.datetime.now().date())
+        end_date__lt=datetime.datetime.now().date())
     for sub_obj in allocations_to_expire:
         sub_obj.status = expired_status_choice
         sub_obj.save()


### PR DESCRIPTION
…f 'active' to 'expired', other statuses would stay as their current status after expiration date was reached.

NOTE: Need redis running and possibly MailHog to have the scheduler work

Tested fix through the following: 
1. Created many allocations of different statuses (also tested some allocations that were locked/unlocked and some that allowed change requests)
2. Put all created allocations start and end dates so that they should be expired
3. Through ColdFront Administration page, forced the DJANGO Q 'Scheduled tasks' to perform a status update.
4. Force status update by changing 'Date' to 'Now' and 'Time' to 'Now', then click 'SAVE'
5. Status updates should occur shortly after. Then check allocations for the expected status update.

Tested bug through the following:
1. Tested 'active' status to 'expired' 
2. Tested bug of other statuses to 'expired' (found they did not switch their status as described in bug report)
3. Follow steps 3-5 above to force scheduler to update statuses 
