### PR TITLE
Fixed allocation request 'approved' status bug

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1095,7 +1095,7 @@ class AllocationRequestListView(LoginRequiredMixin, UserPassesTestMixin, Templat
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         allocation_list = Allocation.objects.filter(
-            status__name__in=['New', 'Renewal Requested', 'Paid', ])
+            status__name__in=['New', 'Renewal Requested', 'Paid', 'Approved',])
         context['allocation_list'] = allocation_list
         context['PROJECT_ENABLE_PROJECT_REVIEW'] = PROJECT_ENABLE_PROJECT_REVIEW
         context['ALLOCATION_DEFAULT_ALLOCATION_LENGTH'] = ALLOCATION_DEFAULT_ALLOCATION_LENGTH


### PR DESCRIPTION
Resolved #379 : Fixed bug that would cause allocations that had status of 'New', 'Renewal Requested', or 'Paid' would disappear from the allocation request page when changed to a status of 'Approved'. 

Tested bug through the following:
1. Created allocation requests that had statuses of 'New', 'Renewal Requested', and 'Paid' and changed their status to 'Approved'.
2. Confirmed that these allocation requests would not appear on the allocation request page after status change.

Tested fix through the following:
1. Followed the steps for the bug testing and confirmed that these allocations remained on the allocation request page after fix was applied.

Source of bug:  AllocationRequestListView class of the views file for Allocation would only list allocations with status names of 'New', 'Renewal Requested', and 'Paid'. Added 'Approved' into the status names included.