### PR TITLE
User sorting alphabetical by username

### DIFF
--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -30,7 +30,7 @@ class AllocationForm(forms.Form):
         self.fields['resource'].queryset = get_user_resources(request_user)
         self.fields['quantity'].initial = 1
         user_query_set = project_obj.projectuser_set.select_related('user').filter(
-            status__name__in=['Active', ])
+            status__name__in=['Active', ]).order_by("user__username")
         user_query_set = user_query_set.exclude(user=project_obj.pi)
         if user_query_set:
             self.fields['users'].choices = ((user.user.username, "%s %s (%s)" % (


### PR DESCRIPTION
Resolved issue #395 — Prior to this, when users were added to a project and a new allocation was requested, their names showed up in the order they were added. To add some consistency and clean this up (especially for large lists of users), they are now sorted alphabetically by username.