### PR TITLE
Miscellaneous config issues fixed

### DIFF
--- a/coldfront/config/core.py
+++ b/coldfront/config/core.py
@@ -8,7 +8,7 @@ from coldfront.config.env import ENV
 #------------------------------------------------------------------------------
 # General Center Information
 #------------------------------------------------------------------------------
-CENTER_NAME = ENV.str('CENTER_NAME', default='HPC Resources')
+CENTER_NAME = ENV.str('CENTER_NAME', default='HPC Center')
 CENTER_HELP_URL = ENV.str('CENTER_HELP_URL', default='')
 CENTER_PROJECT_RENEWAL_HELP_URL = ENV.str('CENTER_PROJECT_RENEWAL_HELP_URL', default='')
 CENTER_BASE_URL = ENV.str('CENTER_BASE_URL', default='')

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -908,8 +908,12 @@ class AllocationRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, Templat
                     allocation_remove_user.send(sender=self.__class__,
                                                 allocation_user_pk=allocation_user_obj.pk)
 
-            messages.success(
-                request, 'Removed {} users from allocation.'.format(remove_users_count))
+            if remove_users_count == 1:
+                messages.success(
+                    request, 'Removed {} user from allocation.'.format(remove_users_count))
+            else:
+                messages.success(
+                    request, 'Removed {} users from allocation.'.format(remove_users_count))
         else:
             for error in formset.errors:
                 messages.error(request, error)

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -789,8 +789,12 @@ class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
                             allocation_remove_user.send(sender=self.__class__,
                                                         allocation_user_pk=allocation_user_obj.pk)
 
-            messages.success(
-                request, 'Removed {} users from project.'.format(remove_users_count))
+            if remove_users_count == 1:
+                messages.success(
+                    request, 'Removed {} user from project.'.format(remove_users_count))
+            else:
+                messages.success(
+                    request, 'Removed {} users from project.'.format(remove_users_count))
         else:
             for error in formset.errors:
                 messages.error(request, error)

--- a/coldfront/templates/common/authorized_navbar.html
+++ b/coldfront/templates/common/authorized_navbar.html
@@ -41,12 +41,11 @@
         {% if request.user.is_superuser or perms.allocation.can_manage_invoice %}
           {% include 'common/navbar_invoice.html' %}
         {% endif %}
-        <li id="navbar-help" class="nav-item">
-          <a class="nav-link" href="{% settings_value 'CENTER_HELP_URL' %}">Help</a>
-        </li>
+        {% if "settings_value 'CENTER_HELP_URL'"|length == 0 %}
+          {% include 'common/navbar_help.html' %}
+        {% endif %}
       </ul>
-
-      <ul class="navbar-nav ml-auto">
+      <ul class="navbar-nav ms-auto">
         {% include 'common/navbar_login.html' %}
       </ul>
     </div>

--- a/coldfront/templates/common/navbar_help.html
+++ b/coldfront/templates/common/navbar_help.html
@@ -1,0 +1,5 @@
+{% load common_tags %}
+
+<li id="navbar-help" class="nav-item">
+    <a class="nav-link" href="{% settings_value 'CENTER_HELP_URL' %}">Help</a>
+</li>

--- a/coldfront/templates/common/nonauthorized_navbar.html
+++ b/coldfront/templates/common/nonauthorized_navbar.html
@@ -16,9 +16,9 @@
         <li id="navbar-center-summary" class="nav-item">
           <a class="nav-link" href="{% url 'center-summary' %}">Center Summary</a>
         </li>
-        <li id="navbar-help" class="nav-item">
-          <a class="nav-link" href="{% settings_value 'CENTER_HELP_URL' %}">Help</a>
-        </li>
+        {% if "settings_value 'CENTER_HELP_URL'"|length == 0 %}
+          {% include 'common/navbar_help.html' %}
+        {% endif %}
       </ul>
  
       <ul class="navbar-nav ml-auto">


### PR DESCRIPTION
Resolves #414 —

Now, the following occur:

- the Help button on the navbar only appears when the user specifies the center's help URL, otherwise is not present
- when removing a user from an allocation or a project, the alert reads "removed 1 user" instead of "removed 1 users"
- the default center name is HPC Center to avoid redundancies in parts of the website

Tested through:

- specifying a center help URL and seeing the button appear, and not specifying one and seeing the navbar without the button
- removing a user from both a project and an allocation and reading the alert
- checking the default center name in config settings and in parts of the frontend, such as when requesting an allocation