### PR TITLE
Arguments in signal definitions are obsolete

### DIFF
--- a/coldfront/core/allocation/signals.py
+++ b/coldfront/core/allocation/signals.py
@@ -1,14 +1,14 @@
 import django.dispatch
 
-allocation_activate = django.dispatch.Signal(
-    providing_args=["allocation_pk"])
-allocation_disable = django.dispatch.Signal(
-    providing_args=["allocation_pk"])
+allocation_activate = django.dispatch.Signal()
+    #providing_args=["allocation_pk"]
+allocation_disable = django.dispatch.Signal()
+    #providing_args=["allocation_pk"]
 
-allocation_activate_user = django.dispatch.Signal(
-    providing_args=["allocation_user_pk"])
-allocation_remove_user = django.dispatch.Signal(
-    providing_args=["allocation_user_pk"])
+allocation_activate_user = django.dispatch.Signal()
+    #providing_args=["allocation_user_pk"]
+allocation_remove_user = django.dispatch.Signal()
+    #providing_args=["allocation_user_pk"]
 
-allocation_change_approved = django.dispatch.Signal(
-    providing_args=["allocation_pk", "allocation_change_pk"])
+allocation_change_approved = django.dispatch.Signal()
+    #providing_args=["allocation_pk", "allocation_change_pk"]


### PR DESCRIPTION
https://stackoverflow.com/questions/70364068/django-cms-unexpected-keyword-argument-providing-args