### PR TITLE
Add GPUh and Storage metrics support for XDMOD import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ coldfront.db
 .vscode
 db.json
 .env
+.devcontainer/*
+.gitignore
+.bin/*

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,4 @@ coldfront.db
 db.json
 .env
 .devcontainer/*
-.gitignore
 .bin/*

--- a/coldfront/core/allocation/management/commands/add_allocation_defaults.py
+++ b/coldfront/core/allocation/management/commands/add_allocation_defaults.py
@@ -32,6 +32,7 @@ class Command(BaseCommand):
             ('Cloud Account Name', 'Text', False, False),
             ('CLOUD_USAGE_NOTIFICATION', 'Yes/No', False, True),
             ('Core Usage (Hours)', 'Int', True, False),
+            ('Accelerator Usage (Hours)', 'Int', True, False),            
             ('Cloud Storage Quota (TB)', 'Float', True, False),
             ('EXPIRE NOTIFICATION', 'Yes/No', False, True),
             ('freeipa_group', 'Text', False, False),

--- a/coldfront/plugins/xdmod/management/commands/xdmod_usage.py
+++ b/coldfront/plugins/xdmod/management/commands/xdmod_usage.py
@@ -42,6 +42,8 @@ class Command(BaseCommand):
             "-x", "--header", help="Include header in output", action="store_true")
         parser.add_argument(
             "-m", "--statistic", help="XDMoD statistic (default total_cpu_hours)", required=True)
+        parser.add_argument(
+            "--expired", help="XDMoD statistic for archived projects", action="store_true")
 
     def write(self, data):
         try:
@@ -454,6 +456,8 @@ class Command(BaseCommand):
         self.filter_resource = ''
         self.filter_account = ''
         self.print_header = False
+        self.fetch_expired = False
+        
         if options['username']:
             logger.info("Filtering output by username: %s",
                         options['username'])
@@ -470,6 +474,10 @@ class Command(BaseCommand):
             self.filter_resource = options['resource']
         if options['header']:
             self.print_header = True
+        
+        if options['expired']:
+            self.fetch_expired = True
+
         if options['statistic']:
             statistic = options['statistic']
 

--- a/coldfront/plugins/xdmod/management/commands/xdmod_usage.py
+++ b/coldfront/plugins/xdmod/management/commands/xdmod_usage.py
@@ -228,8 +228,8 @@ class Command(BaseCommand):
                 continue
 
             try:
-                usage = xdmod_fetch_total_storage(
-                    s.start_date, s.end_date, account_name, resources=resources, statistics='physical_usage')
+                usage = xdmod_fetch_total_cpu_hours(
+                    s.start_date, s.end_date, account_name, resources=resources, statistics='total_gpu_hours')
             except XdmodNotFoundError:
                 logger.warn(
                     "No data in XDMoD found for allocation %s account %s resources %s", s, account_name, resources)

--- a/coldfront/plugins/xdmod/utils.py
+++ b/coldfront/plugins/xdmod/utils.py
@@ -13,9 +13,9 @@ XDMOD_ACCOUNT_ATTRIBUTE_NAME = import_from_settings('XDMOD_ACCOUNT_ATTRIBUTE_NAM
 XDMOD_RESOURCE_ATTRIBUTE_NAME = import_from_settings('XDMOD_RESOURCE_ATTRIBUTE_NAME', 'xdmod_resource')
 
 XDMOD_CPU_HOURS_ATTRIBUTE_NAME = import_from_settings('XDMOD_CPU_HOURS_ATTRIBUTE_NAME', 'Core Usage (Hours)')
-XDMOD_ACC_HOURS_ATTRIBUTE_NAME = import_from_settings('XDMOD_ACC_HOURS_ATTRIBUTE    _NAME', 'Accelerator Usage (Hours)')
+XDMOD_ACC_HOURS_ATTRIBUTE_NAME = import_from_settings('XDMOD_ACC_HOURS_ATTRIBUTE_NAME', 'Accelerator Usage (Hours)')
 
-XDMOD_STORAGE_ATTRIBUTE_NAME = import_from_settings('XDMOD_ACC_HOURS_ATTRIBUTE_NAME', 'Storage Quota (GB)')
+XDMOD_STORAGE_ATTRIBUTE_NAME = import_from_settings('XDMOD_STORAGE_ATTRIBUTE_NAME', 'Storage Quota (GB)')
 XDMOD_STORAGE_GROUP_ATTRIBUTE_NAME = import_from_settings('XDMOD_STORAGE_GROUP_ATTRIBUTE_NAME', 'Storage_Group_Name')
 
 XDMOD_API_URL = import_from_settings('XDMOD_API_URL')

--- a/coldfront/plugins/xdmod/utils.py
+++ b/coldfront/plugins/xdmod/utils.py
@@ -42,7 +42,7 @@ class XdmodNotFoundError(XdmodError):
 def xdmod_fetch_total_cpu_hours(start, end, account, resources=None, statistics='total_cpu_hours'):
     if resources is None:
         resources = []
-
+    
     url = '{}{}'.format(XDMOD_API_URL, _ENDPOINT_CORE_HOURS)
     payload = _DEFAULT_PARAMS
     payload['pi_filter'] = '"{}"'.format(account)
@@ -64,6 +64,8 @@ def xdmod_fetch_total_cpu_hours(start, end, account, resources=None, statistics=
         # expecting xml but XDMoD should just return json always. 
         raise XdmodNotFoundError('Got json response but expected XML: {}'.format(error))
     except json.decoder.JSONDecodeError as e:
+        pass
+    except requests.exceptions.JSONDecodeError:
         pass
 
     try:


### PR DESCRIPTION
This will import GPUh and GB to respective metrics from XDMOD instance. It was tested against our XDMOD, but please be careful. 

Additional argument for xdmod_usage will import metrics for expired allocations - useful for new/migrated setups.

