### PR TITLE
Correct text now displayed on "Activate" button for allocation requests without attributes set

### DIFF
--- a/coldfront/core/allocation/templates/allocation/allocation_request_list.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_request_list.html
@@ -54,7 +54,7 @@ Allocation Review New and Pending Requests
             <td>{{allocation.status}}</td>
             <td class="text-nowrap">
               {% if allocation.get_information == '' %}
-                <a href="{% url 'allocation-activate-request' allocation.pk %}" class="btn btn-success mr-1 confirm-activate" aria-disabled="true">Approve</a>
+                <a href="{% url 'allocation-activate-request' allocation.pk %}" class="btn btn-success mr-1 confirm-activate" aria-disabled="true">Activate</a>
                 <a href="{% url 'allocation-detail' allocation.pk %}" class="btn btn-primary mr-1">Details</a>
               {% else %}
                   <a href="{% url 'allocation-activate-request' allocation.pk %}" class="btn btn-success mr-1">Activate</a>


### PR DESCRIPTION
Resolves #415 — Now, regardless of whether an allocation has attributes set or not, the text displayed on the button is "Activate." Tests were performed by:

1. Logging in as a user
2. Creating multiple allocations
3. Changing the status of some allocations to a property other than "New"
4. Logging in as an admin
5. Setting attributes to one allocation without changing its status
6. Checking that the allocation request button reads "Activate" and activating the allocation
7. Checking that the status of this allocation is "Active" and the expiration date is set to 365 days out
8. Going back to the allocation requests and checking that the request with no attributes has a button reading "Activate" rather than "Approve"
9. Making sure that the user is prompted by an alert to confirm this activation
10. Activating the allocation and checking that the status of this allocation is "Active" and the expiration date is set to 365 days out