### PR TITLE
Refactor of Allocation views.py

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -98,17 +98,14 @@ def set_proj_update_permissions(allocation_obj, user):
     return False
 
 def return_user_permissions(user, allocation):
-    """Return list of a user's permissions for the allocation.
-    1. user must be a current project user
-    2. user must be A. an allocation user, B. a project pi, or C. a project manager.
+    """Return tuple of a project user's permissions for the allocation.
+    Available permissions are "manager", "pi", and "user".
     """
-
     if not allocation.project.projectuser_set.filter(
             user=user, status__name__in=['Active', 'New', ]).exists():
         return tuple()
 
     permissions = list()
-    # is_pi = allocation_obj.project.pi_id == user.id
     if allocation.project.projectuser_set.filter(
         Q(status__name='Active') & Q(user=user) & Q(role_id=1)).exists():
         permissions.append("manager")

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -4,23 +4,19 @@ from datetime import date
 
 from dateutil.relativedelta import relativedelta
 from django import forms
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.models import User
-from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.db import IntegrityError
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.forms import formset_factory
 from django.http import HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
-from django.template.loader import render_to_string
 from django.urls import reverse, reverse_lazy
 from django.utils.html import format_html, mark_safe
 from django.views import View
-from django.views.generic import DetailView, ListView, TemplateView
+from django.views.generic import ListView, TemplateView
 from django.views.generic.edit import CreateView, FormView, UpdateView
 
 from coldfront.core.allocation.forms import (AllocationAccountForm,

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -547,19 +547,17 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
         resources_form_default_quantities = {}
         resources_form_label_texts = {}
         resources_with_eula = {}
+        attr_types = ('quantity_default', 'quantity_label', 'eula')
         for resource in user_resources:
-            attr_types = {'quantity_default': None, 'quantity_label': None, 'eula': None}
             for attr_type in attr_types:
-                if resource.resourceattribute_set.filter(
-                        resource_attribute_type__name=attr_type).exists():
-                    attr_types[attr_type] = resource.resourceattribute_set.get(
-                            resource_attribute_type__name=attr_type).value
-
-            resources_form_default_quantities[resource.id] = int(attr_types['quantity_default'])
-            resources_form_label_texts[resource.id] = mark_safe(
-                    '<strong>{}*</strong>'.format(attr_types['quantity_label']))
-            resources_with_eula[resource.id] = attr_types['eula']
-
+                if resource.resourceattribute_set.filter(resource_attribute_type__name=attr_type).exists():
+                    value = resource.resourceattribute_set.get(resource_attribute_type__name=attr_type).value
+                    if attr_type == "eula":
+                        resources_with_eula[resource.id] = value
+                    elif attr_type == "quantity_default":
+                        resources_form_default_quantities[resource.id] = int(value)
+                    elif attr_type == "quantity_label":
+                        resources_form_label_texts[resource.id] = mark_safe(f'<strong>{value}*</strong>')
         context['AllocationAccountForm'] = AllocationAccountForm()
         context['resources_form_default_quantities'] = resources_form_default_quantities
         context['resources_form_label_texts'] = resources_form_label_texts


### PR DESCRIPTION
I noticed the note on messy logic in AllocationChangeView.post() and thought I would try simplifying the method a bit. To eliminate unnecessary else statements and make it easier to follow the method logic, I changed the if statements to look for errors instead of check whether conditions were right to proceed. 

I also performed a few other small refactoring tasks - removed unused imports, made small restructures to remove repeating code,  removed unneeded else statements where they did not appear to improve legibility, etc.

I also added two functions for checking the permissions statuses of different users which I found helpful in the development of permissions-dependent views on the FASRC branch.