### PR TITLE
Signal fixed on changing allocation statuses

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -232,12 +232,12 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             if action != 'auto-approve':
                 messages.success(request, 'Allocation Activated!')
 
-        elif old_status != allocation_obj.status.name in ['Denied', 'New']:
+        elif old_status != allocation_obj.status in ['Denied', 'New', 'Revoked']:
             allocation_obj.start_date = None
             allocation_obj.end_date = None
             allocation_obj.save()
 
-            if allocation_obj.status.name == 'Denied':
+            if allocation_obj.status.name == ['Denied', 'Revoked']:
                 allocation_disable.send(
                     sender=self.__class__, allocation_pk=allocation_obj.pk)
                 allocation_users = allocation_obj.allocationuser_set.exclude(
@@ -245,9 +245,12 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
                 for allocation_user in allocation_users:
                     allocation_remove_user.send(
                         sender=self.__class__, allocation_user_pk=allocation_user.pk)
-
+            if allocation_obj.status == 'Denied':
                 send_allocation_customer_email(allocation_obj, 'Allocation Denied', 'email/allocation_denied.txt', domain_url=get_domain_url(self.request))
                 messages.success(request, 'Allocation Denied!')
+            elif allocation_obj.status == 'Revoked':
+                send_allocation_customer_email(allocation_obj, 'Allocation Revoked', 'email/allocation_revoked.txt', domain_url=get_domain_url(self.request))
+                messages.success(request, 'Allocation Revoked!')
             else:
                 messages.success(request, 'Allocation updated!')
         else:

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -232,7 +232,7 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             if action != 'auto-approve':
                 messages.success(request, 'Allocation Activated!')
 
-        elif old_status != allocation_obj.status in ['Denied', 'New', 'Revoked']:
+        elif old_status != allocation_obj.status.name in ['Denied', 'New', 'Revoked']:
             allocation_obj.start_date = None
             allocation_obj.end_date = None
             allocation_obj.save()
@@ -245,10 +245,10 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
                 for allocation_user in allocation_users:
                     allocation_remove_user.send(
                         sender=self.__class__, allocation_user_pk=allocation_user.pk)
-            if allocation_obj.status == 'Denied':
+            if allocation_obj.status.name == 'Denied':
                 send_allocation_customer_email(allocation_obj, 'Allocation Denied', 'email/allocation_denied.txt', domain_url=get_domain_url(self.request))
                 messages.success(request, 'Allocation Denied!')
-            elif allocation_obj.status == 'Revoked':
+            elif allocation_obj.status.name == 'Revoked':
                 send_allocation_customer_email(allocation_obj, 'Allocation Revoked', 'email/allocation_revoked.txt', domain_url=get_domain_url(self.request))
                 messages.success(request, 'Allocation Revoked!')
             else:

--- a/coldfront/templates/email/allocation_activated.txt
+++ b/coldfront/templates/email/allocation_activated.txt
@@ -3,6 +3,7 @@ Dear {{center_name}} user,
 Your allocation request for {{resource}} has been activated. You now have access to this resource.
 
 To view your allocations information, please go to {{allocation_url}}
+
 If you are a student or collaborator under this project, you are receiving this notice as a courtesy. If you would like
 to opt out of future notifications, instructions can be found here: {{opt_out_instruction_url}}
 

--- a/coldfront/templates/email/allocation_change_approved.txt
+++ b/coldfront/templates/email/allocation_change_approved.txt
@@ -3,6 +3,7 @@ Dear {{center_name}} user,
 Your allocation change request for {{resource}} has been approved. The requested changes are now active.
 
 To view your allocation's information, please go to {{allocation_url}}
+
 If you are a student or collaborator under this project, you are receiving this notice as a courtesy. If you would like
 to opt out of future notifications, instructions can be found here: {{opt_out_instruction_url}}
 

--- a/coldfront/templates/email/allocation_change_denied.txt
+++ b/coldfront/templates/email/allocation_change_denied.txt
@@ -3,6 +3,7 @@ Dear {{center_name}} user,
 Your allocation change request for {{resource}} has been denied.
 
 Please login to view a message from the system administrators pertaining to your allocation change request: {{allocation_url}}
+
 If you are a student or collaborator under this project, you are receiving this notice as a courtesy. If you would like
 to opt out of future notifications, instructions can be found here: {{opt_out_instruction_url}}
 

--- a/coldfront/templates/email/allocation_revoked.txt
+++ b/coldfront/templates/email/allocation_revoked.txt
@@ -2,7 +2,7 @@ Dear {{center_name}} user,
 
 Your allocation for {{resource}} has been revoked.
 
-Please login to view a message from the system administrators: {{allocation_url}}
+Please login to view a message from the system administrators: {{url}}
 
 If you are a student or collaborator under this project, you are receiving this notice as a courtesy. If you would like
 to opt out of future notifications, instructions can be found here: {{opt_out_instruction_url}}

--- a/coldfront/templates/email/allocation_revoked.txt
+++ b/coldfront/templates/email/allocation_revoked.txt
@@ -1,6 +1,6 @@
 Dear {{center_name}} user,
 
-Your allocation request for {{resource}} has been denied.
+Your allocation for {{resource}} has been revoked.
 
 Please login to view a message from the system administrators: {{allocation_url}}
 


### PR DESCRIPTION
Resolves issue #474 — Now, allocations that have been given a revoked status display a similar behavior to an allocation that has been marked as denied, sending an email to the user and signaling that the allocation should be disabled. Newlines are also added to email templates to enhance readability.