### PR TITLE
Ability to add emails in bulk added

### DIFF
--- a/coldfront/core/project/templates/project/add_user_search_results.html
+++ b/coldfront/core/project/templates/project/add_user_search_results.html
@@ -6,11 +6,17 @@
     {% if number_of_usernames_found %}
       <strong>Found {{number_of_usernames_found}} of
       {{number_of_usernames_searched}} usernames searched.</strong>
+    {% elif number_of_emails_found %}
+      <strong>Found {{number_of_emails_found}} of
+        {{number_of_emails_searched}} emails searched.</strong>
     {% elif matches %}
-      <strong>Found {{matches|length}} match{{matches|length|pluralize}}.</strong>
+      <strong>Found {{matches|length}} match{{matches|pluralize:"es"}}.</strong>
     {% endif %}
     <br>
-    {% if usernames_not_found %}
+    {% if emails_not_found %}
+      Email{{emails_not_found|length|pluralize}} missing from database
+      {{emails_not_found|length|pluralize:"is, are"}}: {{ emails_not_found|join:", " }}.
+    {% elif usernames_not_found %}
       Username{{usernames_not_found|length|pluralize}} missing from database
       {{usernames_not_found|length|pluralize:"is, are"}}: {{ usernames_not_found|join:", " }}.
     {% endif %}

--- a/coldfront/core/user/forms.py
+++ b/coldfront/core/user/forms.py
@@ -5,6 +5,7 @@ from django.utils.html import mark_safe
 class UserSearchForm(forms.Form):
     CHOICES = [('username_only', 'Exact Username Only'),
                # ('all_fields', mark_safe('All Fields <a href="#" data-toggle="popover" data-trigger="focus" data-content="This option will be ignored if multiple usernames are specified."><i class="fas fa-info-circle"></i></a>')),
+               ('bulk_import', mark_safe('Bulk Import Emails <span class="text-secondary">Use this option to import multiple emails at once.</span>')),
                ('all_fields', mark_safe('All Fields <span class="text-secondary">This option will be ignored if multiple usernames are entered in the search user text area.</span>')),
                ]
     q = forms.CharField(label='Search String', min_length=2, widget=forms.Textarea(attrs={'rows': 4}),

--- a/coldfront/core/user/utils.py
+++ b/coldfront/core/user/utils.py
@@ -20,17 +20,29 @@ class UserSearch(abc.ABC):
         pass
 
     def search(self):
+        matches = []
         if len(self.user_search_string.split()) > 1:
-            search_by = 'username_only'
-            matches = []
-            number_of_usernames_found = 0
-            users_not_found = []
+            if self.search_by == 'username_only':
+                matches = []
+                number_of_usernames_found = 0
+                users_not_found = []
 
-            user_search_string = sorted(list(set(self.user_search_string.split())))
-            for username in user_search_string:
-                match = self.search_a_user(username, search_by)
-                if match:
-                    matches.extend(match)
+                user_search_string = sorted(list(set(self.user_search_string.split())))
+                for username in user_search_string:
+                    match = self.search_a_user(username, self.search_by)
+                    if match:
+                        matches.extend(match)
+                        #todos: what is the difference bw usersearch and combinedusersearch?, add functionality back for all fields
+            elif self.search_by == 'bulk_import':
+                matches = []
+                number_of_emails_found = 0
+                emails_not_found = []
+
+                user_search_string = sorted(list(set(self.user_search_string.split())))
+                for email in user_search_string:
+                    match = self.search_a_user(email, self.search_by)
+                    if match:
+                        matches.extend(match)
         else:
             matches = self.search_a_user(self.user_search_string, self.search_by)
 
@@ -52,6 +64,8 @@ class LocalUserSearch(UserSearch):
 
         elif user_search_string and search_by == 'username_only':
             entries = User.objects.filter(username=user_search_string, is_active=True)
+        elif user_search_string and search_by == 'bulk_import':
+            entries = User.objects.filter(email=user_search_string, is_active=True)
         else:
             entries = User.objects.all()[:size_limit]
 
@@ -73,19 +87,26 @@ class LocalUserSearch(UserSearch):
 
 class CombinedUserSearch:
 
-    def __init__(self, user_search_string, search_by, usernames_names_to_exclude=[]):
+    def __init__(self, user_search_string, search_by, usernames_names_to_exclude=[], emails_to_exclude=[]):
         self.USER_SEARCH_CLASSES = import_from_settings('ADDITIONAL_USER_SEARCH_CLASSES', [])
         self.USER_SEARCH_CLASSES.insert(0, 'coldfront.core.user.utils.LocalUserSearch')
         self.user_search_string = user_search_string
         self.search_by = search_by
         self.usernames_names_to_exclude = usernames_names_to_exclude
+        self.emails_to_exclude = emails_to_exclude
 
     def search(self):
 
         matches = []
         usernames_not_found = []
         usernames_found = []
-
+        emails_not_found = []
+        emails_found = []
+        emails_to_exclude = []
+        number_of_emails_found = 0
+        number_of_usernames_found = 0
+        number_of_emails_searched = 0
+        number_of_usernames_searched = 0
 
         for search_class in self.USER_SEARCH_CLASSES:
             cls = import_string(search_class)
@@ -93,24 +114,42 @@ class CombinedUserSearch:
             users = search_class_obj.search()
 
             for user in users:
-                username = user.get('username')
-                if username not in usernames_found and username not in self.usernames_names_to_exclude:
-                    usernames_found.append(username)
-                    matches.append(user)
+                if search_class_obj.search_by == 'bulk_import':
+                    email = user.get('email')
+                    if email not in emails_found and email not in self.emails_to_exclude:
+                        emails_found.append(email)
+                        matches.append(user)
+                else:
+                    username = user.get('username')
+                    if username not in usernames_found and username not in self.usernames_names_to_exclude:
+                        usernames_found.append(username)
+                        matches.append(user)
 
         if len(self.user_search_string.split()) > 1:
-            number_of_usernames_searched = len(self.user_search_string.split())
-            number_of_usernames_found = len(usernames_found)
-            usernames_not_found = list(set(self.user_search_string.split()) - set(usernames_found) - set(self.usernames_names_to_exclude))
+            if search_class_obj.search_by == 'bulk_import':
+                number_of_emails_searched = len(self.user_search_string.split())
+                number_of_emails_found = len(emails_found)
+                emails_not_found = list(set(self.user_search_string.split()) - set(emails_found) - set(self.emails_to_exclude))
+            else:
+                number_of_usernames_searched = len(self.user_search_string.split())
+                number_of_usernames_found = len(usernames_found)
+                usernames_not_found = list(set(self.user_search_string.split()) - set(usernames_found) - set(self.usernames_names_to_exclude))
+           
         else:
             number_of_usernames_searched = None
+            number_of_emails_searched = None
             number_of_usernames_found = None
             usernames_not_found = None
+            emails_not_found = None
+            number_of_emails_found = None
 
         context = {
             'matches': matches,
             'number_of_usernames_searched': number_of_usernames_searched,
+            'number_of_emails_searched': number_of_emails_searched,
             'number_of_usernames_found': number_of_usernames_found,
-            'usernames_not_found': usernames_not_found
+            'usernames_not_found': usernames_not_found,
+            'emails_not_found': emails_not_found,
+            'number_of_emails_found': number_of_emails_found
         }
         return context


### PR DESCRIPTION
Solves issue #491 — you can now add users to a project by providing multiple emails at once. Emails can be separated by spaces or newlines, similar to when searching on multiple usernames.