### PR TITLE
Update mokey_oidc readme to include OIDC configuration without Mokey/Hydra integration

### DIFF
--- a/coldfront/plugins/mokey_oidc/README.md
+++ b/coldfront/plugins/mokey_oidc/README.md
@@ -20,11 +20,11 @@ Django users.
 - pip install mozilla-django-oidc
 
 ## Usage
+### Mokey/Hydra integration
 
 To enable this plugin set the following environment variables:
 
 ```
-
 PLUGIN_AUTH_OIDC=True
 PLUGIN_MOKEY=True
 OIDC_OP_JWKS_ENDPOINT="https://hydra.local/.well-known/jwks.json"
@@ -35,3 +35,9 @@ OIDC_OP_AUTHORIZATION_ENDPOINT="https://hydra.local/oauth2/auth"
 OIDC_OP_TOKEN_ENDPOINT="https://hydra.local/oauth2/token"
 OIDC_OP_USER_ENDPOINT="https://hydra.local/userinfo"
 ```
+
+### OIDC
+If you are just using OIDC and do not need Mokey/Hydra integration: 
+- Set the above environment variables, but do not set `PLUGIN_MOKEY`.
+- In your [ColdFront configuration file](https://coldfront.readthedocs.io/en/latest/config/#configuration-files) (`local_settings.py` or set by the `COLDFRONT_CONFIG` environment variable), set `SESSION_COOKIE_SAMESITE = "Lax"`
+- You may also need to edit `mozilla-django-oidc` [settings](https://mozilla-django-oidc.readthedocs.io/en/stable/settings.html) in your `local_settings.py`.


### PR DESCRIPTION
I had an issue with using `mozilla-django-oidc` was that the user would log in with OIDC, get redirected to our provider, but ultimately get returned to the login failure url (`/` by default) and not get logged in. The problem was that the `sessionid` cookie was not getting returned to us in Firefox, because the `SESSION_COOKIE_SAMESITE` setting is set to `"Strict"` in ColdFront's default settings in `auth.py`.

I fixed the problem by changing the setting to `"Lax"`.

Also removed an extra newline at the start of the code block.