### PR TITLE
Grants formatting error fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ db.json
 .env
 .devcontainer/*
 .bin/*
-coldfront/core/allocation/migrations/0006_auto_20230607_1719.py

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ db.json
 .env
 .devcontainer/*
 .bin/*
+coldfront/core/allocation/migrations/0006_auto_20230607_1719.py

--- a/coldfront/core/grant/forms.py
+++ b/coldfront/core/grant/forms.py
@@ -17,9 +17,9 @@ class GrantForm(ModelForm):
             'direct_funding': 'Direct funding to {}'.format(CENTER_NAME)
         }
         help_texts = {
-            'percent_credit': 'Percent credit as entered in the sponsored projects form for grant submission as financial credit to the department/unit in the credit distribution section. Only digits, spaces, and percent symbols can be entered.',
-            'direct_funding': 'Funds budgeted specifically for {} services, hardware, software, and/or personnel. Only digits, spaces, commas, and dollar signs can be entered.'.format(CENTER_NAME),
-            'total_amount_awarded': 'Only digits, commas, and dollar signs can be entered.'
+            'percent_credit': 'Percent credit as entered in the sponsored projects form for grant submission as financial credit to the department/unit in the credit distribution section. Enter only digits, decimals, percent symbols, or spaces.',
+            'direct_funding': 'Funds budgeted specifically for {} services, hardware, software, and/or personnel. Enter only digits, decimals, commas, dollar signs, or spaces.'.format(CENTER_NAME),
+            'total_amount_awarded': 'Enter only digits, decimals, commas, dollar signs, or spaces.'
         }
 
     def __init__(self, *args, **kwargs):

--- a/coldfront/core/grant/forms.py
+++ b/coldfront/core/grant/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.forms import ModelForm
 from django.shortcuts import get_object_or_404
 
-from coldfront.core.grant.models import Grant
+from coldfront.core.grant.models import Grant, MoneyField
 from coldfront.core.utils.common import import_from_settings
 
 CENTER_NAME = import_from_settings('CENTER_NAME')
@@ -17,14 +17,14 @@ class GrantForm(ModelForm):
             'direct_funding': 'Direct funding to {}'.format(CENTER_NAME)
         }
         help_texts = {
-            'percent_credit': 'Percent credit as entered in the sponsored projects form for grant submission as financial credit to the department/unit in the credit distribution section',
-            'direct_funding': 'Funds budgeted specifically for {} services, hardware, software, and/or personnel'.format(CENTER_NAME)
+            'percent_credit': 'Percent credit as entered in the sponsored projects form for grant submission as financial credit to the department/unit in the credit distribution section. Only digits and percent symbols can be entered.',
+            'direct_funding': 'Funds budgeted specifically for {} services, hardware, software, and/or personnel. Only digits, commas, and dollar signs can be entered.'.format(CENTER_NAME),
+            'total_amount_awarded': 'Only digits, commas, and dollar signs can be entered.'
         }
 
     def __init__(self, *args, **kwargs):
         super(GrantForm, self).__init__(*args, **kwargs) 
         self.fields['funding_agency'].queryset = self.fields['funding_agency'].queryset.order_by('name')
-
 
 class GrantDeleteForm(forms.Form):
     title = forms.CharField(max_length=255, disabled=True)

--- a/coldfront/core/grant/forms.py
+++ b/coldfront/core/grant/forms.py
@@ -33,7 +33,6 @@ class GrantDeleteForm(forms.Form):
     grant_end = forms.CharField(max_length=150, required=False, disabled=True)
     selected = forms.BooleanField(initial=False, required=False)
 
-
 class GrantDownloadForm(forms.Form):
     pk = forms.IntegerField(required=False, disabled=True)
     title = forms.CharField(required=False, disabled=True)

--- a/coldfront/core/grant/forms.py
+++ b/coldfront/core/grant/forms.py
@@ -17,8 +17,8 @@ class GrantForm(ModelForm):
             'direct_funding': 'Direct funding to {}'.format(CENTER_NAME)
         }
         help_texts = {
-            'percent_credit': 'Percent credit as entered in the sponsored projects form for grant submission as financial credit to the department/unit in the credit distribution section. Only digits and percent symbols can be entered.',
-            'direct_funding': 'Funds budgeted specifically for {} services, hardware, software, and/or personnel. Only digits, commas, and dollar signs can be entered.'.format(CENTER_NAME),
+            'percent_credit': 'Percent credit as entered in the sponsored projects form for grant submission as financial credit to the department/unit in the credit distribution section. Only digits, spaces, and percent symbols can be entered.',
+            'direct_funding': 'Funds budgeted specifically for {} services, hardware, software, and/or personnel. Only digits, spaces, commas, and dollar signs can be entered.'.format(CENTER_NAME),
             'total_amount_awarded': 'Only digits, commas, and dollar signs can be entered.'
         }
 

--- a/coldfront/core/grant/models.py
+++ b/coldfront/core/grant/models.py
@@ -56,7 +56,6 @@ class MoneyField(models.CharField):
                            'Invalid input.')
         ]
         def to_python(self, value):
-        # Remove commas from the input value
             if value:
                 value = value.replace(',', '')
                 value = round(float(value.replace('$', '')), 2)
@@ -69,7 +68,6 @@ class PercentField(models.CharField):
                         'Invalid input.')
     ]
     def to_python(self, value):
-    # Remove commas from the input value
         if value:
             value = round(float(value.replace('%', '')), 2)
         return super().to_python(value)

--- a/coldfront/core/grant/models.py
+++ b/coldfront/core/grant/models.py
@@ -56,8 +56,9 @@ class MoneyField(models.CharField):
                         'Invalid input.')
     ]
     def to_python(self, value):
-        if "," in value or "$" in value:
+        if "," in value:
             value = value.replace(',', '')
+        if "$" in value:
             value = round(float(value.replace('$', '')), 2)
         if " " in value:
             value = value.replace(' ', '')
@@ -72,6 +73,7 @@ class PercentField(models.CharField):
     def to_python(self, value):
         if "%" in value:
             value = round(float(value.replace('%', '')), 2)
+        if " " in value:
             value = value.replace(" ", "")
         return super().to_python(value)
 

--- a/coldfront/core/grant/models.py
+++ b/coldfront/core/grant/models.py
@@ -51,33 +51,31 @@ class GrantStatusChoice(TimeStampedModel):
     
 class MoneyField(models.CharField):
     validators = [
-        RegexValidator(r'^[0-9,.$]+$',
-                        'Enter only digits, commas, dollar signs, or spaces.',
+        RegexValidator(r'\$*[\d,.]{1,}$',
+                        'Enter only digits, decimals, commas, dollar signs, or spaces.',
                         'Invalid input.')
     ]
     def to_python(self, value):
-        if "," or "$" or " " in value:
-            if "," in value:
-                value = value.replace(',', '')
-            if "$" in value:
-                value = round(float(value.replace('$', '')), 2)
-            if " " in value:
-                value = value.replace(' ', '')
-        return super().to_python(value)
+        value = super().to_python(value)
+        if value:
+            value = value.replace(" ", "")
+            value = value.replace(".", "")
+            value = value.replace(",", "")
+            value = value.replace("$", "")
+        return value
         
 class PercentField(models.CharField):
     validators = [
-        RegexValidator(r'^[0-9,%]+%',
-                        'Enter only digits, percent symbols, or spaces.',
+        RegexValidator(r'^[\d,.]{1,6}\%*$',
+                        'Enter only digits, decimals, percent symbols, or spaces.',
                         'Invalid input.')
     ]
     def to_python(self, value):
-        if "%" or " " in value:
-            if "%" in value:
-                value = round(float(value.replace('%', '')), 2)
-            if " " in value:
-                value = value.replace(" ", "")
-        return super().to_python(value)
+        value = super().to_python(value)
+        if value:
+            value = value.replace(" ", "")
+            value = value.replace("%", "")
+        return value
 
 class Grant(TimeStampedModel):
     """ A grant is funding that a PI receives for their project.

--- a/coldfront/core/grant/models.py
+++ b/coldfront/core/grant/models.py
@@ -59,7 +59,6 @@ class MoneyField(models.CharField):
         value = super().to_python(value)
         if value:
             value = value.replace(" ", "")
-            value = value.replace(".", "")
             value = value.replace(",", "")
             value = value.replace("$", "")
         return value

--- a/coldfront/core/grant/models.py
+++ b/coldfront/core/grant/models.py
@@ -56,12 +56,13 @@ class MoneyField(models.CharField):
                         'Invalid input.')
     ]
     def to_python(self, value):
-        if "," in value:
-            value = value.replace(',', '')
-        if "$" in value:
-            value = round(float(value.replace('$', '')), 2)
-        if " " in value:
-            value = value.replace(' ', '')
+        if "," or "$" or " " in value:
+            if "," in value:
+                value = value.replace(',', '')
+            if "$" in value:
+                value = round(float(value.replace('$', '')), 2)
+            if " " in value:
+                value = value.replace(' ', '')
         return super().to_python(value)
         
 class PercentField(models.CharField):
@@ -71,10 +72,11 @@ class PercentField(models.CharField):
                         'Invalid input.')
     ]
     def to_python(self, value):
-        if "%" in value:
-            value = round(float(value.replace('%', '')), 2)
-        if " " in value:
-            value = value.replace(" ", "")
+        if "%" or " " in value:
+            if "%" in value:
+                value = round(float(value.replace('%', '')), 2)
+            if " " in value:
+                value = value.replace(" ", "")
         return super().to_python(value)
 
 class Grant(TimeStampedModel):

--- a/coldfront/core/grant/models.py
+++ b/coldfront/core/grant/models.py
@@ -50,26 +50,29 @@ class GrantStatusChoice(TimeStampedModel):
         return [self.name]
     
 class MoneyField(models.CharField):
-        validators = [
-            RegexValidator(r'^[0-9,.$]+$',
-                           'Enter a valid number with commas and/or dollar signs.',
-                           'Invalid input.')
-        ]
-        def to_python(self, value):
-            if value:
-                value = value.replace(',', '')
-                value = round(float(value.replace('$', '')), 2)
-            return super().to_python(value)
-        
-class PercentField(models.CharField):
     validators = [
-        RegexValidator(r'^[0-9,%]',
-                        'Enter a valid number with a percent symbol.',
+        RegexValidator(r'^[0-9,.$]+$',
+                        'Enter only digits, commas, dollar signs, or spaces.',
                         'Invalid input.')
     ]
     def to_python(self, value):
-        if value:
+        if "," in value or "$" in value:
+            value = value.replace(',', '')
+            value = round(float(value.replace('$', '')), 2)
+        if " " in value:
+            value = value.replace(' ', '')
+        return super().to_python(value)
+        
+class PercentField(models.CharField):
+    validators = [
+        RegexValidator(r'^[0-9,%]+%',
+                        'Enter only digits, percent symbols, or spaces.',
+                        'Invalid input.')
+    ]
+    def to_python(self, value):
+        if "%" in value:
             value = round(float(value.replace('%', '')), 2)
+            value = value.replace(" ", "")
         return super().to_python(value)
 
 class Grant(TimeStampedModel):

--- a/coldfront/core/grant/templates/grant/grant_report_list.html
+++ b/coldfront/core/grant/templates/grant/grant_report_list.html
@@ -46,13 +46,13 @@ Grants Report
                 <td class="text-nowrap"><a href="{% url 'project-detail' form.project_pk.value %}">{{ form.pi_first_name.value }} {{ form.pi_last_name.value }}</a></td>
                 <td class="text-nowrap">{{ form.role.value }}</td>
                 <td class="text-nowrap">{{ form.grant_pi.value }}</td>
-                <td class="text-nowrap">{{ form.total_amount_awarded.value|intcomma }}</td>
+                <td class="text-nowrap">{{ form.total_amount_awarded.value|floatformat:2 }}</td>
                 <td class="text-nowrap">{{ form.funding_agency.value }}</td>
                 <td class="text-nowrap">{{ form.grant_number.value }}</td>
                 <td class="text-nowrap">{{ form.grant_start.value|date:"M. d, Y" }}</td>
                 <td class="text-nowrap">{{ form.grant_end.value|date:"M. d, Y" }}</td>
-                <td>{{ form.percent_credit.value }}</td>
-                <td>{{ form.direct_funding.value|intcomma }}</td>
+                <td>{{ form.percent_credit.value|floatformat:2 }}</td>
+                <td>{{ form.direct_funding.value|floatformat:2 }}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/coldfront/core/grant/templates/grant/grant_report_list.html
+++ b/coldfront/core/grant/templates/grant/grant_report_list.html
@@ -46,13 +46,13 @@ Grants Report
                 <td class="text-nowrap"><a href="{% url 'project-detail' form.project_pk.value %}">{{ form.pi_first_name.value }} {{ form.pi_last_name.value }}</a></td>
                 <td class="text-nowrap">{{ form.role.value }}</td>
                 <td class="text-nowrap">{{ form.grant_pi.value }}</td>
-                <td class="text-nowrap">{{ form.total_amount_awarded.value|floatformat:2 }}</td>
+                <td class="text-nowrap">{{ form.total_amount_awarded.value|floatformat:2|intcomma }}</td>
                 <td class="text-nowrap">{{ form.funding_agency.value }}</td>
                 <td class="text-nowrap">{{ form.grant_number.value }}</td>
                 <td class="text-nowrap">{{ form.grant_start.value|date:"M. d, Y" }}</td>
                 <td class="text-nowrap">{{ form.grant_end.value|date:"M. d, Y" }}</td>
-                <td>{{ form.percent_credit.value|floatformat:2 }}</td>
-                <td>{{ form.direct_funding.value|floatformat:2 }}</td>
+                <td>{{ form.percent_credit.value|floatformat:2|intcomma }}</td>
+                <td>{{ form.direct_funding.value|floatformat:2|intcomma }}</td>
               </tr>
             {% endfor %}
           </tbody>

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -331,7 +331,7 @@ Project Detail
               <td>{{ grant.title }}</td>
               <td class="text-nowrap">{{ grant.grant_pi }}</td>
               <td>{{ grant.role}}</td>
-              <td>{{ grant.total_amount_awarded|floatformat:2}}</td>
+              <td>{{ grant.total_amount_awarded|floatformat:2|intcomma }}</td>
               <td>{{ grant.grant_start|date:"Y-m-d" }}</td>
               <td>{{ grant.grant_end|date:"Y-m-d" }}</td>
               {% if grant.status.name == 'Active' %}

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -331,12 +331,12 @@ Project Detail
               <td>{{ grant.title }}</td>
               <td class="text-nowrap">{{ grant.grant_pi }}</td>
               <td>{{ grant.role}}</td>
-              <td>{{ grant.total_amount_awarded|intcomma}}</td>
+              <td>{{ grant.total_amount_awarded|floatformat:2}}</td>
               <td>{{ grant.grant_start|date:"Y-m-d" }}</td>
               <td>{{ grant.grant_end|date:"Y-m-d" }}</td>
               {% if grant.status.name == 'Active' %}
                 <td class="text-success">{{ grant.status.name }}</td>
-              {% elif  grant.status.name == 'Archived' %}
+              {% elif grant.status.name == 'Archived' %}
                 <td class="text-danger">{{ grant.status.name }}</td>
               {% else %}
                 <td class="text-info">{{ grant.status.name }}</td>


### PR DESCRIPTION
Resolves issue #442 — Grant amounts in the grant creation/ editing form can now be entered with dollar signs and commas, and percents can be entered with percent signs. In the grant report and project detail pages, grant amounts and percentages are also formatted to be rounded to two decimal places for consistency.