### PR TITLE
Add signal for new allocation requests.

### DIFF
--- a/coldfront/core/allocation/signals.py
+++ b/coldfront/core/allocation/signals.py
@@ -1,5 +1,7 @@
 import django.dispatch
 
+allocation_new = django.dispatch.Signal()
+    #providing_args=["allocation_pk"]
 allocation_activate = django.dispatch.Signal()
     #providing_args=["allocation_pk"]
 allocation_disable = django.dispatch.Signal()

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -48,7 +48,8 @@ from coldfront.core.allocation.models import (Allocation,
                                               AllocationUser,
                                               AllocationUserNote,
                                               AllocationUserStatusChoice)
-from coldfront.core.allocation.signals import (allocation_activate,
+from coldfront.core.allocation.signals import (allocation_new,
+                                               allocation_activate,
                                                allocation_activate_user,
                                                allocation_disable,
                                                allocation_remove_user,
@@ -541,6 +542,8 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                                             status=allocation_user_active_status)
 
         send_allocation_admin_email(allocation_obj, 'New Allocation Request', 'email/new_allocation_request.txt', domain_url=get_domain_url(self.request))
+        allocation_new.send(sender=self.__class__,
+                            allocation_pk=allocation_obj.pk)
         return super().form_valid(form)
 
     def get_success_url(self):


### PR DESCRIPTION
This allows centers to write their own plugins that allows for a small task to be done when an allocation is created. For example, automatically assigning certain allocation attributes: when a new allocation request for slurm resource is created, a plugin could read this signal and automatically assign the `slurm_account_name` attribute based on project name and allocation id.