### PR TITLE
Add configuration file for default values to populate e.g. status choices for different core applications

### DIFF
--- a/coldfront/config/defaults.py
+++ b/coldfront/config/defaults.py
@@ -1,0 +1,155 @@
+"""Storage of default choices for attribute and status values."""
+
+### Allocation ###
+
+ALLOCATION_DEFAULTS = {
+    'attrtypes': (
+        'Date',
+        'Float',
+        'Int',
+        'Text',
+        'Yes/No',
+        'No',
+        'Attribute Expanded Text'
+    ),
+    'statuschoices': (
+        'Active',
+        'Denied',
+        'Expired',
+        'New',
+        'Paid',
+        'Payment Pending',
+        'Payment Requested',
+        'Payment Declined',
+        'Renewal Requested',
+        'Revoked',
+        'Unpaid',
+    ),
+    'changestatuschoices': ('Pending', 'Approved', 'Denied'),
+    'allocationuserstatuschoices': ('Active', 'Error', 'Removed'),
+    'allocationattrtypes': (
+        # name, attribute_type, has_usage, is_private
+        ('Cloud Account Name', 'Text', False, False),
+        ('CLOUD_USAGE_NOTIFICATION', 'Yes/No', False, True),
+        ('Core Usage (Hours)', 'Int', True, False),
+        ('Accelerator Usage (Hours)', 'Int', True, False),
+        ('Cloud Storage Quota (TB)', 'Float', True, False),
+        ('EXPIRE NOTIFICATION', 'Yes/No', False, True),
+        ('freeipa_group', 'Text', False, False),
+        ('Is Course?', 'Yes/No', False, True),
+        ('Paid', 'Float', False, False),
+        ('Paid Cloud Support (Hours)', 'Float', True, True),
+        ('Paid Network Support (Hours)', 'Float', True, True),
+        ('Paid Storage Support (Hours)', 'Float', True, True),
+        ('Purchase Order Number', 'Int', False, True),
+        ('send_expiry_email_on_date', 'Date', False, True),
+        ('slurm_account_name', 'Text', False, False),
+        ('slurm_specs', 'Attribute Expanded Text', False, True),
+        ('slurm_specs_attriblist', 'Text', False, True),
+        ('slurm_user_specs', 'Attribute Expanded Text', False, True),
+        ('slurm_user_specs_attriblist', 'Text', False, True),
+        ('Storage Quota (GB)', 'Int', False, False),
+        ('Storage_Group_Name', 'Text', False, False),
+        ('SupportersQOS', 'Yes/No', False, False),
+        ('SupportersQOSExpireDate', 'Date', False, False),
+    ),
+}
+
+
+### Resource ###
+RESOURCE_DEFAULTS = {
+    'attrtypes': (
+        'Active/Inactive',
+        'Date',
+        'Int',
+        'Public/Private',
+        'Text',
+        'Yes/No',
+        'Attribute Expanded Text'
+    ),
+    'resourceattrtypes': (
+        # resource_attribute_type, attribute_type
+        ('Core Count', 'Int'),
+        ('expiry_time', 'Int'),
+        ('fee_applies', 'Yes/No'),
+        ('Node Count', 'Int'),
+        ('Owner', 'Text'),
+        ('quantity_default_value', 'Int'),
+        ('quantity_label', 'Text'),
+        ('eula', 'Text'),
+        ('OnDemand','Yes/No'),
+        ('ServiceEnd', 'Date'),
+        ('ServiceStart', 'Date'),
+        ('slurm_cluster', 'Text'),
+        ('slurm_specs', 'Attribute Expanded Text'),
+        ('slurm_specs_attriblist', 'Text'),
+        ('Status', 'Public/Private'),
+        ('Vendor', 'Text'),
+        ('Model', 'Text'),
+        ('SerialNumber', 'Text'),
+        ('RackUnits', 'Int'),
+        ('InstallDate', 'Date'),
+        ('WarrantyExpirationDate', 'Date'),
+    ),
+    'resourcetypes': (
+        # resource_type, description
+        ('Cloud', 'Cloud Computing'),
+        ('Cluster', 'Cluster servers'),
+        ('Cluster Partition', 'Cluster Partition '),
+        ('Compute Node', 'Compute Node'),
+        ('Server', 'Extra servers providing various services'),
+        ('Software License', 'Software license purchased by users'),
+        ('Storage', 'NAS storage'),
+    )
+}
+
+
+### Project ###
+
+PROJECT_DEFAULTS = {
+    'statuschoices': ('New', 'Active', 'Archived'),
+    'projectreviewstatuschoices':  ('Completed', 'Pending'),
+    'projectuserrolechoices': ('User', 'Manager'),
+    'projectuserstatuschoices': (
+        'Active', 'Pending - Add', 'Pending - Remove', 'Denied', 'Removed'
+    ),
+    # in utils.add_project_user_status_choices, projectuserstatuschoices are ['Active', 'Pending Remove', 'Denied', 'Removed'].
+    # What are the correct options?
+    'attrtypes': ('Date', 'Float', 'Int', 'Text', 'Yes/No'),
+    'projectattrtypes': (
+        # name, attribute_type, has_usage, is_private
+        ('Project ID', 'Text', False, False),
+        ('Account Number', 'Int', False, True),
+    ),
+}
+
+
+### Grants ###
+
+GRANT_DEFAULTS = {
+    'fundingagencies': (
+        'Department of Defense (DoD)',
+        'Department of Energy (DOE)',
+        'Environmental Protection Agency (EPA)',
+        'National Aeronautics and Space Administration (NASA)',
+        'National Institutes of Health (NIH)',
+        'National Science Foundation (NSF)',
+        'New York State Department of Health (DOH)',
+        'New York State (NYS)',
+        'Empire State Development (ESD)',
+        "Empire State Development's Division of Science, Technology and Innovation (NYSTAR)",
+        'Other'
+    ),
+    'statuschoices': ('Active', 'Archived', 'Pending')
+}
+
+
+### Publication ###
+
+PUBLICATION_DEFAULTS = {
+    'publicationsources': (
+        # name, url
+        ('doi', 'https://doi.org/'),
+        ('manual', None),
+    )
+}

--- a/coldfront/core/allocation/management/commands/add_allocation_defaults.py
+++ b/coldfront/core/allocation/management/commands/add_allocation_defaults.py
@@ -1,57 +1,35 @@
 from django.core.management.base import BaseCommand
 
-from coldfront.core.allocation.models import (AttributeType,
-                                              AllocationAttributeType,
-                                              AllocationStatusChoice,
-                                              AllocationChangeStatusChoice,
-                                              AllocationUserStatusChoice)
-
+from coldfront.core.allocation.models import (
+    AttributeType,
+    AllocationAttributeType,
+    AllocationStatusChoice,
+    AllocationChangeStatusChoice,
+    AllocationUserStatusChoice
+)
+from coldfront.config.defaults import ALLOCATION_DEFAULTS as defaults
 
 class Command(BaseCommand):
     help = 'Add default allocation related choices'
 
     def handle(self, *args, **options):
 
-        for attribute_type in ('Date', 'Float', 'Int', 'Text', 'Yes/No', 'No',
-            'Attribute Expanded Text'):
+        for attribute_type in defaults['attrtypes']:
             AttributeType.objects.get_or_create(name=attribute_type)
 
-        for choice in ('Active', 'Denied', 'Expired',
-                       'New', 'Paid', 'Payment Pending',
-                       'Payment Requested', 'Payment Declined',
-                       'Renewal Requested', 'Revoked', 'Unpaid',):
+        for choice in defaults['statuschoices']:
             AllocationStatusChoice.objects.get_or_create(name=choice)
 
-        for choice in ('Pending', 'Approved', 'Denied',):
+        for choice in defaults['changestatuschoices']:
             AllocationChangeStatusChoice.objects.get_or_create(name=choice)
 
-        for choice in ('Active', 'Error', 'Removed', ):
+        for choice in defaults['allocationuserstatuschoices']:
             AllocationUserStatusChoice.objects.get_or_create(name=choice)
 
-        for name, attribute_type, has_usage, is_private in (
-            ('Cloud Account Name', 'Text', False, False),
-            ('CLOUD_USAGE_NOTIFICATION', 'Yes/No', False, True),
-            ('Core Usage (Hours)', 'Int', True, False),
-            ('Accelerator Usage (Hours)', 'Int', True, False),            
-            ('Cloud Storage Quota (TB)', 'Float', True, False),
-            ('EXPIRE NOTIFICATION', 'Yes/No', False, True),
-            ('freeipa_group', 'Text', False, False),
-            ('Is Course?', 'Yes/No', False, True),
-            ('Paid', 'Float', False, False),
-            ('Paid Cloud Support (Hours)', 'Float', True, True),
-            ('Paid Network Support (Hours)', 'Float', True, True),
-            ('Paid Storage Support (Hours)', 'Float', True, True),
-            ('Purchase Order Number', 'Int', False, True),
-            ('send_expiry_email_on_date', 'Date', False, True),
-            ('slurm_account_name', 'Text', False, False),
-            ('slurm_specs', 'Attribute Expanded Text', False, True),
-            ('slurm_specs_attriblist', 'Text', False, True),
-            ('slurm_user_specs', 'Attribute Expanded Text', False, True),
-            ('slurm_user_specs_attriblist', 'Text', False, True),
-            ('Storage Quota (GB)', 'Int', False, False),
-            ('Storage_Group_Name', 'Text', False, False),
-            ('SupportersQOS', 'Yes/No', False, False),
-            ('SupportersQOSExpireDate', 'Date', False, False),
-        ):
-            AllocationAttributeType.objects.get_or_create(name=name, attribute_type=AttributeType.objects.get(
-                name=attribute_type), has_usage=has_usage, is_private=is_private)
+        for name, attribute_type, has_usage, is_private in defaults['allocationattrtypes']:
+            AllocationAttributeType.objects.get_or_create(
+                name=name,
+                attribute_type=AttributeType.objects.get(name=attribute_type),
+                has_usage=has_usage,
+                is_private=is_private,
+            )

--- a/coldfront/core/allocation/test_models.py
+++ b/coldfront/core/allocation/test_models.py
@@ -2,7 +2,10 @@
 
 from django.test import TestCase
 
+from coldfront.config.defaults import ALLOCATION_DEFAULTS as defaults
+from coldfront.core.allocation.models import AllocationStatusChoice, AllocationAttributeType
 from coldfront.core.test_helpers.factories import AllocationFactory, ResourceFactory
+from coldfront.core.test_helpers.utils import CommandTestBase
 
 
 class AllocationModelTests(TestCase):
@@ -21,3 +24,21 @@ class AllocationModelTests(TestCase):
             self.allocation.project.pi
         )
         self.assertEqual(str(self.allocation), allocation_str)
+
+
+class AllocationCommandTests(CommandTestBase):
+    """tests for Allocation commands"""
+
+    def test_add_allocation_defaults_basic(self):
+        """Test that add_allocation_defaults adds allocation defaults"""
+        self.assertEqual(AllocationStatusChoice.objects.count(), 0)
+        self.assertEqual(AllocationAttributeType.objects.count(), 0)
+        self.call_command('add_allocation_defaults')
+        self.assertEqual(
+            AllocationStatusChoice.objects.count(),
+            len(defaults['statuschoices'])
+        )
+        self.assertEqual(
+            AllocationAttributeType.objects.count(),
+            len(defaults['allocationattrtypes'])
+        )

--- a/coldfront/core/grant/management/commands/add_default_grant_options.py
+++ b/coldfront/core/grant/management/commands/add_default_grant_options.py
@@ -3,6 +3,7 @@ import os
 from django.core.management.base import BaseCommand
 
 from coldfront.core.grant.models import GrantFundingAgency, GrantStatusChoice
+from coldfront.config.defaults import GRANT_DEFAULTS as defaults
 
 app_dir = os.path.dirname(__file__)
 
@@ -11,21 +12,9 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         GrantFundingAgency.objects.all().delete()
-        for choice in [
-                'Department of Defense (DoD)',
-                'Department of Energy (DOE)',
-                'Environmental Protection Agency (EPA)',
-                'National Aeronautics and Space Administration (NASA)',
-                'National Institutes of Health (NIH)',
-                'National Science Foundation (NSF)',
-                'New York State Department of Health (DOH)',
-                'New York State (NYS)',
-                'Empire State Development (ESD)',
-                "Empire State Development's Division of Science, Technology and Innovation (NYSTAR)",
-                'Other'
-            ]:
+        for choice in defaults['fundingagencies']:
             GrantFundingAgency.objects.get_or_create(name=choice)
 
         GrantStatusChoice.objects.all().delete()
-        for choice in ['Active', 'Archived', 'Pending', ]:
+        for choice in defaults['statuschoices']:
             GrantStatusChoice.objects.get_or_create(name=choice)

--- a/coldfront/core/project/management/commands/add_default_project_choices.py
+++ b/coldfront/core/project/management/commands/add_default_project_choices.py
@@ -1,37 +1,38 @@
-import os
-from inspect import Attribute
 from django.core.management.base import BaseCommand
-
-from coldfront.core.project.models import (ProjectAttributeType,
-                                            ProjectReviewStatusChoice,
-                                            ProjectStatusChoice,
-                                            ProjectUserRoleChoice,
-                                            ProjectUserStatusChoice,
-                                            AttributeType)
+from coldfront.config.defaults import PROJECT_DEFAULTS as defaults
+from coldfront.core.project.models import (
+    AttributeType,
+    ProjectStatusChoice,
+    ProjectAttributeType,
+    ProjectUserRoleChoice,
+    ProjectUserStatusChoice,
+    ProjectReviewStatusChoice,
+)
 
 
 class Command(BaseCommand):
     help = 'Add default project related choices'
 
     def handle(self, *args, **options):
-        for choice in ['New', 'Active', 'Archived', ]:
+        for choice in defaults['statuschoices']:
             ProjectStatusChoice.objects.get_or_create(name=choice)
 
-        for choice in ['Completed', 'Pending', ]:
+        for choice in defaults['projectreviewstatuschoices']:
             ProjectReviewStatusChoice.objects.get_or_create(name=choice)
 
-        for choice in ['User', 'Manager', ]:
+        for choice in defaults['projectuserrolechoices']:
             ProjectUserRoleChoice.objects.get_or_create(name=choice)
 
-        for choice in ['Active', 'Pending - Add', 'Pending - Remove', 'Denied', 'Removed', ]:
+        for choice in defaults['projectuserstatuschoices']:
             ProjectUserStatusChoice.objects.get_or_create(name=choice)
 
-        for attribute_type in ('Date', 'Float', 'Int', 'Text', 'Yes/No'):
+        for attribute_type in defaults['attrtypes']:
             AttributeType.objects.get_or_create(name=attribute_type)
 
-        for name, attribute_type, has_usage, is_private in (
-            ('Project ID', 'Text', False, False),
-            ('Account Number', 'Int', False, True),
-        ):
-            ProjectAttributeType.objects.get_or_create(name=name, attribute_type=AttributeType.objects.get(
-                name=attribute_type), has_usage=has_usage, is_private=is_private)
+        for name, attribute_type, has_usage, is_private in defaults['projectattrtypes']:
+            ProjectAttributeType.objects.get_or_create(
+                name=name,
+                attribute_type=AttributeType.objects.get(name=attribute_type),
+                has_usage=has_usage,
+                is_private=is_private,
+            )

--- a/coldfront/core/project/tests.py
+++ b/coldfront/core/project/tests.py
@@ -1,20 +1,23 @@
 import logging
 
-from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.core.exceptions import ValidationError
 
+from coldfront.core.test_helpers.utils import CommandTestBase
+from coldfront.config.defaults import PROJECT_DEFAULTS as defaults
 from coldfront.core.test_helpers.factories import (
     UserFactory,
     ProjectFactory,
     FieldOfScienceFactory,
+    PAttributeTypeFactory,
     ProjectAttributeFactory,
     ProjectStatusChoiceFactory,
     ProjectAttributeTypeFactory,
-    PAttributeTypeFactory,
 )
 from coldfront.core.project.models import (
     Project,
     ProjectAttribute,
+    ProjectStatusChoice,
     ProjectAttributeType,
 )
 
@@ -205,3 +208,13 @@ class TestProjectAttribute(TestCase):
         )
         with self.assertRaises(ValidationError):
             new_attr.clean()
+
+
+class TestProjectCommands(CommandTestBase):
+    """Test the custom commands for projects"""
+
+    def test_add_default_project_choices(self):
+        """Test that the import_projects command works"""
+        self.assertEqual(ProjectStatusChoice.objects.count(), 0)
+        self.call_command('add_default_project_choices')
+        self.assertEqual(ProjectStatusChoice.objects.count(), len(defaults['statuschoices']))

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -1,20 +1,21 @@
+from coldfront.config.defaults import PROJECT_DEFAULTS as defaults
 
 def add_project_status_choices(apps, schema_editor):
     ProjectStatusChoice = apps.get_model('project', 'ProjectStatusChoice')
 
-    for choice in ['New', 'Active', 'Archived', ]:
+    for choice in defaults['statuschoices']:
         ProjectStatusChoice.objects.get_or_create(name=choice)
 
 
 def add_project_user_role_choices(apps, schema_editor):
     ProjectUserRoleChoice = apps.get_model('project', 'ProjectUserRoleChoice')
 
-    for choice in ['User', 'Manager', ]:
+    for choice in defaults['projectuserrolechoices']:
         ProjectUserRoleChoice.objects.get_or_create(name=choice)
 
 
 def add_project_user_status_choices(apps, schema_editor):
     ProjectUserStatusChoice = apps.get_model('project', 'ProjectUserStatusChoice')
 
-    for choice in ['Active', 'Pending Remove', 'Denied', 'Removed', ]:
+    for choice in defaults['projectuserstatuschoices']:
         ProjectUserStatusChoice.objects.get_or_create(name=choice)

--- a/coldfront/core/publication/management/commands/add_default_publication_sources.py
+++ b/coldfront/core/publication/management/commands/add_default_publication_sources.py
@@ -1,8 +1,7 @@
-import os
-
 from django.core.management.base import BaseCommand
 
 from coldfront.core.publication.models import PublicationSource
+from coldfront.config.defaults import PUBLICATION_DEFAULTS as defaults
 
 
 class Command(BaseCommand):
@@ -10,8 +9,5 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         PublicationSource.objects.all().delete()
-        for name, url in [
-                ('doi', 'https://doi.org/'),
-                ('manual', None),
-            ]:
+        for name, url in defaults['publicationsources']:
             PublicationSource.objects.get_or_create(name=name, url=url)

--- a/coldfront/core/resource/management/commands/add_resource_defaults.py
+++ b/coldfront/core/resource/management/commands/add_resource_defaults.py
@@ -1,8 +1,11 @@
 from django.core.management.base import BaseCommand
 
-from coldfront.core.resource.models import (AttributeType,
-                                            ResourceAttributeType,
-                                            ResourceType)
+from coldfront.core.resource.models import (
+    ResourceType,
+    AttributeType,
+    ResourceAttributeType,
+)
+from coldfront.config.defaults import RESOURCE_DEFAULTS as defaults
 
 
 class Command(BaseCommand):
@@ -10,44 +13,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        for attribute_type in ('Active/Inactive', 'Date', 'Int', 
-            'Public/Private', 'Text', 'Yes/No', 'Attribute Expanded Text'):
+        for attribute_type in defaults['attrtypes']:
             AttributeType.objects.get_or_create(name=attribute_type)
 
-        for resource_attribute_type, attribute_type in (
-            ('Core Count', 'Int'),
-            ('expiry_time', 'Int'),
-            ('fee_applies', 'Yes/No'),
-            ('Node Count', 'Int'),
-            ('Owner', 'Text'),
-            ('quantity_default_value', 'Int'),
-            ('quantity_label', 'Text'),
-            ('eula', 'Text'),
-            ('OnDemand','Yes/No'),
-            ('ServiceEnd', 'Date'),
-            ('ServiceStart', 'Date'),
-            ('slurm_cluster', 'Text'),
-            ('slurm_specs', 'Attribute Expanded Text'),
-            ('slurm_specs_attriblist', 'Text'),
-            ('Status', 'Public/Private'),
-            ('Vendor', 'Text'),
-            ('Model', 'Text'),
-            ('SerialNumber', 'Text'),
-            ('RackUnits', 'Int'),
-            ('InstallDate', 'Date'),
-            ('WarrantyExpirationDate', 'Date'),
-        ):
+        for resource_attribute_type, attribute_type in defaults['resourceattrtypes']:
             ResourceAttributeType.objects.get_or_create(
                 name=resource_attribute_type, attribute_type=AttributeType.objects.get(name=attribute_type))
 
-        for resource_type, description in (
-            ('Cloud', 'Cloud Computing'),
-            ('Cluster', 'Cluster servers'),
-            ('Cluster Partition', 'Cluster Partition '),
-            ('Compute Node', 'Compute Node'),
-            ('Server', 'Extra servers providing various services'),
-            ('Software License', 'Software license purchased by users'),
-            ('Storage', 'NAS storage'),
-        ):
+        for resource_type, description in defaults['resourcetypes']:
             ResourceType.objects.get_or_create(
                 name=resource_type, description=description)

--- a/coldfront/core/resource/tests.py
+++ b/coldfront/core/resource/tests.py
@@ -1,3 +1,22 @@
 from django.test import TestCase
 
-# Create your tests here.
+from coldfront.config.defaults import RESOURCE_DEFAULTS as defaults
+from coldfront.core.test_helpers.utils import CommandTestBase
+from coldfront.core.resource.models import (
+    ResourceType,
+    ResourceAttributeType,
+)
+
+
+class ResourceCommandTests(CommandTestBase):
+    """tests for Resource commands"""
+
+    def test_add_resource_defaults_basic(self):
+        """Test that add_resource_defaults adds resource defaults"""
+        self.assertEqual(ResourceAttributeType.objects.count(), 0)
+        self.assertEqual(ResourceType.objects.count(), 0)
+        self.call_command('add_resource_defaults')
+        self.assertEqual(
+            ResourceAttributeType.objects.count(), len(defaults['resourceattrtypes'])
+        )
+        self.assertEqual(ResourceType.objects.count(), len(defaults['resourcetypes']))

--- a/coldfront/core/test_helpers/factories.py
+++ b/coldfront/core/test_helpers/factories.py
@@ -6,6 +6,7 @@ from factory.django import DjangoModelFactory
 from faker import Faker
 from faker.providers import BaseProvider, DynamicProvider
 
+from coldfront.config import defaults
 from coldfront.core.field_of_science.models import FieldOfScience
 from coldfront.core.resource.models import ResourceType, Resource
 from coldfront.core.project.models import (
@@ -38,8 +39,6 @@ from coldfront.core.publication.models import PublicationSource
 
 ### Default values and Faker provider setup ###
 
-project_status_choice_names = ['New', 'Active', 'Archived']
-project_user_role_choice_names = ['User', 'Manager']
 field_of_science_names = ['Physics', 'Chemistry', 'Economics', 'Biology', 'Sociology']
 attr_types = ['Date', 'Int', 'Float', 'Text', 'Boolean']
 
@@ -114,7 +113,7 @@ class ProjectStatusChoiceFactory(DjangoModelFactory):
         # ensure that names are unique
         django_get_or_create = ('name',)
     # randomly generate names from list of default values
-    name = FuzzyChoice(project_status_choice_names)
+    name = FuzzyChoice(defaults.PROJECT_DEFAULTS['statuschoices'])
 
 
 class ProjectFactory(DjangoModelFactory):

--- a/coldfront/core/test_helpers/utils.py
+++ b/coldfront/core/test_helpers/utils.py
@@ -1,5 +1,25 @@
 """utility functions for unit and integration testing"""
 
+from io import StringIO
+from django.core.management import call_command
+from django.test import TestCase
+
+class CommandTestBase(TestCase):
+    """Base class for command tests"""
+
+    def call_command(self, command, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            command,
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+
+
 def login_and_get_page(client, user, page):
     """force login and return get response for page"""
     client.force_login(user, backend="django.contrib.auth.backends.ModelBackend")


### PR DESCRIPTION
I originally floated the idea of adding a new config file that would serve as a central reference list for all objects that are to be automatically added to the database in functions like add_allocation_defaults [here](https://github.com/ubccr/coldfront/pull/546#discussion_r1256751809). This PR is a follow-up on that. I included all apps with add_default commands. 

There are a few ways I could see this config file being useful for other purposes, e.g., checking whether a given item is in the database in a given view.