### PR TITLE
Fixing Allocations/Resource list incorrect

### DIFF
--- a/coldfront/core/resource/templates/resource_detail.html
+++ b/coldfront/core/resource/templates/resource_detail.html
@@ -125,20 +125,27 @@ Resource Detail
 
   <div class="card-body">
     {% if child_resources %}
-      <div class="table-responsive">
-        <table id="child_resource_table" class="table table-bordered table-sm">
-          <thead>
-            <tr>
-              <th scope="col">Resource Name</th>
-              <th scope="col">WarrantyExpire</th>
-              <th scope="col">ServiceEnd</th>
-              <th scope="col">Vendor</th>
-              <th scope="col">Serial #</th>
-              <th scope="col">Model</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for child in child_resources %}
+    {% if child_resources.0.Acc %}
+    <div class="alert alert-info" role="alert">
+      <i class="fas fa-info-circle" aria-hidden="true"></i>
+      There are no child resources to display.
+    </div>
+  {% else %}
+    <div class="table-responsive">
+      <table id="child_resource_table" class="table table-bordered table-sm">
+        <thead>
+          <tr>
+            <th scope="col">Resource Name</th>
+            <th scope="col">WarrantyExpire</th>
+            <th scope="col">ServiceEnd</th>
+            <th scope="col">Vendor</th>
+            <th scope="col">Serial #</th>
+            <th scope="col">Model</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for child in child_resources %}
+              {% if child.Available %}
                 <tr>
                   <td><a href="{% url 'resource-detail' child.object.pk %}">{{child.object}}</a></td>
                   <td>{{child.WarrantyExpirationDate}}</td>
@@ -147,10 +154,12 @@ Resource Detail
                   <td>{{child.SerialNumber}}</td>
                   <td>{{child.Model}}</td>
                 </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
+              {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% endif %}
       {% else %}
         <div class="alert alert-info" role="alert">
           <i class="fas fa-info-circle" aria-hidden="true"></i>

--- a/coldfront/core/resource/templates/resource_list.html
+++ b/coldfront/core/resource/templates/resource_list.html
@@ -66,14 +66,16 @@ Resource List
       </thead>
       <tbody>
         {% for resource in resource_list %}
+        <tr>
           <tr>
-            <td><a href="/resource/{{resource.id}}/">{{ resource.id }}</a></td>
-            <td>{{ resource }}</td>
-            <td>{{ resource.parent_resource }}</td>
-            <td>{{ resource.resource_type.name }}</td>
+            {% if resource.is_available %}
+              <td><a href="/resource/{{resource.id}}/">{{ resource.id }}</a></td>
+              <td>{{ resource }}</td>
+              <td>{{ resource.parent_resource }}</td>
+              <td>{{ resource.resource_type.name }}</td>
+            </tr>
+            {% endif %}
           </tr>
-        {% endfor %}
-      </tbody>
     </table>
     {% if is_paginated %} Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
       <ul class="pagination float-right mr-3">

--- a/coldfront/core/resource/views.py
+++ b/coldfront/core/resource/views.py
@@ -27,7 +27,11 @@ class ResourceDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
     def get_child_resources(self, resource_obj):
         child_resources = [resource for resource in resource_obj.resource_set.all(
         ).order_by(Lower("name"))]
-
+        acc=True
+        for m in child_resources:
+            if(m.is_available==True):
+                acc=False
+        
         child_resources = [
 
             {'object': resource,
@@ -35,12 +39,14 @@ class ResourceDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
              'ServiceEnd': resource.get_attribute('ServiceEnd'),
              'Vendor': resource.get_attribute('Vendor'),
              'SerialNumber': resource.get_attribute('SerialNumber'),
-             'Model': resource.get_attribute('Model'),            
+             'Model': resource.get_attribute('Model'),
+             'Available' : resource.is_available,
+             'Allocatable' : resource.is_allocatable,
+             'Acc':acc
              }
+        for resource in child_resources
 
-            for resource in child_resources
         ]
-
         return child_resources
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Fixes issue #467  in which if a resource is marked as not available, it still shows up in the list of resources and as a child resource.
Now, if a resource is marked as not available, it does not show up in the list of resources or as a child resource. The resource still exists but does not show up on the page.
If all the child resources are not available, the child resources list shows that there are no resources available.