### PR TITLE
Feature aria label

### DIFF
--- a/coldfront/templates/common/authorized_navbar.html
+++ b/coldfront/templates/common/authorized_navbar.html
@@ -5,7 +5,7 @@
   <div class="container">
     <a class="navbar-brand d-block d-sm-none text-primary" href="#">ColdFront</a>
 
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-main">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-main" aria-expanded="true" aria-label="Toggle Nvigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 

--- a/coldfront/templates/common/nonauthorized_navbar.html
+++ b/coldfront/templates/common/nonauthorized_navbar.html
@@ -4,7 +4,7 @@
   <div class="container">
     <a class="navbar-brand d-block d-sm-none text-primary" href="#">ColdFront</a>
 
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-main">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-main" aria-expanded="true" aria-label="Toggle Nvigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 


### PR DESCRIPTION
The navigation expand/collapse button lacks an Aria label, compromising the accessibility of the user interface. Addressing this issue is crucial to ensure a seamless and inclusive user experience for all.

issue: #590