### PR TITLE
Fixed a bug that prevented allocations from being disabled even after it has been denied or revoked

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -238,7 +238,7 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             allocation_obj.end_date = None
             allocation_obj.save()
 
-            if allocation_obj.status.name == ['Denied', 'Revoked']:
+            if allocation_obj.status.name in ['Denied', 'Revoked']:
                 allocation_disable.send(
                     sender=self.__class__, allocation_pk=allocation_obj.pk)
                 allocation_users = allocation_obj.allocationuser_set.exclude(


### PR DESCRIPTION
The if statement used the wrong operator to determine if the allocation status was changed to "Denied" or "Revoked". This prevented a signal from being sent that would indicated that the allocation should be disabled.