### PR TITLE
Setting that adds limits to project titles

### DIFF
--- a/coldfront/config/core.py
+++ b/coldfront/config/core.py
@@ -17,6 +17,8 @@ CENTER_BASE_URL = ENV.str('CENTER_BASE_URL', default='')
 # Enable Project Review
 #------------------------------------------------------------------------------
 PROJECT_ENABLE_PROJECT_REVIEW = ENV.bool('PROJECT_ENABLE_PROJECT_REVIEW', default=True)
+PROJECT_TITLE_REGEX = ENV.str('PROJECT_TITLE_REGEX', default='.*')
+PROJECT_TITLE_REGEX_DESCRIPTION = ENV.str('PROJECT_TITLE_REGEX_DESCRIPTION', default='')
 
 #------------------------------------------------------------------------------
 # Allocation related

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -5,6 +5,7 @@ from enum import Enum
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import MinLengthValidator
+from django.core.validators import RegexValidator
 from django.db import models
 from ast import literal_eval
 from coldfront.core.utils.validate import AttributeValidator
@@ -15,6 +16,8 @@ from coldfront.core.field_of_science.models import FieldOfScience
 from coldfront.core.utils.common import import_from_settings
 
 PROJECT_ENABLE_PROJECT_REVIEW = import_from_settings('PROJECT_ENABLE_PROJECT_REVIEW', False)
+PROJECT_TITLE_REGEX = import_from_settings('PROJECT_TITLE_REGEX', '.*')
+PROJECT_TITLE_REGEX_DESCRIPTION = import_from_settings('PROJECT_TITLE_REGEX_DESCRIPTION', '')
 
 class ProjectPermission(Enum):
     """ A project permission stores the user, manager, pi, and update fields of a project. """
@@ -76,7 +79,7 @@ class Project(TimeStampedModel):
 We do not have information about your research. Please provide a detailed description of your work and update your field of science. Thank you!
         '''
 
-    title = models.CharField(max_length=255,)
+    title = models.CharField(max_length=255, validators=[RegexValidator(PROJECT_TITLE_REGEX, PROJECT_TITLE_REGEX_DESCRIPTION)])
     pi = models.ForeignKey(User, on_delete=models.CASCADE,)
     description = models.TextField(
         default=DEFAULT_DESCRIPTION,

--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -87,6 +87,8 @@ The following settings are ColdFront specific settings related to the core appli
 | CENTER_PROJECT_RENEWAL_HELP_URL        | The URL of the article describing project renewals |
 | CENTER_BASE_URL                        | The base URL of your center.                   |
 | PROJECT_ENABLE_PROJECT_REVIEW          | Enable or disable project reviews. Default True|
+| PROJECT_TITLE_REGEX                    | Set a regular expression (regex) to limit project titles. Default ".*" (anything)
+| PROJECT_TITLE_REGEX_DESCRIPTION        | Message that gets displayed to the user when the regex is not followed. Default "" (empty string)
 | ALLOCATION_ENABLE_ALLOCATION_RENEWAL   | Enable or disable allocation renewals. Default True |
 | ALLOCATION_DEFAULT_ALLOCATION_LENGTH   | Default number of days an allocation is active for. Default 365 |
 | ALLOCATION_ENABLE_CHANGE_REQUESTS_BY_DEFAULT | Enable or disable allocation change requests. Default True |


### PR DESCRIPTION
Adds new settings to set a regex for project titles, as well as a message that gets displayed to users when the regex is not met.