### PR TITLE
Generic Multipurpose Search

### DIFF
--- a/coldfront/config/core.py
+++ b/coldfront/config/core.py
@@ -61,6 +61,10 @@ INVOICE_DEFAULT_STATUS = ENV.str('INVOICE_DEFAULT_STATUS', default='New')
 ONDEMAND_URL = ENV.str('ONDEMAND_URL', default=None)
 
 #------------------------------------------------------------------------------
+# Toggle Generic Search Form
+#------------------------------------------------------------------------------
+GENERIC_SEARCH_FIELD = ENV.str('GENERIC_SEARCH_FIELD', default=False)
+#------------------------------------------------------------------------------
 # Default Strings. Override these in local_settings.py
 #------------------------------------------------------------------------------
 LOGIN_FAIL_MESSAGE = ENV.str('LOGIN_FAIL_MESSAGE', '')

--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -16,21 +16,25 @@ EMAIL_DIRECTOR_PENDING_PROJECT_REVIEW_EMAIL = import_from_settings(
 EMAIL_ADMIN_LIST = import_from_settings('EMAIL_ADMIN_LIST', [])
 EMAIL_DIRECTOR_EMAIL_ADDRESS = import_from_settings(
     'EMAIL_DIRECTOR_EMAIL_ADDRESS', '')
-
+GENERIC_SEARCH_FIELD = import_from_settings('GENERIC_SEARCH_FIELD', False)
 
 class ProjectSearchForm(forms.Form):
     """ Search form for the Project list page.
     """
+    GENERIC_SEARCH = 'Search Value'
     LAST_NAME = 'Last Name'
     USERNAME = 'Username'
     FIELD_OF_SCIENCE = 'Field of Science'
 
-    last_name = forms.CharField(
-        label=LAST_NAME, max_length=100, required=False)
-    username = forms.CharField(label=USERNAME, max_length=100, required=False)
-    field_of_science = forms.CharField(
-        label=FIELD_OF_SCIENCE, max_length=100, required=False)
-    show_all_projects = forms.BooleanField(initial=False, required=False)
+    if GENERIC_SEARCH_FIELD:
+        generic = forms.CharField(label=GENERIC_SEARCH, max_length=100, required=False)
+    else:
+        last_name = forms.CharField(
+            label=LAST_NAME, max_length=100, required=False)
+        username = forms.CharField(label=USERNAME, max_length=100, required=False)
+        field_of_science = forms.CharField(
+            label=FIELD_OF_SCIENCE, max_length=100, required=False)
+        show_all_projects = forms.BooleanField(initial=False, required=False)
 
 
 class ProjectAddUserForm(forms.Form):

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -218,6 +218,19 @@ class ProjectListView(LoginRequiredMixin, ListView):
                     Q(projectuser__status__name='Active')
                 ).order_by(order_by)
 
+            # Generic Search
+            if data.get('generic'):
+                projects = projects.filter(
+                    Q(pi__last_name__icontains=data.get('generic')) |
+                    Q(title__icontains=data.get('generic')) |
+                    Q(pi__username__icontains=data.get('generic')) |
+                    (
+                        Q(projectuser__user__username__icontains=data.get('generic')) &
+                        Q(projectuser__status__name='Active')
+                    ) |
+                    Q(description__icontains=data.get('generic'))
+                )  
+
             # Last Name
             if data.get('last_name'):
                 projects = projects.filter(

--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -95,6 +95,7 @@ The following settings are ColdFront specific settings related to the core appli
 | ALLOCATION_RESOURCE_ORDERING           | Controls the ordering of parent resources for an allocation (if allocation has multiple resources).  Should be a list of field names suitable for Django QuerySet order_by method.  Default is ['-is_allocatable', 'name']; i.e. prefer Resources with is_allocatable field set, ordered by name of the Resource.|
 | INVOICE_ENABLED                        | Enable or disable invoices. Default True       |
 | ONDEMAND_URL                           | The URL to your Open OnDemand installation     |
+| GENERIC_SEARCH_FIELD                   | Switches from the current search field to a new "multipurpose" search field that will automatically search all current fields, plus more. Default False
 | LOGIN_FAIL_MESSAGE                     | Custom message when user fails to login. Here you can paint a custom link to your user account portal |
 | ENABLE_SU                              | Enable administrators to login as other users. Default True |
 


### PR DESCRIPTION
Adds an option to switch from the current search options, to one multipurpose search field. This search field will allow users to search through the Project title, PI last name, PI username, active Project user usernames, and the Project description.