### PR TITLE
Add option to disable grants, publications, and research outputs

### DIFF
--- a/coldfront/config/core.py
+++ b/coldfront/config/core.py
@@ -14,6 +14,13 @@ CENTER_PROJECT_RENEWAL_HELP_URL = ENV.str('CENTER_PROJECT_RENEWAL_HELP_URL', def
 CENTER_BASE_URL = ENV.str('CENTER_BASE_URL', default='')
 
 #------------------------------------------------------------------------------
+# Enable Research Outputs, Grants, Publications
+#------------------------------------------------------------------------------
+RESEARCH_OUTPUT_ENABLE = ENV.bool('RESEARCH_OUTPUT_ENABLE', default=True)
+GRANT_ENABLE = ENV.bool('GRANT_ENABLE', default=True)
+PUBLICATION_ENABLE = ENV.bool('PUBLICATION_ENABLE', default=True)
+
+#------------------------------------------------------------------------------
 # Enable Project Review
 #------------------------------------------------------------------------------
 PROJECT_ENABLE_PROJECT_REVIEW = ENV.bool('PROJECT_ENABLE_PROJECT_REVIEW', default=True)
@@ -38,7 +45,10 @@ ALLOCATION_ACCOUNT_MAPPING = ENV.dict('ALLOCATION_ACCOUNT_MAPPING', default={})
 
 SETTINGS_EXPORT += [
     'ALLOCATION_ACCOUNT_ENABLED',
-    'CENTER_HELP_URL'
+    'CENTER_HELP_URL',
+    'RESEARCH_OUTPUT_ENABLE',
+    'GRANT_ENABLE',
+    'PUBLICATION_ENABLE',
 ]
 
 ADMIN_COMMENTS_SHOW_EMPTY = ENV.bool('ADMIN_COMMENTS_SHOW_EMPTY', default=True)

--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -22,11 +22,16 @@ urlpatterns = [
     path('project/', include('coldfront.core.project.urls')),
     path('allocation/', include('coldfront.core.allocation.urls')),
     path('resource/', include('coldfront.core.resource.urls')),
-    path('grant/', include('coldfront.core.grant.urls')),
-    path('publication/', include('coldfront.core.publication.urls')),
-    path('research-output/', include('coldfront.core.research_output.urls')),
 ]
 
+if settings.GRANT_ENABLE:
+    urlpatterns.append(path('grant/', include('coldfront.core.grant.urls')))
+
+if settings.PUBLICATION_ENABLE:
+    urlpatterns.append(path('publication/', include('coldfront.core.publication.urls')))
+
+if settings.RESEARCH_OUTPUT_ENABLE:
+    urlpatterns.append(path('research-output/', include('coldfront.core.research_output.urls')))
 
 if 'coldfront.plugins.iquota' in settings.INSTALLED_APPS:
     urlpatterns.append(path('iquota/', include('coldfront.plugins.iquota.urls')))

--- a/coldfront/core/portal/templates/portal/center_summary.html
+++ b/coldfront/core/portal/templates/portal/center_summary.html
@@ -14,6 +14,7 @@ Center Summary
 <h2>{% settings_value 'CENTER_NAME' %} Scientific Impact</h2>
 <hr>
 
+{% if settings.PUBLICATION_ENABLE %}
 <!-- Start  Publications -->
 <div class="card mb-3 border-primary">
   <div class="card-header bg-primary text-white">
@@ -25,7 +26,9 @@ Center Summary
   </div>
 </div>
 <!-- End Publications -->
+{% endif %}
 
+{% if settings.RESEARCH_OUTPUT_ENABLE %}
 <!-- Start  Research Outputs -->
 <div class="card mb-3 border-primary">
   <div class="card-header bg-primary text-white">
@@ -36,7 +39,9 @@ Center Summary
   </div>
 </div>
 <!-- End Research Outputs -->
+{% endif %}
 
+{% if settings.GRANT_ENABLE %}
 <!-- Start  Grants -->
 <div class="card mb-3 border-primary">
   <div class="card-header bg-primary text-white">
@@ -52,6 +57,7 @@ Center Summary
   </div>
 </div>
 <!-- End Grants -->
+{% endif %}
 
 <!-- Start Allocation by Field of Science -->
 <div class="card mb-3 border-primary">

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -44,9 +44,15 @@ Project Detail
     <div class="card-body">
       {% if project.status.name != 'Archived' %}
         <a class="btn btn-success" href="{% url 'project-add-users-search' project.pk %}" role="button"><i class="fas fa-user-plus" aria-hidden="true"></i> Add Users</a>
+{% if settings.GRANT_ENABLE %}
         <a class="btn btn-success" href="{% url 'grant-create' project.id %}" role="button"><i class="fas fa-trophy" aria-hidden="true"></i> Add Grant</a>
+{% endif %}
+{% if settings.PUBLICATION_ENABLE %}
         <a class="btn btn-success" href="{% url 'publication-search' project.pk %}" role="button"><i class="fas fa-newspaper" aria-hidden="true"></i> Add Publication</a>
+{% endif %}
+{% if settings.RESEARCH_OUTPUT_ENABLE %}
         <a class="btn btn-success" href="{% url 'add-research-output' project.pk %}" role="button"><i class="far fa-newspaper" aria-hidden="true"></i> Add Research Output</a>
+{% endif %}
       {% endif %}
     </div>
   </div>
@@ -293,6 +299,7 @@ Project Detail
 
 <!-- End Project Attributes -->
 
+{% if settings.GRANT_ENABLE %}
 <!-- Start Project Grants -->
 <div class="card mb-3">
   <div class="card-header">
@@ -353,8 +360,10 @@ Project Detail
   </div>
 </div>
 <!-- End Project Grants -->
+{% endif %}
 
 
+{% if settings.PUBLICATION_ENABLE %}
 <!-- Start Project Publications -->
 <div class="card mb-3">
   <div class="card-header">
@@ -405,8 +414,10 @@ Project Detail
   </div>
 </div>
 <!-- End Project Publications -->
+{% endif %}
 
 
+{% if settings.RESEARCH_OUTPUT_ENABLE %}
 <!-- Start Project ResearchOutputs -->
 <div class="card mb-3">
   <div class="card-header">
@@ -446,7 +457,7 @@ Project Detail
   </div>
 </div>
 <!-- End Project ResearchOutputs -->
-
+{% endif %}
 
 <!-- Start Admin Messages -->
 <div class="card mb-3">

--- a/coldfront/core/project/templates/project/project_review.html
+++ b/coldfront/core/project/templates/project/project_review.html
@@ -20,21 +20,32 @@ Review Project
 
   <ol>
     <li><a href="{% url 'project-detail' project.pk %}"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Verify</a> your project description is accurate</li>
+
+{% if settings.PUBLICATION_ENABLE %}
     <li><a href="{% url 'project-detail' project.pk %}#publications"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Add</a> Publications</li>
+{% endif %}
+{% if settings.GRANT_ENABLE %}
     <li><a href="{% url 'project-detail' project.pk %}#grants"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Add</a> Grants</li>
+{% endif %}
+{% if settings.RESEARCH_OUTPUT_ENABLE %}
     <li><a href="{% url 'project-detail' project.pk %}#users"><i class="fas fa-external-link-alt" aria-hidden="true"></i> Verify</a> the user accounts in your group and remove any that should no longer have access to {% settings_value 'CENTER_NAME' %} resources</li>
+{% endif %}
   </ol>
 
   <div class="table-responsive">
     <table class="table table-bordered table-sm">
+{% if settings.GRANT_ENABLE %}
       <tr>
         <th scope="row" class="text-nowrap">Grants Last Updated:</th>
         <td>{{project.latest_grant.modified|date:"M. d, Y"|default:"No grants"}}</td>
       </tr>
+{% endif %}
+{% if settings.PUBLICATION_ENABLE %}
       <tr>
         <th scope="row" class="text-nowrap">Publications Last Updated:</th>
         <td>{{project.latest_publication.created|date:"M. d, Y"|default:"No publications"}}</td>
       </tr>
+{% endif %}
       <tr>
         <th scope="row" class="text-nowrap">Users in project:</th>
         <td>{{project_users}}</td>

--- a/coldfront/core/project/templates/project/project_review_email.html
+++ b/coldfront/core/project/templates/project/project_review_email.html
@@ -35,14 +35,18 @@ Email User
           <th scope="row" class="text-nowrap">Date Review Submitted:</th>
           <td>{{ project_review.created|date:"M-d-Y" }}</td>
         </tr>
+{% if settings.GRANT_ENABLE %}
         <tr>
           <th scope="row" class="text-nowrap">Grants Last Updated:</th>
           <td>{{project_review.project.latest_grant.modified|date:"M-d-Y"|default:"No grants"}}</td>
         </tr>
+{% endif %}
+{% if settings.PUBLICATION_ENABLE %}
         <tr>
           <th scope="row" class="text-nowrap">Publications Last Updated:</th>
           <td>{{project_review.project.latest_publication.created|date:"M-d-Y"|default:"No publications"}}</td>
         </tr>
+{% endif %}
       </table>
     </div>
   </div>

--- a/coldfront/core/project/templates/project/project_review_list.html
+++ b/coldfront/core/project/templates/project/project_review_list.html
@@ -20,8 +20,12 @@ Project Review List
           <th scope="col">Project Title</th>
           <th scope="col">Date Review Submitted</th>
           <th scope="col">PI</th>
+{% if settings.GRANT_ENABLE %}
           <th scope="col">Grants Last Updated</th>
+{% endif %}
+{% if settings.PUBLICATION_ENABLE %}
           <th scope="col">Publications Last Updated</th>
+{% endif %}
           <th scope="col">Reason for not Updating Project</th>
           <th scope="col">Project Review Actions</th>
         </tr>
@@ -32,8 +36,12 @@ Project Review List
             <td><a href="{% url 'project-detail' project_review.project.pk %}">{{project_review.project.title|truncatechars:50}}</a></td>
             <td >{{ project_review.created|date:"M. d, Y" }}</td>        
             <td>{{project_review.project.pi.first_name}} {{project_review.project.pi.last_name}} ({{project_review.project.pi.username}})</td>
+{% if settings.GRANT_ENABLE %}
             <td >{{ project_review.project.latest_grant.modified|date:"M. d, Y"|default:"No grants" }}</td>
+{% endif %}
+{% if settings.PUBLICATION_ENABLE %}
             <td >{{ project_review.project.latest_publication.created|date:"M. d, Y"|default:"No publications" }}</td>
+{% endif %}
             <td >{{ project_review.reason_for_not_updating_project}}</td>
             <td class="text-nowrap">
               <a href="{% url 'project-review-complete' project_review.pk %}" class="btn btn-success mr-1">Mark Complete</a>

--- a/coldfront/core/project/urls.py
+++ b/coldfront/core/project/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
     path('project-review-list', project_views.ProjectReviewListView.as_view(),name='project-review-list'),
     path('project-review-complete/<int:project_review_pk>/', project_views.ProjectReviewCompleteView.as_view(),
          name='project-review-complete'),
-    path('project-review/<int:pk>/email', project_views.ProjectReivewEmailView.as_view(), name='project-review-email'),
+    path('project-review/<int:pk>/email', project_views.ProjectReviewEmailView.as_view(), name='project-review-email'),
     path('<int:pk>/projectnote/add', project_views.ProjectNoteCreateView.as_view(), name='project-note-add'),
     path('<int:pk>/project-attribute-create/', project_views.ProjectAttributeCreateView.as_view(), name='project-attribute-create'),
     path('<int:pk>/project-attribute-delete/', project_views.ProjectAttributeDeleteView.as_view(), name='project-attribute-delete'),

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1103,7 +1103,7 @@ class ProjectReviewCompleteView(LoginRequiredMixin, UserPassesTestMixin, View):
         return HttpResponseRedirect(reverse('project-review-list'))
 
 
-class ProjectReivewEmailView(LoginRequiredMixin, UserPassesTestMixin, FormView):
+class ProjectReviewEmailView(LoginRequiredMixin, UserPassesTestMixin, FormView):
     form_class = ProjectReviewEmailForm
     template_name = 'project/project_review_email.html'
     login_url = "/"

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -11,6 +11,8 @@
       Allocation Requests</a>
     <a id="navbar-allocation-change-requests" class="dropdown-item" href="{% url 'allocation-change-list' %}">
       Allocation Change Requests</a>
+{% if settings.GRANT_ENABLE %}
     <a id="navbar-grant-report" class="dropdown-item" href="{% url 'grant-report' %}">Grant Report</a>
+{% endif %}
   </div>
 </li>

--- a/coldfront/templates/common/navbar_director.html
+++ b/coldfront/templates/common/navbar_director.html
@@ -5,6 +5,8 @@
     <a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a>
     <a class="dropdown-item" href="{% url 'resource-list' %}">All Resources</a>
     <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
+{% if settings.GRANT_ENABLE %}
     <a id="navbar-grant-report" class="dropdown-item" href="{% url 'grant-report' %}">Grant Report</a>
+{% endif %}
   </div>
 </li>

--- a/coldfront/templates/common/navbar_nonadmin_staff.html
+++ b/coldfront/templates/common/navbar_nonadmin_staff.html
@@ -21,7 +21,7 @@
       <a id="navbar-allocation-requests" class="dropdown-item" href="{% url 'allocation-request-list' %}">
         Allocation Requests</a>
     {% endif %}
-    {% if perms.grant.can_view_all_grants %}
+    {% if settings.GRANT_ENABLE and perms.grant.can_view_all_grants %}
       <a id="navbar-grant-report" class="dropdown-item" href="{% url 'grant-report' %}">Grant Report</a>
     {% endif %}
   </div>

--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -97,6 +97,9 @@ The following settings are ColdFront specific settings related to the core appli
 | ONDEMAND_URL                           | The URL to your Open OnDemand installation     |
 | LOGIN_FAIL_MESSAGE                     | Custom message when user fails to login. Here you can paint a custom link to your user account portal |
 | ENABLE_SU                              | Enable administrators to login as other users. Default True |
+| RESEARCH_OUTPUT_ENABLE                 | Enable or disable research outputs. Default True |
+| GRANT_ENABLE                           | Enable or disable grants. Default True           |
+| PUBLICATION_ENABLE                     | Enable or disable publications. Default True     |
 
 
 ### Database settings


### PR DESCRIPTION
Fixes #507 

Users can now toggle whether or not they would like grant, publication, and research output functionality by setting the following config options:

- RESEARCH_OUTPUT_ENABLE (True or False)
- GRANT_ENABLE (True or False)
- PUBLICATION_ENABLE (True or False)

To avoid conflicts while reenabling, these apps are installed by default, but if a user sets the config option to False for any of the above, it removes all functionality from the frontend.