### PR TITLE
Document required SESSION_COOKIE_SAMESITE setting for OIDC auth

### DIFF
--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -174,6 +174,11 @@ For more info on [ColdFront plugins](../../plugin/existing_plugins/) (Django app
     ```
     $ pip install mozilla_django_oidc
     ```
+!!! warning "SESSION\_COOKIE\_SAMESITE"
+
+    mozilla_django_oidc uses cookies to store state in an anonymous session during the
+    authentication process. You must use `SESSION_COOKIE_SAMESITE="Lax"` in your
+    settings for authentication to work correctly.
 
 | Name                           | Description                          |
 | :------------------------------|:-------------------------------------|


### PR DESCRIPTION
Whilst setting up OIDC auth with Coldfront I ran into this issue. SESSION\_COOKIE\_SAMESITE is set to "strict" in `coldfrotn/config/auth.py`. This doesn't play nicely as with OIDC however as mozilla\_django\_oidc uses anonmyous sessions to store state for the authentication requst. The strict setting prevents the session cookie from being included upon redirects from the IDP preventing verification of the state data.

This requirement is mentioned in the README for the mokey plugin but this PR adds the info into the configuration section of the docs for better discoverability.