### PR TITLE
Implement native plugin mechanism

### DIFF
--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -1,6 +1,9 @@
 """
 ColdFront URL Configuration
 """
+from importlib import import_module
+from importlib.metadata import entry_points
+
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
@@ -33,11 +36,32 @@ if settings.PUBLICATION_ENABLE:
 if settings.RESEARCH_OUTPUT_ENABLE:
     urlpatterns.append(path('research-output/', include('coldfront.core.research_output.urls')))
 
-if 'coldfront.plugins.iquota' in settings.INSTALLED_APPS:
-    urlpatterns.append(path('iquota/', include('coldfront.plugins.iquota.urls')))
+# if 'coldfront.plugins.iquota' in settings.INSTALLED_APPS:
+#     urlpatterns.append(path('iquota/', include('coldfront.plugins.iquota.urls')))
 
 if 'mozilla_django_oidc' in settings.INSTALLED_APPS:
     urlpatterns.append(path('oidc/', include('mozilla_django_oidc.urls')))
 
 if 'django_su.backends.SuBackend' in settings.AUTHENTICATION_BACKENDS:
     urlpatterns.append(path('su/', include('django_su.urls')))
+
+
+# add settings from plugins in source tree
+for app_path in settings.INSTALLED_APPS:
+    if "coldfront.plugins" not in app_path:
+        continue
+    try:
+        plugin_urls = import_module(".urls", package=app_path)
+        urlpatterns.extend(getattr(plugin_urls, 'urlpatterns', []))
+    except ModuleNotFoundError:
+        pass
+
+# add urls from pip installed plugins
+for entry_point in entry_points(group="coldfront_plugins").select(name="app"):
+    if entry_point.value not in settings.INSTALLED_APPS:
+        continue
+    try:
+        plugin_urls = import_module(".urls", package=entry_point.value)
+        urlpatterns.extend(getattr(plugin_urls, 'urlpatterns', []))
+    except ModuleNotFoundError:
+        pass

--- a/coldfront/plugins/iquota/urls.py
+++ b/coldfront/plugins/iquota/urls.py
@@ -1,7 +1,10 @@
-from django.urls import path
+from django.urls import include, path
 
 from coldfront.plugins.iquota.views import get_isilon_quota
 
+
 urlpatterns = [
-    path('get-isilon-quota/', get_isilon_quota, name='get-isilon-quota'),
+    path(
+        "iquota/", include([path('get-isilon-quota/', get_isilon_quota, name='get-isilon-quota')]),
+    ),
 ]


### PR DESCRIPTION
This PR accompanies #636 and demonstrates a pattern for extending the existing plugin system to prevent the need to edit core coldfront files. The core idea is that by searching for files in the `plugins` directory and using entry points for pip installed packages it's possible to automate the discovery and loading of settings and urlpatterns.

To try it out:
- Checkout this branch.
- Pip install the example plugin I've created at [cc-a/coldfront_native_plugin](https://github.com/cc-a/coldfront_native_plugin) (pip install git+https://github.com/cc-a/coldfront_native_plugin.git).
- Run coldfront showplugins to see the plugin just installed.
- Run coldfront migrate and note that the migration from the plugin is applied.
- Start the development server and open http://localhost:8000/djp-plugin/.

Some thoughts:
- Under the hood this is doing a lot of what djp makes easier to do.
- I've jumped through certain hoops to make sure the existing plugins still work so some complexity .
- Things could be made simpler again by dropping support for loading third party plugins from the `plugins` directory and having developers `pip install -e` them if necessary.