### PR TITLE
Fixes the bug in ubccr#647

### DIFF
--- a/coldfront/core/allocation/templates/allocation/allocation_request_list.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_request_list.html
@@ -43,7 +43,7 @@ Allocation Review New and Pending Requests
         {% for allocation in allocation_list %}
           <tr>
             <td>{{allocation.pk}}</td>
-            <td>{{ allocation.created|date:"M. d, Y" }}</td>
+            <td>{{allocation_renewal_dates|get_value_from_dict:allocation.pk|default:allocation.created|date:"M. d, Y"}}</td>
             <td><a href="{% url 'project-detail' allocation.project.pk %}">{{allocation.project.title|truncatechars:50}}</a></td>
             <td>{{allocation.project.pi.first_name}} {{allocation.project.pi.last_name}}
               ({{allocation.project.pi.username}})</td>

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -946,6 +946,16 @@ class AllocationRequestListView(LoginRequiredMixin, UserPassesTestMixin, Templat
         context = super().get_context_data(**kwargs)
         allocation_list = Allocation.objects.filter(
             status__name__in=['New', 'Renewal Requested', 'Paid', 'Approved',])
+
+        allocation_renewal_dates = {}
+        for allocation in allocation_list.filter(status__name='Renewal Requested'):
+            allocation_history = allocation.history.all().order_by('-history_date')
+            for history in allocation_history:
+                if history.status.name != 'Renewal Requested':
+                    break
+                allocation_renewal_dates[allocation.pk] = history.history_date
+
+        context['allocation_renewal_dates'] = allocation_renewal_dates
         context['allocation_status_active'] = AllocationStatusChoice.objects.get(name='Active')
         context['allocation_list'] = allocation_list
         context['PROJECT_ENABLE_PROJECT_REVIEW'] = PROJECT_ENABLE_PROJECT_REVIEW


### PR DESCRIPTION
Fixes #647. This loops through the history of an allocation with the status "Renewal Requested" from latest to earliest and finds the date of the history with the first "Renewal Requested" status. Since it loops from latest to earliest it will always grab the date of the latest renewal request.