### PR TITLE
Adding ProjectCreateView fields into dedicated form class. 

### DIFF
--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -190,3 +190,8 @@ class ProjectAttributeUpdateForm(forms.Form):
             proj_attr = ProjectAttribute.objects.get(pk=cleaned_data.get('pk'))
             proj_attr.value = cleaned_data.get('new_value')
             proj_attr.clean()
+
+class ProjectCreationForm(forms.ModelForm):
+    class Meta:
+        model = Project
+        fields = ['title', 'description', 'field_of_science']

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -43,7 +43,8 @@ from coldfront.core.project.forms import (ProjectAddUserForm,
                                           ProjectReviewForm,
                                           ProjectSearchForm,
                                           ProjectUserUpdateForm,
-                                          ProjectAttributeUpdateForm)
+                                          ProjectAttributeUpdateForm,
+                                          ProjectCreationForm)
 from coldfront.core.project.models import (Project,
                                            ProjectAttribute,
                                            ProjectReview,
@@ -451,7 +452,7 @@ class ProjectArchiveProjectView(LoginRequiredMixin, UserPassesTestMixin, Templat
 class ProjectCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     model = Project
     template_name_suffix = '_create_form'
-    fields = ['title', 'description', 'field_of_science', ]
+    form_class = ProjectCreationForm
 
     def test_func(self):
         """ UserPassesTestMixin Tests"""


### PR DESCRIPTION
**Reason**

Project creation is an essential feature and it may be expected for the associated fields to change over time. Currently, if sites wish to alter the associated fields then the `view.py` class must be changed itself, arguably creating issues with readability, maintenance and overpopulating the view class with form fields. 

**Changes made**

- Removing project creation fields and redirecting to a form class
- Implementing project form class. 



