### PR TITLE
Adds allocation limits for a resource

### DIFF
--- a/coldfront/core/resource/management/commands/add_resource_defaults.py
+++ b/coldfront/core/resource/management/commands/add_resource_defaults.py
@@ -10,7 +10,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        for attribute_type in ('Active/Inactive', 'Date', 'Int', 
+        for attribute_type in ('Active/Inactive', 'Date', 'Int',
             'Public/Private', 'Text', 'Yes/No', 'Attribute Expanded Text'):
             AttributeType.objects.get_or_create(name=attribute_type)
 
@@ -36,6 +36,7 @@ class Command(BaseCommand):
             ('RackUnits', 'Int'),
             ('InstallDate', 'Date'),
             ('WarrantyExpirationDate', 'Date'),
+            ('allocation_limit', 'Int'),
         ):
             ResourceAttributeType.objects.get_or_create(
                 name=resource_attribute_type, attribute_type=AttributeType.objects.get(name=attribute_type))


### PR DESCRIPTION
This PR adds the ability to set a limit on the number of allocations a resource can have in a project. This is set by creating a new 
`allocation_limit` resource attribute for a resource with the number you want to limit the resource to. It will prevent users from submitting a new allocation request for that resource if the limit is reached. This limit applies to all projects for that resource. This partially handles #659.

![allocation_limit](https://github.com/user-attachments/assets/60fbe193-1624-4efe-a10c-203707960117)
