### PR TITLE
Support Python 3.13

### DIFF
--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1,5 +1,4 @@
 import datetime
-from pipes import Template
 import pprint
 import django
 import logging 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ doi2bib==0.4.0
 factory-boy==3.3.0
 Faker==24.1.0
 fontawesome-free==5.15.4
-FormEncode==2.1.0
+FormEncode==2.1.1
 future==1.0.0
 humanize==4.9.0
 idna==3.6

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'factory-boy==3.3.0',
         'Faker==24.1.0',
         'fontawesome-free==5.15.4',
-        'FormEncode==2.1.0',
+        'FormEncode==2.1.1',
         'future==1.0.0',
         'humanize==4.9.0',
         'idna==3.6',


### PR DESCRIPTION
Allows running on Python 3.13+ without the `legacy-cgi` package.

The `cgi` package was deprecated in Python 3.11 and [removed in Python 3.13](https://docs.python.org/3.13/library/cgi.html), which `FormEncode` used [until version 2.1.1](https://github.com/formencode/formencode/releases/tag/2.1.1).

Also removed an unused `pipes` import (which was also removed in Python 3.13).