### PR TITLE
 Add an Allocation Attribute Edit Page

### DIFF
--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -226,6 +226,24 @@ class AllocationAttributeUpdateForm(forms.Form):
         allocation_attribute.clean()
 
 
+class AllocationAttributeEditForm(forms.Form):
+    attribute_pk = forms.IntegerField(required=False, disabled=True)
+    name = forms.CharField(max_length=150, required=False, disabled=True)
+    orig_value = forms.CharField(max_length=150, required=False, disabled=True)
+    value = forms.CharField(max_length=150, required=False, disabled=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["attribute_pk"].widget = forms.HiddenInput()
+
+    def clean(self):
+        cleaned_data = super().clean()
+        allocation_attribute = AllocationAttribute.objects.get(pk=cleaned_data.get("attribute_pk"))
+
+        allocation_attribute.value = cleaned_data.get("value")
+        allocation_attribute.clean()
+
+
 class AllocationChangeForm(forms.Form):
     EXTENSION_CHOICES = [(0, "No Extension")]
     for choice in ALLOCATION_CHANGE_REQUEST_EXTENSION_DAYS:

--- a/coldfront/core/allocation/signals.py
+++ b/coldfront/core/allocation/signals.py
@@ -21,3 +21,6 @@ allocation_change_approved = django.dispatch.Signal()
 
 allocation_change_created = django.dispatch.Signal()
 # providing_args=["allocation_pk", "allocation_change_pk"]
+
+allocation_attribute_changed = django.dispatch.Signal()
+# providing_args=["attribute_pk", "allocation_pk"]

--- a/coldfront/core/allocation/templates/allocation/allocation_allocationattribute_delete.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_allocationattribute_delete.html
@@ -54,7 +54,7 @@ Delete Allocation Attributes from Allocation
   <a class="btn btn-secondary mb-3" href="{% url 'allocation-detail' allocation.pk %}" role="button"><i
       class="fas fa-long-arrow-left" aria-hidden="true"></i> Back to Allocation</a>
   <div class="alert alert-info">
-    No users to remove!
+    No attributes to remove!
   </div>
 {% endif %}
 

--- a/coldfront/core/allocation/templates/allocation/allocation_attribute_edit.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_attribute_edit.html
@@ -1,0 +1,81 @@
+{% extends "common/base.html" %} {% load crispy_forms_tags %} {% load static %}
+{% block title %} Allocation Change Detail {% endblock %} {% block content %}
+
+<h2>
+  Edit attributes for {{ allocation.get_parent_resource }} for project: {{ allocation.project.title }}
+</h2>
+<hr />
+<form method="post">
+  <div class="card mb-3">
+    <div class="card-header">
+      <h3 class="d-inline">
+        <i class="fas fa-info-circle" aria-hidden="true"></i> Allocation
+        Attributes
+      </h3>
+    </div>
+    <div class="card-body">
+      {% if attributes %} {% csrf_token %}
+      <div class="table-responsive">
+        <table class="table table-bordered table-sm">
+          <thead>
+            <tr class="d-flex">
+              <th class="col-6" scope="col">Attribute</th>
+              <th class="col-6" scope="col">Set New Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for form in formset %}
+            <tr class="d-flex">
+              <td class="col-6">{{form.name.value}}</td>
+              <td class="col-6">
+                {{form.value}}
+                <span
+                  class="d-none"
+                  id="change-indicator-{{form.attribute_pk.value}}"
+                >
+                  <i class="fas fa-info-circle" aria-hidden="true"></i>
+                  Value changed
+                </span>
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <div class="alert alert-info" role="alert">
+        <i class="fas fa-info-circle" aria-hidden="true"></i>
+        This allocation has no attributes.
+      </div>
+      {% endif %}
+
+      {% if attributes %}
+        <input class="btn btn-success" type="submit" value="Confirm" />
+      {% endif %}
+      <a
+        class="btn btn-secondary"
+        href="{% url 'allocation-detail' allocation.pk %}"
+        role="button"
+        >Cancel</a
+      >
+      {{ formset.management_form }}
+    </div>
+  </div>
+</form>
+
+<script>
+  $(document).ready(function() {
+    {% for form in formset %}
+    $("#{{form.value.auto_id}}").on("input", function(){
+      let change_indicator = $("#change-indicator-{{form.attribute_pk.value}}");
+      if ($(this).val() != "{{form.orig_value.value|escapejs}}") {
+        change_indicator.removeClass("d-none");
+      } else {
+        change_indicator.addClass("d-none");
+      }
+    });
+    $("#{{form.value.auto_id}}").trigger("input");
+    {% endfor %}
+  })
+</script>
+{% endblock %}

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -214,6 +214,11 @@ Allocation Detail
       <h3 class="d-inline"><i class="fas fa-info-circle" aria-hidden="true"></i> Allocation Attributes</h3>
       <div class="float-right">
         {% if request.user.is_superuser %}
+          {% if attributes %}
+            <a class="btn btn-info" href="{% url 'allocation-attribute-edit' allocation.pk %}" role="button">
+              <i class="fas fa-edit" aria-hidden="true"></i> Edit Allocation Attributes
+            </a>
+          {% endif %}
           <a class="btn btn-success" href="{% url 'allocation-attribute-add' allocation.pk %}" role="button">
             <i class="fas fa-plus" aria-hidden="true"></i> Add Allocation Attribute
           </a>
@@ -299,7 +304,6 @@ Allocation Detail
                   {% else %}
                     <td class="text-info">{{ change_request.status.name }}</td>
                   {% endif %}
-                  </td>
                   {% if change_request.notes %}
                     <td>{{change_request.notes}}</td>
                   {% else %}

--- a/coldfront/core/allocation/urls.py
+++ b/coldfront/core/allocation/urls.py
@@ -33,6 +33,11 @@ urlpatterns = [
     ),
     path("<int:pk>/change-request", allocation_views.AllocationChangeView.as_view(), name="allocation-change"),
     path(
+        "<int:pk>/allocationattribute/edit",
+        allocation_views.AllocationAttributeEditView.as_view(),
+        name="allocation-attribute-edit",
+    ),
+    path(
         "<int:pk>/allocationattribute/delete",
         allocation_views.AllocationAttributeDeleteView.as_view(),
         name="allocation-attribute-delete",


### PR DESCRIPTION
This PR adds a page that allows admins to edit allocation attributes and a button on the Allocation Detail page to access this page, which would close #672.

![image](https://github.com/user-attachments/assets/0718de2c-8239-46a4-98b5-74a059bb635d)
![image](https://github.com/user-attachments/assets/25fa06e2-856d-4687-9bbf-07e15efe38b9)

This PR also adds a signal for allocation attribute changes, which is sent when Allocation Change Requests are approved and through this page, which should [help] close #293.