### PR TITLE
Adds auto_compute_allocation plugin

### DIFF
--- a/coldfront/config/plugins/auto_compute_allocation.py
+++ b/coldfront/config/plugins/auto_compute_allocation.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from coldfront.config.base import INSTALLED_APPS, ENV
+from coldfront.config.env import ENV
+
+INSTALLED_APPS += [
+    "coldfront.plugins.auto_compute_allocation",
+]
+
+AUTO_COMPUTE_ALLOCATION_CORE_HOURS = ENV.int(
+    "AUTO_COMPUTE_ALLOCATION_CORE_HOURS", default=0
+)
+AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING = ENV.int(
+    "AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING", default=0
+)
+AUTO_COMPUTE_ALLOCATION_END_DELTA = ENV.int(
+    "AUTO_COMPUTE_ALLOCATION_END_DELTA", default=365
+)
+AUTO_COMPUTE_ALLOCATION_CHANGABLE = ENV.bool(
+    "AUTO_COMPUTE_ALLOCATION_CHANGABLE", default=True
+)
+AUTO_COMPUTE_ALLOCATION_LOCKED = ENV.bool(
+    "AUTO_COMPUTE_ALLOCATION_LOCKED", default=False
+)
+AUTO_COMPUTE_ALLOCATION_FAIRSHARE_INSTITUTION = ENV.bool(
+    "AUTO_COMPUTE_ALLOCATION_FAIRSHARE_INSTITUTION", default=False
+)
+AUTO_COMPUTE_ALLOCATION_CLUSTERS = ENV.tuple(
+    "AUTO_COMPUTE_ALLOCATION_CLUSTERS", default=()
+)
+# example auto|Cluster| results in auto|Cluster|CDF0001 where CDF0001 is an example project_code for pk=1
+AUTO_COMPUTE_ALLOCATION_DESCRIPTION = ENV.str(
+    "AUTO_COMPUTE_ALLOCATION_DESCRIPTION", default="auto|Cluster|"
+)

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -28,6 +28,7 @@ plugin_configs = {
     "PLUGIN_AUTH_LDAP": "plugins/ldap.py",
     "PLUGIN_LDAP_USER_SEARCH": "plugins/ldap_user_search.py",
     "PLUGIN_API": "plugins/api.py",
+    'PLUGIN_AUTO_COMPUTE_ALLOCATION': 'plugins/auto_compute_allocation.py',
 }
 
 # This allows plugins to be enabled via environment variables. Can alternatively

--- a/coldfront/plugins/auto_compute_allocation/README.md
+++ b/coldfront/plugins/auto_compute_allocation/README.md
@@ -1,0 +1,110 @@
+# auto\_compute\_allocation - A plugin to create an automatically assigned compute allocation
+
+Coldfront django plugin providing capability to create an automatically assigned compute allocation (a coldfront project resource allocation mapping to an HPC Cluster resource or multiple such resources).
+
+The motivation for using this plugin is to use Coldfront as the source of truth. This might be in constrast to another operating modality where information is [generally] imported from another system into Coldfront to provide allocations.
+
+- By using the plugin an allocation to use configured HPC Cluster(s) will be created each time a new project is created, which Coldfront operators simply need to checkover and then approve/activate...
+
+This has the benefit of recucing Workload:
+- Coldfront operators workload is reduced slightly, whilst also providing consistency and accuracy - operators are required to input and do less.
+- Another reason might be to reduce PI workload. As on a free-at-the-point of use system, its likely that all projects simply get granted a compute allocation and therefore a slurm association to be able to use the HPC Cluster(s). The PI will automatically have the allocation created by Coldfront itself.
+
+
+## Design
+
+
+This plugin makes use of a django signal within Coldfront's project view in order trigger creation. Naming of the allocation created uses ``project_code``.
+
+Allocations are named in the format _auto|Cluster|project_code_  (e.g. ``auto|Cluster|CDF0001``). This allocation description and it's delimiters within, can be controlled with the variable: ``AUTO_COMPUTE_ALLOCATION_DESCRIPTION``, though the _project_code_ will always be appended.
+
+At the time of project creation, only the PI can be known, so this is the only user added.
+
+Further down in the documentation, all variables are described in a table.
+
+As well as controlling the end date of the generated allocation, the changeable and locked attributes can be toggled.
+
+Optionally core hours can be assigned to new projects with ``AUTO_COMPUTE_ALLOCATION_CORE_HOURS`` and specifically training projects with ``AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING``. These are activated by providing an integer greater than 0.
+
+A variable can be used to filter which Cluster resources the allocation can work with ``AUTO_COMPUTE_ALLOCATION_CLUSTERS``.
+
+Finally an optional usage, is to enable an institute based fairshare attribute. This requires the _institution feature_ has been enabled correctly, such that a match is found (for the submitting PI). If a match isn't found then this attribute can't be set and the code handles.
+
+
+### Design - signals and actions
+
+#### signals
+
+The following Coldfront django signal is used by this plugin, upon Coldfront WebUI action:
+
+- project new
+
+#### actions
+
+The aforemention signal triggers a function in ``tasks.py``, this inturn uses functions in ``utils.py`` to accomplish the action required which is to create an automatically generated compute allocation for the project.
+
+## Management commands
+
+No management commands are present or required by this plugin itself.
+
+
+## Requirements
+
+The plugin requires that the project code feature is enabled.
+
+``PROJECT_CODE`` is required to be set to a valid string. E.g. 'CDF', 'COMP' etc. in the Coldfront django settings - e.g. coldfront.env
+
+
+## Usage
+
+The plugin requires that various environment variables are defined in the Coldfront django settings - e.g. coldfront.env
+
+Example pre-requisites - we require ``PROJECT_CODE`` to be enabled, here is an example using CDF and padding of 4. The padding is optional but ``PROJECT_CODE`` is required.
+
+**Example Required project_code:**
+```
+PROJECT_CODE="CDF"
+```
+Example Optional project_code padding:
+```
+PROJECT_CODE_PADDING=4
+```
+
+
+Next the environment variables for the plugin itself, here are the descriptions and defaults.
+
+### Auto_Compute_Allocation Plugin optional variables
+
+All variables for this plugin are currently **optional**.
+
+| Option | Default | Description |
+|--- | --- | --- |
+| `AUTO_COMPUTE_ALLOCATION_CORE_HOURS` | `int`, 0 | Optional, number of core hours to provide on the allocation, if 0 then this functionality is not triggered and no core hours will be added  |
+| `AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING` | `int`, 0 | Optional, number of core hours to provide on the allocation, if 0 then this functionality is not triggered and no core hours will be added. This applies to projects which select 'Training' as their field of science discipline.  |
+| `AUTO_COMPUTE_ALLOCATION_END_DELTA` | `int`, 365 | Optional, number of days from creation of the allocation to expiry, default 365 to align with default project duration of 1 year  |
+| `AUTO_COMPUTE_ALLOCATION_CHANGABLE` | `bool`, True | Optional, allows the allocation to have a request logged to change - this might be useful for an extension |
+| `AUTO_COMPUTE_ALLOCATION_LOCKED` | `bool`, False | Optional, prevents the allocation from being modified by admin - this might be useful for an extensions |
+| `AUTO_COMPUTE_ALLOCATION_FAIRSHARE_INSTITUTION` | `bool`, False | Optional, provides an institution based slurm fairshare attribute, requires that the _institution feature_ is setup correctly |
+| `AUTO_COMPUTE_ALLOCATION_CLUSTERS` | `tuple`, empty () | Optional, filter for clusters to automatically allocate on - example value ``AUTO_COMPUTE_ALLOCATION_CLUSTERS=(Cluster1,Cluster4)`` |
+| ``AUTO_COMPUTE_ALLOCATION_DESCRIPTION`` | `str`, "auto\|Cluster\|" | Optionally control the produced description for the allocation and its delimters within. The _project_code_ will always be appended. Example resultant description: ``auto\|Cluster\|CDF0001`` |
+
+
+
+## Example settings
+
+- 10k core hours for new project
+- 100 core hours for a new training project
+- default 365 end delta - no need to set variable
+
+```
+AUTO_COMPUTE_ALLOCATION_CORE_HOURS=10000
+AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING=100
+```
+
+
+## Future work
+
+Future work could include:
+
+- accelerator allocation
+- some more specific logic to map to partitions

--- a/coldfront/plugins/auto_compute_allocation/__init__.py
+++ b/coldfront/plugins/auto_compute_allocation/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+default_app_config = 'coldfront.plugins.auto_compute_allocation.apps.AutoComputeAllocationConfig'

--- a/coldfront/plugins/auto_compute_allocation/apps.py
+++ b/coldfront/plugins/auto_compute_allocation/apps.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Coldfront auto_compute_allocation plugin apps.py"""
+
+from django.apps import AppConfig
+
+
+class AutoComputeAllocationConfig(AppConfig):
+    name = "coldfront.plugins.auto_compute_allocation"
+
+    def ready(self):
+        import coldfront.plugins.auto_compute_allocation.signals

--- a/coldfront/plugins/auto_compute_allocation/signals.py
+++ b/coldfront/plugins/auto_compute_allocation/signals.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Coldfront auto_compute_allocation plugin signals.py"""
+
+import logging
+
+from django.dispatch import receiver
+from django_q.tasks import async_task
+
+from coldfront.core.project.models import Project
+from coldfront.core.project.signals import project_new
+from coldfront.core.project.views import ProjectCreateView
+from coldfront.core.utils.common import import_from_settings
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(project_new, sender=ProjectCreateView)
+def project_new_auto_compute_allocation(sender, **kwargs):
+    project_obj = kwargs.get("project_obj")
+    # Add a compute allocation
+    async_task(
+        "coldfront.plugins.auto_compute_allocation.tasks.add_auto_compute_allocation",
+        project_obj,
+    )

--- a/coldfront/plugins/auto_compute_allocation/tasks.py
+++ b/coldfront/plugins/auto_compute_allocation/tasks.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Coldfront auto_compute_allocation plugin tasks.py"""
+
+import logging
+
+from coldfront.core.utils.common import import_from_settings
+
+from coldfront.core.allocation.models import (
+    Allocation,
+    AllocationAttribute,
+    AllocationAttributeType,
+    AllocationStatusChoice,
+    AllocationUser,
+    AllocationUserStatusChoice,
+)
+
+from coldfront.core.project.models import Project
+
+from coldfront.plugins.auto_compute_allocation.utils import (
+    get_cluster_resources_tuple,
+    allocation_auto_compute,
+    allocation_auto_compute_attribute_create,
+    allocation_auto_compute_fairshare_institute,
+    allocation_auto_compute_pi,
+)
+
+logger = logging.getLogger(__name__)
+
+# Environment variables for auto_compute_allocation in tasks.py
+AUTO_COMPUTE_ALLOCATION_CORE_HOURS = import_from_settings(
+    "AUTO_COMPUTE_ALLOCATION_CORE_HOURS"
+)
+AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING = import_from_settings(
+    "AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING"
+)
+AUTO_COMPUTE_ALLOCATION_FAIRSHARE_INSTITUTION = import_from_settings(
+    "AUTO_COMPUTE_ALLOCATION_FAIRSHARE_INSTITUTION"
+)
+
+
+# automatically create a compute allocation, called by project_new signal
+def add_auto_compute_allocation(project_obj):
+    """Method to add a compute allocation automatically upon project creation - uses signals for project creation"""
+
+    # if project_code not enabled or None or empty, print appropriate message and stop
+    if not hasattr(project_obj, "project_code"):
+        logger.info(
+            "WARNING: Enable project_code to use the auto_compute_allocation plugin"
+        )
+        logger.info(
+            f"WARNING: Additional message - this issue was encountered with project pk {project_obj.pk}"
+        )
+        return None
+    if project_obj.project_code in [None, ""]:
+        logger.info(
+            "WARNING: None or empty project_code value encountered, please run the project code management command"
+        )
+        logger.info(
+            f"WARNING: Additional message - this issue was encountered with project pk {project_obj.pk}"
+        )
+        return None
+
+    project_code = project_obj.project_code
+    auto_allocation_clusters = get_cluster_resources_tuple()
+
+    # core hours
+    allocation_attribute_type_obj_core_hours = AllocationAttributeType.objects.get(
+        name="Core Usage (Hours)"
+    )
+    # slurm account name
+    allocation_attribute_type_obj_slurm_account_name = (
+        AllocationAttributeType.objects.get(name="slurm_account_name")
+    )
+    # slurm user specs
+    allocation_attribute_type_obj_slurm_user_specs = (
+        AllocationAttributeType.objects.get(name="slurm_user_specs")
+    )
+
+    try:
+        # create the allocation and return it - using utils.py function
+        allocation_obj = allocation_auto_compute(project_obj, project_code)
+
+        # add all clusters in the tuple, which might just be 1x
+        allocation_obj.resources.add(*auto_allocation_clusters)
+
+        # allocation user - PI - using utils.py function
+        allocation_auto_compute_pi(project_obj, allocation_obj)
+
+        # add the slurm account name
+        # use generic utils.py function
+        allocation_auto_compute_attribute_create(
+            allocation_attribute_type_obj_slurm_account_name,
+            allocation_obj,
+            project_code,
+        )
+
+        # add slurm user specs
+        fairshare_value = "Fairshare=parent"
+        # use generic utils.py function
+        allocation_auto_compute_attribute_create(
+            allocation_attribute_type_obj_slurm_user_specs,
+            allocation_obj,
+            fairshare_value,
+        )
+
+    except Exception as e:
+        logger.error("Failed to add auto_compute_allocation: %s", e)
+
+    # add core hours non-training project
+    if (
+        AUTO_COMPUTE_ALLOCATION_CORE_HOURS > 0
+        and project_obj.field_of_science.description != "Training"
+    ):
+        # use generic utils.py function
+        core_hours_quantity = AUTO_COMPUTE_ALLOCATION_CORE_HOURS
+        allocation_auto_compute_attribute_create(
+            allocation_attribute_type_obj_core_hours,
+            allocation_obj,
+            core_hours_quantity,
+        )
+    # add core hours training project
+    elif (
+        AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING > 0
+        and project_obj.field_of_science.description == "Training"
+    ):
+        # use generic utils.py function
+        core_hours_quantity = AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING
+        allocation_auto_compute_attribute_create(
+            allocation_attribute_type_obj_core_hours,
+            allocation_obj,
+            core_hours_quantity,
+        )
+
+    # finally if enabled, add the institution based fairshare - using utils.py function
+    if AUTO_COMPUTE_ALLOCATION_FAIRSHARE_INSTITUTION:
+        allocation_auto_compute_fairshare_institute(
+            project_obj, allocation_obj, project_code
+        )

--- a/coldfront/plugins/auto_compute_allocation/utils.py
+++ b/coldfront/plugins/auto_compute_allocation/utils.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Coldfront auto_compute_allocation plugin utils.py"""
+
+import logging
+import datetime
+
+from coldfront.core.utils.common import import_from_settings
+
+from coldfront.core.allocation.models import (
+    Allocation,
+    AllocationAttribute,
+    AllocationAttributeType,
+    AllocationStatusChoice,
+    AllocationUser,
+    AllocationUserStatusChoice,
+)
+from coldfront.core.project.models import Project
+from coldfront.core.resource.models import Resource, ResourceType
+
+# Environment variables for auto_compute_allocation in utils.py
+AUTO_COMPUTE_ALLOCATION_END_DELTA = import_from_settings(
+    "AUTO_COMPUTE_ALLOCATION_END_DELTA"
+)
+AUTO_COMPUTE_ALLOCATION_CHANGABLE = import_from_settings(
+    "AUTO_COMPUTE_ALLOCATION_CHANGABLE"
+)
+AUTO_COMPUTE_ALLOCATION_LOCKED = import_from_settings("AUTO_COMPUTE_ALLOCATION_LOCKED")
+AUTO_COMPUTE_ALLOCATION_CLUSTERS = import_from_settings(
+    "AUTO_COMPUTE_ALLOCATION_CLUSTERS"
+)
+AUTO_COMPUTE_ALLOCATION_DESCRIPTION = import_from_settings(
+    "AUTO_COMPUTE_ALLOCATION_DESCRIPTION"
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_cluster_resources_tuple():
+    """ Method to get all cluster Resources configured the Coldfront instance, optionally can filter out using variable"""
+    # find 'Cluster' within ResourceType
+    cluster_pk_value = ResourceType.objects.get(name="Cluster").pk
+    # filter for clusters
+    resource_queryset = Resource.objects.filter(resource_type=cluster_pk_value)
+    # initialise a list which will store all clusters - even if just 1x
+    cluster_list = []
+
+    # If a filter is defined then find matches
+    if AUTO_COMPUTE_ALLOCATION_CLUSTERS:
+        for filter_cluster in AUTO_COMPUTE_ALLOCATION_CLUSTERS:
+            matched_cluster = Resource.objects.get(name=filter_cluster)
+            cluster_list.append(matched_cluster.pk)
+        auto_allocation_clusters = tuple(cluster_list)
+    # Otherwise all clusters
+    else:
+        for a_cluster in resource_queryset:
+            cluster_list.append(a_cluster.pk)
+        auto_allocation_clusters = tuple(cluster_list)
+    return auto_allocation_clusters
+
+
+# create the allocation
+def allocation_auto_compute(project_obj, project_code):
+    """ Method to create the auto_compute allocation """
+    allocation_end_date = datetime.date.today() + datetime.timedelta(
+        days=AUTO_COMPUTE_ALLOCATION_END_DELTA
+    )
+
+    allocation_status_obj = AllocationStatusChoice.objects.get(
+        name="New"
+    )  # alternative is Active
+    allocation_description = str(f"{AUTO_COMPUTE_ALLOCATION_DESCRIPTION}{project_code}")
+
+    allocation_obj = Allocation.objects.create(
+        project=project_obj,
+        justification="System automatically created compute allocation",
+        description=allocation_description,
+        status=allocation_status_obj,
+        quantity=1,
+        start_date=datetime.date.today(),
+        end_date=allocation_end_date,
+        is_locked=AUTO_COMPUTE_ALLOCATION_LOCKED,  # admin needs to unlock to permit changes
+        is_changeable=AUTO_COMPUTE_ALLOCATION_CHANGABLE,
+    )  # no ability to request change to this allocation
+    return allocation_obj
+
+
+# adding pi to allocation, not other users, as they won't exist on project creation
+def allocation_auto_compute_pi(project_obj, allocation_obj):
+    """ Method to add the PI to the auto_compute allocation """
+    allocation_user_obj = AllocationUser.objects.create(
+        allocation=allocation_obj,
+        user=project_obj.pi,
+        status=AllocationUserStatusChoice.objects.get(name="Active"),
+    )
+    return allocation_user_obj
+
+
+def allocation_auto_compute_attribute_create(
+    allocation_attribute_type_obj, allocation_obj, allocation_value
+):
+    """ generic method to add allocation attribute types and corresponding values """
+    allocation_attribute_obj = AllocationAttribute.objects.create(
+        allocation=allocation_obj,
+        allocation_attribute_type=allocation_attribute_type_obj,
+        value=allocation_value,
+    )
+    return allocation_attribute_obj
+
+
+# slurm specs when fairshare institution is enabled, test for pre-reqs first
+def allocation_auto_compute_fairshare_institute(
+    project_obj, allocation_obj, project_code
+):
+    """ method to add an institutional fair share value for slurm association - slurm specs """
+    # if institution not enabled or None or empty, print appropriate message and return
+    if not hasattr(project_obj, "institution"):
+        logger.info(
+            "WARNING: Enable institution feature to set per institution fairshare in the auto_compute_allocation plugin"
+        )
+        logger.info(
+            f"WARNING: Additional message - this issue was encountered with project pk {project_obj.pk}"
+        )
+        return None
+    if project_obj.institution in [None, "", "None"]:
+        logger.info(
+            f"WARNING: None or empty institution value encountered, an institution value is required to set per institution fairshare in the auto_compute_allocation plugin - value found was {project_obj.institution}"
+        )
+        logger.info(
+            f"WARNING: Additional message - this issue was encountered with project pk {project_obj.pk}"
+        )
+        return None
+
+    fairshare_institution = project_obj.institution
+
+    allocation_attribute_type_obj = AllocationAttributeType.objects.get(
+        name="slurm_specs"
+    )
+    fairshare_value = f"Fairshare={fairshare_institution}"
+
+    AllocationAttribute.objects.create(
+        allocation=allocation_obj,
+        allocation_attribute_type=allocation_attribute_type_obj,
+        value=fairshare_value,
+    )


### PR DESCRIPTION
This PR adds auto_compute_allocation

A README.md is present which covers most of the information required. No management commands are provided.

The automatic allocation is created on project creation.

---

Example non-training project

![image](https://github.com/user-attachments/assets/efb6ed5a-171e-43ec-9501-46bd4d6e0eef)

Allocation detail against fictional seahawk cluster, named using project_code

![image](https://github.com/user-attachments/assets/f2f93759-93a6-449c-8a17-89928f9f1bb4)

Allocation attributes, showing slurm account name based on project_code, institution fairshare, core hours allocated by use of VAR

![image](https://github.com/user-attachments/assets/a8586f50-3c49-4b5d-8b23-d3531ee720ff)

