### PR TITLE
Add pagination to ColdFront API for large query requests

### DIFF
--- a/coldfront/config/plugins/api.py
+++ b/coldfront/config/plugins/api.py
@@ -20,4 +20,6 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': [
         'django_filters.rest_framework.DjangoFilterBackend'
     ],
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 100,
 }


### PR DESCRIPTION
I love the new ColdFront API! I got an error trying the `/api/projects/?project_users=true` endpoint due to the large number of results. That might have been because I was using SQLite, but maybe this would be useful to have? I wasn't sure what `PAGE_SIZE` to start with. Just a thought!