### PR TITLE
Changed the version to type: input

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-fix.yml
+++ b/.github/ISSUE_TEMPLATE/bug-fix.yml
@@ -11,18 +11,12 @@ body:
       value: "A bug happened!"
     validations:
       required: true
-  - type: dropdown
+  - type: input
     id: version
     attributes:
       label: Version
       description: What version of our software are you running?
-      options:
-        - 1.1.5
-        - 1.1.4
-        - 1.1.3
-        - 1.1.2
-        - 1.1.1
-        - 1.1.0 or before
+      placeholder: 1.X.X
   - type: dropdown
     id: component
     attributes:


### PR DESCRIPTION
Modified the bug-fix.yml file so that the entry area for the version number is now a generic input text box instead of a selector with only a limited number of versions. Closes #691 