### PR TITLE
Update dockerfile to python3.12, venv, uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
-FROM python:3.8
+FROM python:3.12
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
-COPY requirements.txt ./
-RUN pip3 install -r requirements.txt
+RUN pip3 install --upgrade pip uv "setuptools<81"
 COPY . .
-
-RUN python3 ./manage.py initial_setup
-RUN python3 ./manage.py load_test_data
+RUN uv venv .venv
+RUN . .venv/bin/activate \
+    && uv pip install .
+RUN . .venv/bin/activate \
+    && python3 ./manage.py initial_setup -f
+RUN . .venv/bin/activate \
+    && python3 ./manage.py load_test_data
 
 ENV DEBUG=True
 
 EXPOSE 8000
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["bash", "-c", ". .venv/bin/activate && python3 ./manage.py runserver 0.0.0.0:8000"]


### PR DESCRIPTION
Updated dockerfile from old version
- use python 3.12
- use uv to install (requires venv)
- add `-f` flag to force init data (suppress a confirmation)

Know that further dockerfile update is in progress, just a fix for a temporary working test demo.