### PR TITLE
Refactored deprecated logging module functionality

### DIFF
--- a/coldfront/config/logging.py
+++ b/coldfront/config/logging.py
@@ -30,7 +30,7 @@ LOGGING = {
     },
     "loggers": {
         "django_auth_ldap": {
-            "level": "WARN",
+            "level": "WARNING",
             # 'handlers': ['console', 'file'],
             "handlers": [
                 "console",

--- a/coldfront/core/attribute_expansion.py
+++ b/coldfront/core/attribute_expansion.py
@@ -114,7 +114,7 @@ def get_attribute_parameter_value(argument, attribute_parameter_dict, error_text
             return tmpstr
         else:
             # Bad string literal
-            logger.warn(
+            logger.warning(
                 "Bad string literal '{}' found while processing {}; missing final single quote".format(
                     argument, error_text
                 )
@@ -167,7 +167,7 @@ def get_attribute_parameter_value(argument, attribute_parameter_dict, error_text
             value = float(argument)
             return value
         except ValueError:
-            logger.warn(
+            logger.warning(
                 "Unable to evaluate argument '{arg}' while processing {etxt}, returning None".format(
                     arg=argument, etxt=error_text
                 )
@@ -214,12 +214,12 @@ def process_attribute_parameter_operation(opcode, oldvalue, argument, error_text
     """
     # Argument should never be None
     if argument is None:
-        logger.warn("Operator {}= acting on None argument in {}, returning None".format(opcode, error_text))
+        logger.warning("Operator {}= acting on None argument in {}, returning None".format(opcode, error_text))
         return None
     # Assignment and default operations allow oldvalue to be None
     if oldvalue is None:
         if opcode != ":" and opcode != "|":
-            logger.warn("Operator {}= acting on oldvalue=None in {}, returning None".format(opcode, error_text))
+            logger.warning("Operator {}= acting on oldvalue=None in {}, returning None".format(opcode, error_text))
             return None
 
     try:
@@ -241,7 +241,7 @@ def process_attribute_parameter_operation(opcode, oldvalue, argument, error_text
                 newval = oldvalue + argument
                 return newval
             else:
-                logger.warn(
+                logger.warning(
                     "Operator {}= acting on parameter of type {} in {}, returning None".format(
                         opcode, type(oldvalue), error_text
                     )
@@ -267,7 +267,7 @@ def process_attribute_parameter_operation(opcode, oldvalue, argument, error_text
         # If reached here, we do not recognize opcode
         logger.error("Unrecognized operation {}= in {}, returning None".format(opcode, error_text))
     except Exception:
-        logger.warn(
+        logger.warning(
             "Error performing operator {op}= on oldvalue='{old}' and argument={arg} in {errtext}".format(
                 op=opcode, old=oldvalue, arg=argument, errtext=error_text
             )

--- a/coldfront/core/utils/common.py
+++ b/coldfront/core/utils/common.py
@@ -46,5 +46,5 @@ def su_login_callback(user):
     if user.is_active and user.is_superuser:
         return True
 
-    logger.warn("User {} requested to login as another user but does not have permissions", user)
+    logger.warning("User {} requested to login as another user but does not have permissions", user)
     return False

--- a/coldfront/plugins/freeipa/management/commands/freeipa_check.py
+++ b/coldfront/plugins/freeipa/management/commands/freeipa_check.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
                 res = api.Command.group_add_member(group, user=[user.username])
                 check_ipa_group_error(res)
             except AlreadyMemberError:
-                logger.warn("User %s is already a member of group %s", user.username, group)
+                logger.warning("User %s is already a member of group %s", user.username, group)
             except Exception as e:
                 logger.error("Failed adding user %s to group %s: %s", user.username, group, e)
             else:
@@ -81,7 +81,7 @@ class Command(BaseCommand):
                 res = api.Command.group_remove_member(group, user=[user.username])
                 check_ipa_group_error(res)
             except NotMemberError:
-                logger.warn("User %s is not a member of group %s", user.username, group)
+                logger.warning("User %s is not a member of group %s", user.username, group)
             except Exception as e:
                 logger.error("Failed removing user %s from group %s: %s", user.username, group, e)
             else:
@@ -170,10 +170,10 @@ class Command(BaseCommand):
             return
 
         if freeipa_status == "Disabled" and user.is_active:
-            logger.warn("User is active in coldfront but disabled in FreeIPA: %s", user.username)
+            logger.warning("User is active in coldfront but disabled in FreeIPA: %s", user.username)
             self.sync_user_status(user, active=False)
         elif freeipa_status == "Enabled" and not user.is_active:
-            logger.warn("User is not active in coldfront but enabled in FreeIPA: %s", user.username)
+            logger.warning("User is not active in coldfront but enabled in FreeIPA: %s", user.username)
             self.sync_user_status(user, active=True)
 
         for g in active_groups:
@@ -253,22 +253,22 @@ class Command(BaseCommand):
         elif verbosity == 3:
             root_logger.setLevel(logging.DEBUG)
         else:
-            root_logger.setLevel(logging.WARN)
+            root_logger.setLevel(logging.WARNING)
 
         self.noop = FREEIPA_NOOP
         if options["noop"]:
             self.noop = True
-            logger.warn("NOOP enabled")
+            logger.warning("NOOP enabled")
 
         self.sync = False
         if options["sync"]:
             self.sync = True
-            logger.warn("Syncing FreeIPA with ColdFront")
+            logger.warning("Syncing FreeIPA with ColdFront")
 
         self.disable = False
         if options["disable"]:
             self.disable = True
-            logger.warn("Disabling users in ColdFront that are disabled in FreeIPA")
+            logger.warning("Disabling users in ColdFront that are disabled in FreeIPA")
 
         header = [
             "action",

--- a/coldfront/plugins/freeipa/management/commands/freeipa_expire_users.py
+++ b/coldfront/plugins/freeipa/management/commands/freeipa_expire_users.py
@@ -47,17 +47,17 @@ class Command(BaseCommand):
         elif verbosity == 3:
             root_logger.setLevel(logging.DEBUG)
         else:
-            root_logger.setLevel(logging.WARN)
+            root_logger.setLevel(logging.WARNING)
 
         self.sync = False
         if options["sync"]:
             self.sync = True
-            logger.warn("Syncing FreeIPA with ColdFront")
+            logger.warning("Syncing FreeIPA with ColdFront")
 
         self.noop = FREEIPA_NOOP
         if options["noop"]:
             self.noop = True
-            logger.warn("NOOP enabled")
+            logger.warning("NOOP enabled")
 
         header = [
             "username",

--- a/coldfront/plugins/freeipa/tasks.py
+++ b/coldfront/plugins/freeipa/tasks.py
@@ -24,11 +24,11 @@ logger = logging.getLogger(__name__)
 def add_user_group(allocation_user_pk):
     allocation_user = AllocationUser.objects.get(pk=allocation_user_pk)
     if allocation_user.allocation.status.name != "Active":
-        logger.warn("Allocation is not active. Will not add groups")
+        logger.warning("Allocation is not active. Will not add groups")
         return
 
     if allocation_user.status.name != "Active":
-        logger.warn("Allocation user status is not 'Active'. Will not add groups.")
+        logger.warning("Allocation user status is not 'Active'. Will not add groups.")
         return
 
     groups = allocation_user.allocation.get_attribute_list(UNIX_GROUP_ATTRIBUTE_NAME)
@@ -39,7 +39,7 @@ def add_user_group(allocation_user_pk):
     os.environ["KRB5_CLIENT_KTNAME"] = CLIENT_KTNAME
     for g in groups:
         if FREEIPA_NOOP:
-            logger.warn(
+            logger.warning(
                 "NOOP - FreeIPA adding user %s to group %s for allocation %s",
                 allocation_user.user.username,
                 g,
@@ -51,7 +51,7 @@ def add_user_group(allocation_user_pk):
             res = api.Command.group_add_member(g, user=[allocation_user.user.username])
             check_ipa_group_error(res)
         except AlreadyMemberError:
-            logger.warn("User %s is already a member of group %s", allocation_user.user.username, g)
+            logger.warning("User %s is already a member of group %s", allocation_user.user.username, g)
         except Exception as e:
             logger.error("Failed adding user %s to group %s: %s", allocation_user.user.username, g, e)
             set_allocation_user_status_to_error(allocation_user_pk)
@@ -66,11 +66,11 @@ def remove_user_group(allocation_user_pk):
         "Pending",
         "Inactive (Renewed)",
     ]:
-        logger.warn("Allocation is not active or pending. Will not remove groups.")
+        logger.warning("Allocation is not active or pending. Will not remove groups.")
         return
 
     if allocation_user.status.name != "Removed":
-        logger.warn("Allocation user status is not 'Removed'. Will not remove groups.")
+        logger.warning("Allocation user status is not 'Removed'. Will not remove groups.")
         return
 
     groups = allocation_user.allocation.get_attribute_list(UNIX_GROUP_ATTRIBUTE_NAME)
@@ -107,7 +107,7 @@ def remove_user_group(allocation_user_pk):
     os.environ["KRB5_CLIENT_KTNAME"] = CLIENT_KTNAME
     for g in groups:
         if FREEIPA_NOOP:
-            logger.warn(
+            logger.warning(
                 "NOOP - FreeIPA removing user %s from group %s for allocation %s",
                 allocation_user.user.username,
                 g,
@@ -119,7 +119,7 @@ def remove_user_group(allocation_user_pk):
             res = api.Command.group_remove_member(g, user=[allocation_user.user.username])
             check_ipa_group_error(res)
         except NotMemberError:
-            logger.warn("User %s is not a member of group %s", allocation_user.user.username, g)
+            logger.warning("User %s is not a member of group %s", allocation_user.user.username, g)
         except Exception as e:
             logger.error("Failed removing user %s from group %s: %s", allocation_user.user.username, g, e)
             set_allocation_user_status_to_error(allocation_user_pk)

--- a/coldfront/plugins/mokey_oidc/auth.py
+++ b/coldfront/plugins/mokey_oidc/auth.py
@@ -43,7 +43,7 @@ class OIDCMokeyAuthenticationBackend(OIDCAuthenticationBackend):
             return None
 
         if not email:
-            logger.warn(
+            logger.warning(
                 "Creating user with no email. Could not find email for user %s in mokey oidc id_token claims: %s",
                 username,
                 claims,
@@ -69,7 +69,7 @@ class OIDCMokeyAuthenticationBackend(OIDCAuthenticationBackend):
         if email and len(email) > 0:
             user.email = email
         else:
-            logger.warn(
+            logger.warning(
                 "Failed to update email. Could not find email for user %s in mokey oidc id_token claims: %s",
                 username,
                 claims,

--- a/coldfront/plugins/slurm/management/commands/slurm_check.py
+++ b/coldfront/plugins/slurm/management/commands/slurm_check.py
@@ -252,17 +252,17 @@ class Command(BaseCommand):
         elif verbosity == 3:
             root_logger.setLevel(logging.DEBUG)
         else:
-            root_logger.setLevel(logging.WARN)
+            root_logger.setLevel(logging.WARNING)
 
         self.sync = False
         if options["sync"]:
             self.sync = True
-            logger.warn("Syncing Slurm with ColdFront")
+            logger.warning("Syncing Slurm with ColdFront")
 
         self.noop = SLURM_NOOP
         if options["noop"]:
             self.noop = True
-            logger.warn("NOOP enabled")
+            logger.warning("NOOP enabled")
 
         if options["cluster"]:
             slurm_cluster = self._cluster_from_dump(options["cluster"])
@@ -277,7 +277,7 @@ class Command(BaseCommand):
             sys.exit(1)
 
         if slurm_cluster.name in SLURM_IGNORE_CLUSTERS:
-            logger.warn("Ignoring cluster %s. Nothing to do.", slurm_cluster.name)
+            logger.warning("Ignoring cluster %s. Nothing to do.", slurm_cluster.name)
             sys.exit(0)
 
         try:

--- a/coldfront/plugins/slurm/management/commands/slurm_dump.py
+++ b/coldfront/plugins/slurm/management/commands/slurm_dump.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
         elif verbosity == 3:
             root_logger.setLevel(logging.DEBUG)
         else:
-            root_logger.setLevel(logging.WARN)
+            root_logger.setLevel(logging.WARNING)
 
         out_dir = None
         if options["output"]:
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             if not os.path.isdir(out_dir):
                 os.mkdir(out_dir, 0o0700)
 
-            logger.warn("Writing output to directory: %s", out_dir)
+            logger.warning("Writing output to directory: %s", out_dir)
 
         for attr in ResourceAttribute.objects.filter(resource_attribute_type__name=SLURM_CLUSTER_ATTRIBUTE_NAME):
             if options["cluster"] and options["cluster"] != attr.value:

--- a/coldfront/plugins/slurm/utils.py
+++ b/coldfront/plugins/slurm/utils.py
@@ -40,7 +40,7 @@ class SlurmError(Exception):
 
 def _run_slurm_cmd(cmd, noop=True):
     if noop:
-        logger.warn("NOOP - Slurm cmd: %s", cmd)
+        logger.warning("NOOP - Slurm cmd: %s", cmd)
         return
 
     try:
@@ -48,11 +48,11 @@ def _run_slurm_cmd(cmd, noop=True):
     except subprocess.CalledProcessError as e:
         if "Nothing deleted" in str(e.stdout):
             # We tried to delete something that didn't exist. Don't throw error
-            logger.warn("Nothing to delete: %s", cmd)
+            logger.warning("Nothing to delete: %s", cmd)
             return e.stdout
         if "Nothing new added" in str(e.stdout):
             # We tried to add something that already exists. Don't throw error
-            logger.warn("Nothing new to add: %s", cmd)
+            logger.warning("Nothing new to add: %s", cmd)
             return e.stdout
 
         logger.error("Slurm command failed: %s", cmd)

--- a/coldfront/plugins/xdmod/management/commands/xdmod_usage.py
+++ b/coldfront/plugins/xdmod/management/commands/xdmod_usage.py
@@ -94,12 +94,12 @@ class Command(BaseCommand):
         for s in allocations.distinct():
             account_name = s.get_attribute(XDMOD_STORAGE_GROUP_ATTRIBUTE_NAME)
             if not account_name:
-                logger.warn("%s attribute not found for allocation: %s", XDMOD_STORAGE_GROUP_ATTRIBUTE_NAME, s)
+                logger.warning("%s attribute not found for allocation: %s", XDMOD_STORAGE_GROUP_ATTRIBUTE_NAME, s)
                 continue
 
             cpu_hours = s.get_attribute(XDMOD_STORAGE_ATTRIBUTE_NAME)
             if not cpu_hours:
-                logger.warn("%s attribute not found for allocation: %s", XDMOD_STORAGE_ATTRIBUTE_NAME, s)
+                logger.warning("%s attribute not found for allocation: %s", XDMOD_STORAGE_ATTRIBUTE_NAME, s)
                 continue
 
             resources = []
@@ -117,7 +117,7 @@ class Command(BaseCommand):
                 resources.append(rname)
 
             if len(resources) == 0:
-                logger.warn(
+                logger.warning(
                     "%s attribute not found on any resouces for allocation: %s", XDMOD_RESOURCE_ATTRIBUTE_NAME, s
                 )
                 continue
@@ -127,12 +127,12 @@ class Command(BaseCommand):
                     s.start_date, s.end_date, account_name, resources=resources, statistics="avg_physical_usage"
                 )
             except XdmodNotFoundError:
-                logger.warn(
+                logger.warning(
                     "No data in XDMoD found for allocation %s account %s resources %s", s, account_name, resources
                 )
                 continue
 
-            logger.warn(
+            logger.warning(
                 "Total GB = %s for allocation %s account %s GB %s resources %s",
                 usage,
                 s,
@@ -199,12 +199,12 @@ class Command(BaseCommand):
         for s in allocations.distinct():
             account_name = s.get_attribute(XDMOD_ACCOUNT_ATTRIBUTE_NAME)
             if not account_name:
-                logger.warn("%s attribute not found for allocation: %s", XDMOD_ACCOUNT_ATTRIBUTE_NAME, s)
+                logger.warning("%s attribute not found for allocation: %s", XDMOD_ACCOUNT_ATTRIBUTE_NAME, s)
                 continue
 
             cpu_hours = s.get_attribute(XDMOD_ACC_HOURS_ATTRIBUTE_NAME)
             if not cpu_hours:
-                logger.warn("%s attribute not found for allocation: %s", XDMOD_ACC_HOURS_ATTRIBUTE_NAME, s)
+                logger.warning("%s attribute not found for allocation: %s", XDMOD_ACC_HOURS_ATTRIBUTE_NAME, s)
                 continue
 
             resources = []
@@ -222,7 +222,7 @@ class Command(BaseCommand):
                 resources.append(rname)
 
             if len(resources) == 0:
-                logger.warn(
+                logger.warning(
                     "%s attribute not found on any resouces for allocation: %s", XDMOD_RESOURCE_ATTRIBUTE_NAME, s
                 )
                 continue
@@ -232,12 +232,12 @@ class Command(BaseCommand):
                     s.start_date, s.end_date, account_name, resources=resources, statistics="total_gpu_hours"
                 )
             except XdmodNotFoundError:
-                logger.warn(
+                logger.warning(
                     "No data in XDMoD found for allocation %s account %s resources %s", s, account_name, resources
                 )
                 continue
 
-            logger.warn(
+            logger.warning(
                 "Total Accelerator hours = %s for allocation %s account %s gpu_hours %s resources %s",
                 usage,
                 s,
@@ -299,12 +299,12 @@ class Command(BaseCommand):
         for s in allocations.distinct():
             account_name = s.get_attribute(XDMOD_ACCOUNT_ATTRIBUTE_NAME)
             if not account_name:
-                logger.warn("%s attribute not found for allocation: %s", XDMOD_ACCOUNT_ATTRIBUTE_NAME, s)
+                logger.warning("%s attribute not found for allocation: %s", XDMOD_ACCOUNT_ATTRIBUTE_NAME, s)
                 continue
 
             cpu_hours = s.get_attribute(XDMOD_CPU_HOURS_ATTRIBUTE_NAME)
             if not cpu_hours:
-                logger.warn("%s attribute not found for allocation: %s", XDMOD_CPU_HOURS_ATTRIBUTE_NAME, s)
+                logger.warning("%s attribute not found for allocation: %s", XDMOD_CPU_HOURS_ATTRIBUTE_NAME, s)
                 continue
 
             resources = []
@@ -322,7 +322,7 @@ class Command(BaseCommand):
                 resources.append(rname)
 
             if len(resources) == 0:
-                logger.warn(
+                logger.warning(
                     "%s attribute not found on any resouces for allocation: %s", XDMOD_RESOURCE_ATTRIBUTE_NAME, s
                 )
                 continue
@@ -330,12 +330,12 @@ class Command(BaseCommand):
             try:
                 usage = xdmod_fetch_total_cpu_hours(s.start_date, s.end_date, account_name, resources=resources)
             except XdmodNotFoundError:
-                logger.warn(
+                logger.warning(
                     "No data in XDMoD found for allocation %s account %s resources %s", s, account_name, resources
                 )
                 continue
 
-            logger.warn(
+            logger.warning(
                 "Total CPU hours = %s for allocation %s account %s cpu_hours %s resources %s",
                 usage,
                 s,
@@ -397,12 +397,12 @@ class Command(BaseCommand):
         for s in allocations.distinct():
             project_name = s.get_attribute(XDMOD_CLOUD_PROJECT_ATTRIBUTE_NAME)
             if not project_name:
-                logger.warn("%s attribute not found for allocation: %s", XDMOD_CLOUD_PROJECT_ATTRIBUTE_NAME, s)
+                logger.warning("%s attribute not found for allocation: %s", XDMOD_CLOUD_PROJECT_ATTRIBUTE_NAME, s)
                 continue
 
             core_time = s.get_attribute(XDMOD_CLOUD_CORE_TIME_ATTRIBUTE_NAME)
             if not core_time:
-                logger.warn("%s attribute not found for allocation: %s", XDMOD_CLOUD_CORE_TIME_ATTRIBUTE_NAME, s)
+                logger.warning("%s attribute not found for allocation: %s", XDMOD_CLOUD_CORE_TIME_ATTRIBUTE_NAME, s)
                 continue
 
             resources = []
@@ -420,7 +420,7 @@ class Command(BaseCommand):
                 resources.append(rname)
 
             if len(resources) == 0:
-                logger.warn(
+                logger.warning(
                     "%s attribute not found on any resouces for allocation: %s", XDMOD_RESOURCE_ATTRIBUTE_NAME, s
                 )
                 continue
@@ -428,12 +428,12 @@ class Command(BaseCommand):
             try:
                 usage = xdmod_fetch_cloud_core_time(s.start_date, s.end_date, project_name, resources=resources)
             except XdmodNotFoundError:
-                logger.warn(
+                logger.warning(
                     "No data in XDMoD found for allocation %s project %s resources %s", s, project_name, resources
                 )
                 continue
 
-            logger.warn(
+            logger.warning(
                 "Cloud core time = %s for allocation %s project %s core_time %s resources %s",
                 usage,
                 s,
@@ -467,12 +467,12 @@ class Command(BaseCommand):
         elif verbosity == 3:
             root_logger.setLevel(logging.DEBUG)
         else:
-            root_logger.setLevel(logging.WARN)
+            root_logger.setLevel(logging.WARNING)
 
         self.sync = False
         if options["sync"]:
             self.sync = True
-            logger.warn("Syncing ColdFront with XDMoD")
+            logger.warning("Syncing ColdFront with XDMoD")
 
         statistic = "total_cpu_hours"
         self.filter_user = ""


### PR DESCRIPTION
Replaced all instances of logging.WARN with logging.WARNING and logging.warn with logging.warning. This ensures that coldfront will not break due to using deprecated functions which were removed in Python 3.13 and greater. 