### PR TITLE
Set up custom coldfront test runner to set fake seed and stress level.

### DIFF
--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -8,14 +8,7 @@ from split_settings.tools import include, optional
 from coldfront.config.env import ENV, PROJECT_ROOT
 
 # ColdFront split settings
-coldfront_configs = [
-    "base.py",
-    "database.py",
-    "auth.py",
-    "logging.py",
-    "core.py",
-    "email.py",
-]
+coldfront_configs = ["base.py", "database.py", "auth.py", "logging.py", "core.py", "email.py", "testing.py"]
 
 # ColdFront plugin settings
 plugin_configs = {

--- a/coldfront/config/testing.py
+++ b/coldfront/config/testing.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+TEST_RUNNER = "coldfront.core.test_helpers.coldfront_test_runner.ColdFrontRunner"

--- a/coldfront/core/test_helpers/coldfront_test_runner.py
+++ b/coldfront/core/test_helpers/coldfront_test_runner.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import random
+from argparse import ArgumentTypeError
+from enum import IntEnum
+
+import factory
+import factory.random
+from django.test.runner import DiscoverRunner
+
+
+class StressLevel(IntEnum):
+    LOW = 8
+    MEDIUM = 128
+    HIGH = 1024
+    EXTREME = 4096
+    SEVERE = 32768
+
+    default = LOW
+
+    @classmethod
+    def get_names(cls) -> list[str]:
+        return [ele.name for ele in cls]
+
+    @classmethod
+    def from_string(cls, value: str):
+        if value.upper() in cls.get_names():
+            return cls[value.upper()]
+        raise ValueError("Cannot convert value to StressLevel")
+
+
+class ColdFrontRunner(DiscoverRunner):
+    def __init__(self, stress_level=StressLevel.default, fake_seed=0, **kwargs):
+        self.stress_level: StressLevel = stress_level
+        self.fake_seed: float = fake_seed
+        global STRESS_LEVEL
+        global FAKE_SEED
+        STRESS_LEVEL = self.stress_level
+        FAKE_SEED = self.fake_seed
+        super().__init__(**kwargs)
+
+    def setup_test_environment(self, **kwargs):
+        print(f"Using the seed {self.fake_seed} for test(s).")
+        factory.random.reseed_random(self.fake_seed)
+        if self.parallel > 1:
+            print("NOTICE: Running test(s) in parallel may produce non-deterministic results.")
+        super().setup_test_environment(**kwargs)
+
+    @staticmethod
+    def get_stress_level_from_arg(value: str):
+        try:
+            return StressLevel.from_string(value)
+        except ValueError:
+            raise ArgumentTypeError(
+                f"Invalid value '{value}' cannot be converted to StressLevel. Use one of: {', '.join(StressLevel.get_names())}."
+            )
+
+    @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument(
+            "--stress-level",
+            dest="stress_level",
+            type=cls.get_stress_level_from_arg,
+            default=StressLevel.default,
+            help="Stress level to run the tests at. Higher levels take longer to run.",
+        )
+        parser.add_argument(
+            "--fake-seed",
+            dest="fake_seed",
+            type=float,
+            default=random.random(),
+            help="Seed for the fake data generator.",
+        )
+        super().add_arguments(parser)
+
+
+STRESS_LEVEL: StressLevel = StressLevel.default
+FAKE_SEED: float = 0


### PR DESCRIPTION
This PR includes a custom test runner for coldfront which is a subclass of the default `DiscoverRunner`. This custom test runner adds flags on the command line to specify the seed used for the random value generation with faker as well as an argument to give a stress level to the tests. This custom test runner will also generate and report each time the test suite is ran what the seed used for faker was regardless of whether or user specified it or not. This closes issue #721. 

The only concern with this is that even when specifying a seed manually, there might be an issue if tests are ever run in parallel that might cause inconsistencies. 

Some things that might want to be modified:
1. What to name the file that stores the new test runner code
2. Whether float or int would be preferred for the seed
3. Whether to keep the constants for FAKE_SEED and STRESS_LEVEL as variables imported from the module or to make these settings using django.conf.settings

If you like it as is then it should be ok to merge in. 