### PR TITLE
Fixed ALLOCATION_RESOURCE_ORDERING 

### DIFF
--- a/coldfront/config/core.py
+++ b/coldfront/config/core.py
@@ -48,6 +48,7 @@ ALLOCATION_FUNCS_ON_EXPIRE = [
 
 # This is in days
 ALLOCATION_DEFAULT_ALLOCATION_LENGTH = ENV.int("ALLOCATION_DEFAULT_ALLOCATION_LENGTH", default=365)
+ALLOCATION_RESOURCE_ORDERING = ENV.list("ALLOCATION_RESOURCE_ORDERING", default=["-is_allocatable", "name"])
 
 # ------------------------------------------------------------------------------
 # Allow user to select account name for allocation

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -19,12 +19,11 @@ import coldfront.core.attribute_expansion as attribute_expansion
 from coldfront.core.project.models import Project, ProjectPermission
 from coldfront.core.resource.models import Resource
 from coldfront.core.utils.common import import_from_settings
-
+from django.conf import settings
 logger = logging.getLogger(__name__)
 
 ALLOCATION_ATTRIBUTE_VIEW_LIST = import_from_settings("ALLOCATION_ATTRIBUTE_VIEW_LIST", [])
 ALLOCATION_FUNCS_ON_EXPIRE = import_from_settings("ALLOCATION_FUNCS_ON_EXPIRE", [])
-ALLOCATION_RESOURCE_ORDERING = import_from_settings("ALLOCATION_RESOURCE_ORDERING", ["-is_allocatable", "name"])
 
 
 class AllocationPermission(Enum):
@@ -192,7 +191,7 @@ class Allocation(TimeStampedModel):
             str: the resources for the allocation
         """
 
-        return ", ".join([ele.name for ele in self.resources.all().order_by(*ALLOCATION_RESOURCE_ORDERING)])
+        return ", ".join([ele.name for ele in self.resources.all().order_by(*settings.ALLOCATION_RESOURCE_ORDERING)])
 
     @property
     def get_resources_as_list(self):
@@ -213,7 +212,7 @@ class Allocation(TimeStampedModel):
         if self.resources.count() == 1:
             return self.resources.first()
         else:
-            parent = self.resources.order_by(*ALLOCATION_RESOURCE_ORDERING).first()
+            parent = self.resources.order_by(*settings.ALLOCATION_RESOURCE_ORDERING).first()
             if parent:
                 return parent
             # Fallback


### PR DESCRIPTION
Fixed ALLOCATION_RESOURCE_ORDERING to actually be configurable using settings/environ. Usages of now use through django.conf.settings .

This closes #714. This will remain as a draft as it probably does not make sense to merge this until #722 is merged. 