### PR TITLE
add coldfront core setting for PROJECT_UPDATE_FIELDS

### DIFF
--- a/coldfront/config/core.py
+++ b/coldfront/config/core.py
@@ -126,3 +126,16 @@ PROJECT_CODE_PADDING = ENV.int("PROJECT_CODE_PADDING", default=None)
 # ------------------------------------------------------------------------------
 
 PROJECT_INSTITUTION_EMAIL_MAP = ENV.dict("PROJECT_INSTITUTION_EMAIL_MAP", default={})
+
+# ------------------------------------------------------------------------------
+# Configure Project fields that project managers can update
+# ------------------------------------------------------------------------------
+
+PROJECT_UPDATE_FIELDS = ENV.list(
+    "PROJECT_UPDATE_FIELDS",
+    default=[
+        "title",
+        "description",
+        "field_of_science",
+    ],
+)

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -82,6 +82,14 @@ if EMAIL_ENABLED:
 
 PROJECT_CODE = import_from_settings("PROJECT_CODE", False)
 PROJECT_CODE_PADDING = import_from_settings("PROJECT_CODE_PADDING", False)
+PROJECT_UPDATE_FIELDS = import_from_settings(
+    "PROJECT_UPDATE_FIELDS",
+    [
+        "title",
+        "description",
+        "field_of_science",
+    ],
+)
 
 logger = logging.getLogger(__name__)
 PROJECT_INSTITUTION_EMAIL_MAP = import_from_settings("PROJECT_INSTITUTION_EMAIL_MAP", False)
@@ -615,11 +623,7 @@ class ProjectCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
 class ProjectUpdateView(SuccessMessageMixin, LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     model = Project
     template_name_suffix = "_update_form"
-    fields = [
-        "title",
-        "description",
-        "field_of_science",
-    ]
+    fields = PROJECT_UPDATE_FIELDS
     success_message = "Project updated."
 
     def test_func(self):

--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -101,9 +101,10 @@ The following settings are ColdFront specific settings related to the core appli
 | RESEARCH_OUTPUT_ENABLE                 | Enable or disable research outputs. Default True |
 | GRANT_ENABLE                           | Enable or disable grants. Default True           |
 | PUBLICATION_ENABLE                     | Enable or disable publications. Default True     |
-| PROJECT_CODE                                 | Specifies a custom internal project identifier. Default False, provide string value to enable.|  
+| PROJECT_CODE                                 | Specifies a custom internal project identifier. Default False, provide string value to enable.|
 | PROJECT_CODE_PADDING                         | Defines a optional padding value to be added before the Primary Key section of PROJECT_CODE. Default False, provide integer value to enable.|
-| PROJECT_INSTITUTION_EMAIL_MAP                | Defines a dictionary where PI domain email addresses are keys and their corresponding institutions are values. Default is False, provide key-value pairs to enable this feature.|  
+| PROJECT_INSTITUTION_EMAIL_MAP                | Defines a dictionary where PI domain email addresses are keys and their corresponding institutions are values. Default is False, provide key-value pairs to enable this feature.|
+| PROJECT_UPDATE_FIELDS                        | Defines a list of Project fields that project managers are able to update. Default is ['title', 'description', 'field_of_science']. |
 ### Database settings
 
 The following settings configure the database server to use, if not set will default to using SQLite:


### PR DESCRIPTION
This allows for center directors to configure which Project fields project managers are able to edit.

Closes #736.