### PR TITLE
UI fixes

### DIFF
--- a/coldfront/core/allocation/templates/allocation/allocation_change_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_change_detail.html
@@ -184,20 +184,17 @@ Allocation Change Detail
         <h3 class="d-inline"><i class="fas fa-info-circle" aria-hidden="true"></i> Actions</h3>
       </div>
       <div class="card-body">
-
-          
-            {% csrf_token %}
-            {{note_form.notes | as_crispy_field}}
-            <div style="float: right;">
-              {% if allocation_change.status.name == 'Pending' %}
-                <button type="submit" name="action" value="approve" class="btn btn-success mr-1">Approve</button>
-                <button type="submit" name="action" value="deny" class="btn btn-danger mr-1">Deny</button>
-              {% endif %}
-                <button type="submit" name="action" value="update" class="btn btn-primary float-right">
-                <i class="fas fa-sync" aria-hidden="true"></i> Update
-              </button>
-            </div>
-        </div>   
+        {% csrf_token %}
+        {{note_form.notes | as_crispy_field}}
+        <div class="d-inline float-right">
+          {% if allocation_change.status.name == 'Pending' %}
+            <button type="submit" name="action" value="approve" class="btn btn-success float-right ml-1">Approve</button>
+            <button type="submit" name="action" value="deny" class="btn btn-danger float-right ml-1">Deny</button>
+          {% endif %}
+            <button type="submit" name="action" value="update" class="btn btn-primary float-right">
+              <i class="fas fa-sync" aria-hidden="true"></i> Update
+            </button>
+        </div>
       </div>
     </div>
   {% endif %}

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -281,6 +281,13 @@ Allocation Detail
 <div class="card mb-3">
   <div class="card-header">
     <h3 class="d-inline"><i class="fas fa-info-circle" aria-hidden="true"></i> Allocation Change Requests</h3> <span class="badge badge-secondary">{{allocation_changes.count}}</span>
+    <div class="float-right">
+      {% if request.user.is_superuser and allocation.is_changeable and not allocation.is_locked and is_allowed_to_update_project and allocation.status.name in 'Active, Renewal Requested, Payment Pending, Payment Requested, Paid' %}
+        <a class="btn btn-primary float-right" href="{% url 'allocation-change' allocation.pk %}" role="button">
+          Request Change
+        </a>
+      {% endif %}
+    </div>
   </div>
   
   <div class="card-body">
@@ -311,7 +318,9 @@ Allocation Detail
                   {% else %}
                     <td></td>
                   {% endif %}
-                  <td><a href="{% url 'allocation-change-detail' change_request.pk %}"><i class="far fa-edit" aria-hidden="true"></i><span class="sr-only">Edit</span></a></td>
+                  {% if can_edit_allocation_changes %}
+                    <td><a href="{% url 'allocation-change-detail' change_request.pk %}"><i class="far fa-edit" aria-hidden="true"></i><span class="sr-only">Edit</span></a></td>
+                  {% endif %}
                 </tr>
             {% endfor %}
           </tbody>

--- a/coldfront/core/allocation/templates/allocation/allocation_remove_users.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_remove_users.html
@@ -48,7 +48,7 @@ Remove Users from Allocation
         {{ formset.management_form }}
         <div>
           <button type="submit" class="btn btn-primary">
-            <i class="fas fa-user-plus" aria-hidden="true"></i> Remove Selected Users from Allocation
+            <i class="fas fa-user-minus" aria-hidden="true"></i> Remove Selected Users from Allocation
           </button>
           <a class="btn btn-secondary" href="{% url 'allocation-detail' allocation.pk %}" role="button">
             <i class="fas fa-long-arrow-left" aria-hidden="true"></i> Back to Allocation

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -183,6 +183,12 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
         context["is_allowed_to_update_project"] = allocation_obj.project.has_perm(
             self.request.user, ProjectPermission.UPDATE
         )
+        # Can the user edit allocation change requests?
+        # condition was taken from core.allocation.views.AllocationChangeDetailView;
+        # maybe better to make a static method that test_func() in that class will call?
+        context["can_edit_allocation_changes"] = self.request.user.has_perm(
+            "allocation.can_view_all_allocations"
+        ) or allocation_obj.has_perm(self.request.user, AllocationPermission.MANAGER)
 
         noteset = allocation_obj.allocationusernote_set.select_related("author")
         notes = noteset.all() if self.request.user.is_superuser else noteset.filter(is_private=False)

--- a/coldfront/core/grant/templates/grant/grant_create.html
+++ b/coldfront/core/grant/templates/grant/grant_create.html
@@ -10,6 +10,7 @@ Create Grant
 
 
 {% block content %}
+<h2>Creating grant for project: {{ project.title }}</h2>
   <form method="post">{% csrf_token %}
     {{ form|crispy }}
     <input class="btn btn-primary" type="submit" value="Save" />

--- a/coldfront/core/grant/templates/grant/grant_update_form.html
+++ b/coldfront/core/grant/templates/grant/grant_update_form.html
@@ -9,6 +9,7 @@ Update Grant
 
 
 {% block content %}
+<h2>Updating grant for project: {{ project.title }}</h2>
 <form method="post">
   {% csrf_token %}
   {{ form|crispy }}

--- a/coldfront/core/portal/templates/portal/authorized_home.html
+++ b/coldfront/core/portal/templates/portal/authorized_home.html
@@ -13,7 +13,7 @@
       <ul class="list-group">
         {% for project in project_list %}
           <li class="list-group-item">
-            <a href="{% url 'project-detail' project.pk %}"><i class="fa fa-folder fa-lg" aria-hidden="true"></i>{{project.title}}</a>
+            <a href="{% url 'project-detail' project.pk %}"><i class="fa fa-folder fa-lg" aria-hidden="true"></i> {{project.title}}</a>
             {% if project.needs_review %}
               <a href="{% url 'project-review' project.pk %}"><span class="badge badge-warning">Needs Review</span></a>
             {% endif %}

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -487,7 +487,7 @@ Project Detail
 <!-- Start Admin Messages -->
 <div class="card mb-3">
   <div class="card-header">
-    <h3 class="d-inline"><i class="fas fa-users" aria-hidden="true"></i> Notifications </h3> <span class="badge badge-secondary">{{project.projectusermessage_set.count}}</span>
+    <h3 class="d-inline"><i class="fas fa-users" aria-hidden="true"></i> Notifications </h3> <span class="badge badge-secondary">{{notes.count}}</span>
     <div class="float-right">
       {% if request.user.is_superuser %}
         <a class="btn btn-success" href="{% url 'project-note-add' project.pk %}" role="button">
@@ -497,8 +497,7 @@ Project Detail
     </div>
   </div>
   <div class="card-body">
-    {% with project.projectusermessage_set.all as all_messages %}
-    {% if all_messages %}
+    {% if notes %}
       <div class="table-responsive">
         <table class="table table-hover">
           <thead>
@@ -509,7 +508,7 @@ Project Detail
             </tr>
           </thead>
           <tbody>
-            {% for message in all_messages %}
+            {% for message in notes %}
               {% if not message.is_private or request.user.is_superuser %}
             <tr>
               <td>{{ message.message }}</td>
@@ -524,7 +523,6 @@ Project Detail
     {% else %}
       <div class="alert alert-info" role="alert"><i class="fas fa-info-circle" aria-hidden="true"></i> There are no messages from system administrators.</div>
     {% endif %}
-    {% endwith %}
   </div>
 </div>
 <!-- End Admin Messages -->

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -198,6 +198,9 @@ class ProjectDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
             if allocation_user:
                 user_status.append(allocation_user.first().status.name)
 
+        note_set = project_obj.projectusermessage_set
+        notes = note_set.all() if self.request.user.is_superuser else note_set.filter(is_private=False)
+        context["notes"] = notes
         context["publications"] = (
             Publication.objects.select_related("source").filter(project=project_obj, status="Active").order_by("-year")
         )

--- a/coldfront/core/publication/templates/publication/publication_add_publication_search_result.html
+++ b/coldfront/core/publication/templates/publication/publication_add_publication_search_result.html
@@ -36,7 +36,7 @@
         </div>
         {{ formset.management_form }}
         <div>
-          <button type="submit" class="btn btn-primary"><i class="fas fa-user-minus" aria-hidden="true"></i> Add Selected Publications to Project</button>
+          <button type="submit" class="btn btn-primary"><i class="fas fa-plus" aria-hidden="true"></i> Add Selected Publications to Project</button>
           <a class="btn btn-secondary" href="{% url 'project-detail' project_pk %}" role="button"><i class="fas fa-long-arrow-left" aria-hidden="true"></i> Back to Project</a>
           <input id="search_ids" type="hidden" name="search_ids" value="{{search_ids}}">
           <input id="pubs" type="hidden" name="pubs" value="{{pubs}}">

--- a/coldfront/core/research_output/templates/research_output/research_output_create.html
+++ b/coldfront/core/research_output/templates/research_output/research_output_create.html
@@ -9,6 +9,7 @@ Create Research Output
 
 
 {% block content %}
+<h2>Creating research output for project: {{ project.title }}</h2>
 <form method="post">
   {% csrf_token %}
   {{ form|crispy }}


### PR DESCRIPTION
- Notifications badge on project detail page now only counts the number of notifications the user can see
- Allocation change request page's approve, deny, and update buttons now have consistent spacing
- Only users can edit a change request can see the edit button on the list in the allocation detail page
  - I took the condition from `test_func()` in `AllocationChangeDetailView` - maybe it's cleaner to have a static function in that class (such as `def can_view(user, allocation_obj)`) to call
- Add "Request Change" button to the allocation change requests section of the allocation detail page
- Add "Creating grant for project:" on grant creation page
- Add "Updating grant for project:" on grant update page
- Add "Adding research output for project:" research output page
- Change "Remove Selected Users from Allocation" button from `fa-user-plus` to `fa-user-minus`
- Changed "Add Selected Publications to Project" button from `fa-user-minus` to `fa-plus`
- Add a space between the folder icon and project title on the home page


Closes #739.