### PR TITLE
Tests for allocation model get_eula

### DIFF
--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -6,6 +6,7 @@
 
 import datetime
 from unittest.mock import patch
+from unittest import skip
 
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
@@ -287,3 +288,21 @@ class AllocationModelExpiresInTests(TestCase):
             allocation: Allocation = AllocationFactory(end_date=self.four_years_after_mocked_today)
 
             self.assertEqual(allocation.expires_in, days_in_four_years_including_leap_year)
+
+class AllocationModelGetEulaTests(TestCase):
+    def test_no_resources_with_eula_attribute_returns_none(self):
+        """Test that None is returned when there are no Resources associated with this allocation that have any ResourceAttributes with a ResourceAttributeType of 'eula'."""
+        allocation = AllocationFactory()
+
+    def test_only_resources_with_eula_for_other_allocations_returns_none(self):
+        """Test that None is returned when there are other allocations with eulas but this allocation does not have any Resources with a eula."""
+        ...
+
+    def test_one_resource_with_eula_returns_eula_resource_attribute_expanded_value(self):
+        """Test that when there is only one Resource with a eula ResourceAttribute associated with this allocation that thr expanded value for that ResourceAttribute is returned."""
+        ...
+
+    @skip("Currently no ordering is taking place, so the result when there are multiple will always be non-deterministic")
+    def test_multiple_resources_with_eula_returns_first_according_to_ordering(self):
+        """Test that when there are multiple resources with EULAs that they return the first ResourceAttribute according to the ordering."""
+        ...

--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -25,6 +25,7 @@ from coldfront.core.test_helpers.factories import (
     ResourceFactory,
     UserFactory,
 )
+import pickle
 
 
 class AllocationModelTests(TestCase):
@@ -150,7 +151,7 @@ class AllocationModelStrTests(TestCase):
     """Tests for Allocation.__str__"""
 
     def setUp(self):
-        self.allocation = AllocationFactory()
+        self.allocation= AllocationFactory()
         self.resource = ResourceFactory()
         self.allocation.resources.add(self.resource)
 
@@ -290,24 +291,45 @@ class AllocationModelExpiresInTests(TestCase):
             self.assertEqual(allocation.expires_in, days_in_four_years_including_leap_year)
 
 class AllocationModelGetEulaTests(TestCase):
-    def test_no_resources_with_eula_attribute_returns_none(self):
-        """Test that None is returned when there are no Resources associated with this allocation that have any ResourceAttributes with a ResourceAttributeType of 'eula'."""
+    def test_no_resources_with_eula_attribute_does_nothing(self):
+        """
+        Test that None is returned and no modifications are made to the Allocation when 
+        there are no Resources associated with this allocation that have 
+        any ResourceAttributes with a ResourceAttributeType of 'eula'.
+        """
         allocation = AllocationFactory()
+        magic_number = 10
+        for i in range(magic_number):
+            resource_attribute = ResourceAttributeFactory()
+
+        non_eula_resources = [ResourceFactory(name="eula") for i in range(magic_number)]
+
+        allocation.resources.add(*non_eula_resources)
+
+        before_state = pickle.dumps(allocation)
+
+        actual = allocation.get_eula()
+
+        after_state = pickle.dumps(allocation)
+
+        self.assertIsNone(actual)
+        self.assertEqual(before_state, after_state)
 
     def test_only_resources_with_eula_for_other_allocations_returns_none(self):
         """Test that None is returned when there are other allocations with eulas but this allocation does not have any Resources with a eula."""
         ...
 
     def test_one_resource_with_eula_returns_eula_resource_attribute_expanded_value(self):
-        """Test that when there is only one Resource with a eula ResourceAttribute associated with this allocation that thr expanded value for that ResourceAttribute is returned."""
-        resource = ResourceFactory()
-        resource_attributes = resource.resourceattribute_set.all()
-        print(len(resource_attributes))
-        for resource_attribute in resource_attributes:
-            attr_type = resource_attribute.resource_attribute_type
-            print(f"The resource_attribute was: {resource_attribute}")
-            print(f"The attr_type was: {attr_type}")
-            print()
+        """Test that when there is only one Resource with a eula ResourceAttribute associated with this allocation that the expanded value for that ResourceAttribute is returned."""
+        # resource = ResourceFactory()
+        # resource_attributes = resource.resourceattribute_set.all()
+        # print(len(resource_attributes))
+        # for resource_attribute in resource_attributes:
+        #     attr_type = resource_attribute.resource_attribute_type
+        #     print(f"The resource_attribute was: {resource_attribute}")
+        #     print(f"The attr_type was: {attr_type}")
+        #     print()
+        ...
 
     @skip("Currently no ordering is taking place, so the result when there are multiple will always be non-deterministic")
     def test_multiple_resources_with_eula_returns_first_according_to_ordering(self):

--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -296,9 +296,8 @@ class AllocationModelExpiresInTests(TestCase):
 class AllocationModelGetEulaTests(TestCase):
     def test_no_resources_with_eula_attribute_does_nothing(self):
         """
-        Test that None is returned and no modifications are made to the Allocation when
-        there are no Resources associated with this allocation that have
-        any ResourceAttributes with a ResourceAttributeType of 'eula'.
+        Test that None is returned when there are no Resources associated 
+        with this allocation that have any ResourceAttributes with a ResourceAttributeType of 'eula'.
         """
         allocation = AllocationFactory()
 
@@ -320,18 +319,17 @@ class AllocationModelGetEulaTests(TestCase):
 
     def test_only_resources_with_eula_for_other_allocations_returns_none(self):
         """
-        Test that None is returned and no modifications are made to the Allocation when
-        there are other allocations with eulas but this allocation does not have any
-        Resources with a eula.
+        Test that None is returned when there are other allocations with eulas but 
+        this allocation does not have any Resources with a eula.
         """
         num_eulas = 10
-        for _ in range(num_eulas):
+        for i in range(num_eulas):
             eula_resource = ResourceFactory()
             eula_resource_attribute_type = ResourceAttributeTypeFactory(name="eula")
             eula_resource_attribute = ResourceAttributeFactory(  # noqa: F841
                 resource=eula_resource, resource_attribute_type=eula_resource_attribute_type
             )
-            eula_allocation = AllocationFactory()
+            eula_allocation = AllocationFactory(name=f"eula allocation {i}")
             eula_allocation.resources.add(eula_resource)
 
         non_eula_resource = ResourceFactory()
@@ -339,7 +337,7 @@ class AllocationModelGetEulaTests(TestCase):
         non_eula_resource_attribute = ResourceAttributeFactory(  # noqa: F841
             resource=non_eula_resource, resource_attribute_type=non_eula_resource_attribute_type
         )
-        non_eula_allocation = AllocationFactory()
+        non_eula_allocation = AllocationFactory(name="No eula here.")
         non_eula_allocation.resources.add(non_eula_resource)
 
         actual = non_eula_allocation.get_eula()

--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -329,7 +329,7 @@ class AllocationModelGetEulaTests(TestCase):
             eula_resource_attribute = ResourceAttributeFactory(  # noqa: F841
                 resource=eula_resource, resource_attribute_type=eula_resource_attribute_type
             )
-            eula_allocation = AllocationFactory(name=f"eula allocation {i}")
+            eula_allocation = AllocationFactory(description=f"eula allocation {i}")
             eula_allocation.resources.add(eula_resource)
 
         non_eula_resource = ResourceFactory()
@@ -337,7 +337,7 @@ class AllocationModelGetEulaTests(TestCase):
         non_eula_resource_attribute = ResourceAttributeFactory(  # noqa: F841
             resource=non_eula_resource, resource_attribute_type=non_eula_resource_attribute_type
         )
-        non_eula_allocation = AllocationFactory(name="No eula here.")
+        non_eula_allocation = AllocationFactory(description="No eula here.")
         non_eula_allocation.resources.add(non_eula_resource)
 
         actual = non_eula_allocation.get_eula()

--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -296,7 +296,7 @@ class AllocationModelExpiresInTests(TestCase):
 class AllocationModelGetEulaTests(TestCase):
     def test_no_resources_with_eula_attribute_does_nothing(self):
         """
-        Test that None is returned when there are no Resources associated 
+        Test that None is returned when there are no Resources associated
         with this allocation that have any ResourceAttributes with a ResourceAttributeType of 'eula'.
         """
         allocation = AllocationFactory()
@@ -319,7 +319,7 @@ class AllocationModelGetEulaTests(TestCase):
 
     def test_only_resources_with_eula_for_other_allocations_returns_none(self):
         """
-        Test that None is returned when there are other allocations with eulas but 
+        Test that None is returned when there are other allocations with eulas but
         this allocation does not have any Resources with a eula.
         """
         num_eulas = 10

--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -300,7 +300,14 @@ class AllocationModelGetEulaTests(TestCase):
 
     def test_one_resource_with_eula_returns_eula_resource_attribute_expanded_value(self):
         """Test that when there is only one Resource with a eula ResourceAttribute associated with this allocation that thr expanded value for that ResourceAttribute is returned."""
-        ...
+        resource = ResourceFactory()
+        resource_attributes = resource.resourceattribute_set.all()
+        print(len(resource_attributes))
+        for resource_attribute in resource_attributes:
+            attr_type = resource_attribute.resource_attribute_type
+            print(f"The resource_attribute was: {resource_attribute}")
+            print(f"The attr_type was: {attr_type}")
+            print()
 
     @skip("Currently no ordering is taking place, so the result when there are multiple will always be non-deterministic")
     def test_multiple_resources_with_eula_returns_first_according_to_ordering(self):


### PR DESCRIPTION
This PR adds tests for the `get_eula` method and also adds new factories for many of the models i the resource app that were necessary for testing `get_eula`. This will be left as a draft PR until #727 is merged since I want to use some of that infrastructure for these tests. 