### PR TITLE
Removed '| safe' usages in templates.

### DIFF
--- a/coldfront/core/allocation/templates/allocation/allocation_create.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_create.html
@@ -60,11 +60,16 @@ Request New Allocation
   </div>
 </div>
 
+{{ resources_form_default_quantities|json_script:"resources-form-default-quantities" }}
+{{ resources_form_label_texts|json_script:"resources-form-label-texts" }}
+{{ resources_with_accounts|json_script:"resources-with-accounts" }}
+{{ resources_with_eula|json_script:"resources-with-eula" }}
+
 <script>
-  var resources_form_default_quantities = {{ resources_form_default_quantities | safe }};
-  var resources_form_label_texts = {{ resources_form_label_texts | safe }};
-  var resources_with_accounts = {{ resources_with_accounts | safe }};
-  var resources_with_eula = {{ resources_with_eula | safe }};
+  var resources_form_default_quantities = JSON.parse(document.getElementById('resources-form-default-quantities').textContent);
+  var resources_form_label_texts = JSON.parse(document.getElementById('resources-form-label-texts').textContent);
+  var resources_with_accounts = JSON.parse(document.getElementById('resources-with-accounts').textContent);
+  var resources_with_eula = JSON.parse(document.getElementById('resources-with-eula').textContent);
 
   $(document).ready(function () {
     $('<br><input id="selectAll" class="check" type="checkbox"> <strong>Select All Users</strong>').insertAfter($("#div_id_users > label"))

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -420,9 +420,12 @@ Allocation Detail
 </div>
 {% endif %}
 
+{{ guage_data|json_script:"guage-data" }}
+
+
 <script>
   $(document).ready(function () {
-    var guage_data = {{ guage_data | safe }};
+    var guage_data = JSON.parse(document.getElementById('guage-data').textContent);
     drawGauges(guage_data);
 
     $('#allocation_change_table').DataTable({

--- a/coldfront/core/allocation/templates/allocation/allocation_renew.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_renew.html
@@ -89,8 +89,11 @@ Renew Allocation
   </div>
 </div>
 
+{{ resource_eula|json_script:"resource-eula" }}
+
+
 <script>
-  var resource_eula = {{ resource_eula | safe }};
+  var resource_eula = JSON.parse(document.getElementById('resource-eula').textContent);
 
   $(document).ready(function () {
     if (resource_eula['eula']) {

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -18,7 +18,7 @@ from django.forms import formset_factory
 from django.http import HttpResponseBadRequest, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse, reverse_lazy
-from django.utils.html import format_html, mark_safe
+from django.utils.html import format_html
 from django.views import View
 from django.views.generic import ListView, TemplateView
 from django.views.generic.edit import CreateView, FormView, UpdateView
@@ -640,7 +640,7 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                     if attr_name == "quantity_default_value":
                         resources_form_default_quantities[resource.id] = int(value)
                     if attr_name == "quantity_label":
-                        resources_form_label_texts[resource.id] = mark_safe(f"<strong>{value}*</strong>")
+                        resources_form_label_texts[resource.id] = value
                     if attr_name == "eula":
                         resources_with_eula[resource.id] = value
 

--- a/coldfront/core/portal/templates/portal/allocation_summary.html
+++ b/coldfront/core/portal/templates/portal/allocation_summary.html
@@ -27,6 +27,10 @@
 </div>
 <!-- End Allocation Charts -->
 
+{{ allocations_chart_data|json_script:"allocations-chart-data" }}
+{{ resources_chart_data|json_script:"resources-chart-data" }}
+
+
 <script>
   $(document).ready(function () {
     drawAllocations();
@@ -70,6 +74,6 @@
     });
   }
 
-  var allocations_chart_data = {{ allocations_chart_data | safe }}
-  var resources_chart_data = {{ resources_chart_data | safe }}
+  var allocations_chart_data = JSON.parse(document.getElementById('allocations-chart-data').textContent);
+  var resources_chart_data = JSON.parse(document.getElementById('resources-chart-data').textContent);
 </script>

--- a/coldfront/core/portal/templates/portal/center_summary.html
+++ b/coldfront/core/portal/templates/portal/center_summary.html
@@ -87,6 +87,10 @@ Center Summary
 </div>
 <!-- End Allocation Charts -->
 
+{{ grants_agency_chart_data|json_script:"grants-agency-chart-data" }}
+{{ publication_by_year_bar_chart_data|json_script:"publication-by-year-bar-chart-data" }}
+
+
 <script>
   $("#navbar-main > ul > li.active").removeClass("active")
   $("#navbar-center-summary").addClass("active")
@@ -150,8 +154,8 @@ Center Summary
     }
   }
 
-  var grants_agency_chart_data = {{ grants_agency_chart_data | safe }}
-  var publication_by_year_bar_chart_data = {{ publication_by_year_bar_chart_data | safe }}
+  var grants_agency_chart_data = JSON.parse(document.getElementById('grants-agency-chart-data').textContent);
+  var publication_by_year_bar_chart_data = JSON.parse(document.getElementById('publication-by-year-bar-chart-data').textContent);
 
   function get_allocation_summary() {
     $.ajax({

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -518,6 +518,7 @@ Project Detail
   </div>
 </div>
 <!-- End Admin Messages -->
+{{ guage_data|json_script:"guage-data" }}
 
 <script>
   function getCookie(name) {
@@ -539,7 +540,7 @@ Project Detail
   $(document).ready(function(){
     $('[data-toggle="popover"]').popover();
 
-    var guage_data = {{ guage_data | safe }};
+    var guage_data = JSON.parse(document.getElementById('guage-data').textContent);
     drawGauges(guage_data);
 
     $('#publication-table').DataTable({

--- a/coldfront/core/utils/templatetags/common_tags.py
+++ b/coldfront/core/utils/templatetags/common_tags.py
@@ -19,7 +19,8 @@ def settings_value(name):
         "CENTER_HELP_URL",
         "EMAIL_PROJECT_REVIEW_CONTACT",
     ]
-    return mark_safe(getattr(settings, name, "") if name in allowed_names else "")
+    # FIXME: This is using mark_safe for now but settings should not contain HTML in the future
+    return mark_safe(getattr(settings, name, "") if name in allowed_names else "")  # noqa: S308
 
 
 @register.filter

--- a/coldfront/plugins/system_monitor/templates/system_monitor/system_monitor_div.html
+++ b/coldfront/plugins/system_monitor/templates/system_monitor/system_monitor_div.html
@@ -36,6 +36,8 @@
 
 <!-- End System Monitor -->
 
+{{ utilization_data|json_script:"utilization-data"}}
+{{ jobs_data|json_script:"jobs-data" }}
 
 <script>
     
@@ -44,8 +46,8 @@
         drawJobs();
     });
 
-    var utilization_data = {{ utilization_data | safe }};
-    var jobs_data = {{ jobs_data | safe }};
+    var utilization_data = JSON.parse(document.getElementById('utilization-data').textContent);
+    var jobs_data = JSON.parse(document.getElementById('jobs-data').textContent);
 
     function drawUtilization() {
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ indent-width = 4
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I"]
+select = ["E4", "E7", "E9", "F", "I", "S308"]
 
 [tool.ruff.format]
 indent-style = "space"


### PR DESCRIPTION
This remediates at least one (and possibly more) minor XSS exploits caused by usage of `| safe` template markings when used inside of script tags. This has been remediated by placing all template-injected JavaScript data into `json_script` template tags and then loading that JSON data inside of scripts using `JSON.parse()`. 

As part of this pull request, markup was removed from `AllocationCreateView` that caused the value of `quantity_label` to be marked as `<strong></strong>` . 

This also introduces a new ruff linter check for "S308" checking improper usage of safe HTML injection into templates: https://docs.astral.sh/ruff/rules/suspicious-mark-safe-usage/. 

Pull request #734 needs to be merged in first. These pull requests address similair issues. This PR will not pass ruff unless #734 is merged. 