### PR TITLE
Tried to INP ruff check and fix test case in slurm plugin.

### DIFF
--- a/coldfront/core/test_helpers/__init__.py
+++ b/coldfront/core/test_helpers/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/coldfront/plugins/slurm/tests/__init__.py
+++ b/coldfront/plugins/slurm/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/coldfront/plugins/slurm/tests/test_associations.py
+++ b/coldfront/plugins/slurm/tests/test_associations.py
@@ -19,7 +19,7 @@ class AssociationTest(TestCase):
         call_command("import_field_of_science_data")
         call_command("add_default_grant_options")
         call_command("add_default_project_choices")
-        call_command("add_default_allocation_choices")
+        call_command("add_allocation_defaults")
         call_command("add_default_publication_sources")
         super(AssociationTest, cls).setUpClass()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ indent-width = 4
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I"]
+select = ["E4", "E7", "E9", "F", "I", "INP"]
 
 [tool.ruff.format]
 indent-style = "space"


### PR DESCRIPTION
Adding the INP rule flagged the fact that the tests in the slurm plugin where not being ran because they were moved into a directory without an `__init__.py`. Once I ran the test suite the test failed, but I fixed the initial problem which seemed to just be that a management command had been renamed. 

However, now the test suite still fails because it cannot create a test fixture that relies on a file `test_data.json` that is not present.