### PR TITLE
Ruff check for Q. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,22 @@ indent-width = 4
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "S308"]
+select = [
+    "E4", 
+    "E7", 
+    "E9", 
+    "F", 
+    "I", 
+    "S308", 
+    "Q",
+]
+
+[tool.ruff.lint.flake8-quotes]
+avoid-escape = true
+docstring-quotes = "double"
+inline-quotes = "double"
+multiline-quotes = "double"
+
 
 [tool.ruff.format]
 indent-style = "space"


### PR DESCRIPTION
Used ColdFront's pre-existing style which used double quotes for everything.