### PR TITLE
ruff check for UP. Fixed code to comply with the UP linter rules.

### DIFF
--- a/coldfront/core/allocation/admin.py
+++ b/coldfront/core/allocation/admin.py
@@ -255,11 +255,7 @@ class AllocationAttributeAdmin(SimpleHistoryAdmin):
         return obj.allocation.status
 
     def pi(self, obj):
-        return "{} {} ({})".format(
-            obj.allocation.project.pi.first_name,
-            obj.allocation.project.pi.last_name,
-            obj.allocation.project.pi.username,
-        )
+        return f"{obj.allocation.project.pi.first_name} {obj.allocation.project.pi.last_name} ({obj.allocation.project.pi.username})"
 
     def project(self, obj):
         return textwrap.shorten(obj.allocation.project.title, width=50)
@@ -339,7 +335,7 @@ class AllocationUserAdmin(SimpleHistoryAdmin):
         return obj.allocation.status
 
     def user_info(self, obj):
-        return "{} {} ({})".format(obj.user.first_name, obj.user.last_name, obj.user.username)
+        return f"{obj.user.first_name} {obj.user.last_name} ({obj.user.username})"
 
     def resource(self, obj):
         return obj.allocation.resources.first()

--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -309,7 +309,7 @@ class AllocationAttributeEditForm(forms.Form):
 class AllocationChangeForm(forms.Form):
     EXTENSION_CHOICES = [(0, "No Extension")]
     for choice in ALLOCATION_CHANGE_REQUEST_EXTENSION_DAYS:
-        EXTENSION_CHOICES.append((choice, "{} days".format(choice)))
+        EXTENSION_CHOICES.append((choice, f"{choice} days"))
 
     end_date_extension = forms.TypedChoiceField(
         label="Request End Date Extension",
@@ -345,7 +345,7 @@ class AllocationAttributeCreateForm(forms.ModelForm):
         fields = "__all__"
 
     def __init__(self, *args, **kwargs):
-        super(AllocationAttributeCreateForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields["allocation_attribute_type"].queryset = self.fields["allocation_attribute_type"].queryset.order_by(
             Lower("name")
         )

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -352,7 +352,7 @@ class Allocation(TimeStampedModel):
         return perm in perms
 
     def __str__(self):
-        return "%s (%s)" % (self.get_parent_resource.name, self.project.pi)
+        return f"{self.get_parent_resource.name} ({self.project.pi})"
 
     def get_eula(self):
         if self.get_resources_as_list:
@@ -536,7 +536,7 @@ class AllocationAttributeType(TimeStampedModel):
     history = HistoricalRecords()
 
     def __str__(self):
-        return "%s" % (self.name)
+        return f"{self.name}"
 
     class Meta:
         ordering = [
@@ -577,9 +577,7 @@ class AllocationAttribute(TimeStampedModel):
             .exclude(id=self.pk)
             .exists()
         ):
-            raise ValidationError(
-                "'{}' attribute already exists for this allocation.".format(self.allocation_attribute_type)
-            )
+            raise ValidationError(f"'{self.allocation_attribute_type}' attribute already exists for this allocation.")
 
         expected_value_type = self.allocation_attribute_type.attribute_type.name.strip()
 
@@ -594,7 +592,7 @@ class AllocationAttribute(TimeStampedModel):
             validator.validate_date()
 
     def __str__(self):
-        return "%s" % (self.allocation_attribute_type.name)
+        return f"{self.allocation_attribute_type.name}"
 
     def typed_value(self):
         """
@@ -664,7 +662,7 @@ class AllocationAttributeUsage(TimeStampedModel):
     history = HistoricalRecords()
 
     def __str__(self):
-        return "{}: {}".format(self.allocation_attribute.allocation_attribute_type.name, self.value)
+        return f"{self.allocation_attribute.allocation_attribute_type.name}: {self.value}"
 
 
 class AllocationUserStatusChoice(TimeStampedModel):
@@ -723,7 +721,7 @@ class AllocationUser(TimeStampedModel):
         return self.status.name == "Active" and self.allocation.status.name in active_allocation_statuses
 
     def __str__(self):
-        return "%s" % (self.user)
+        return f"{self.user}"
 
     class Meta:
         verbose_name_plural = "Allocation User Status"
@@ -803,7 +801,7 @@ class AllocationChangeRequest(TimeStampedModel):
             return self.allocation.resources.filter(is_allocatable=True).first()
 
     def __str__(self):
-        return "%s (%s)" % (self.get_parent_resource.name, self.allocation.project.pi)
+        return f"{self.get_parent_resource.name} ({self.allocation.project.pi})"
 
     def get_absolute_url(self):
         return reverse("allocation-change-detail", kwargs={"pk": self.pk})
@@ -824,4 +822,4 @@ class AllocationAttributeChangeRequest(TimeStampedModel):
     history = HistoricalRecords()
 
     def __str__(self):
-        return "%s" % (self.allocation_attribute.allocation_attribute_type.name)
+        return f"{self.allocation_attribute.allocation_attribute_type.name}"

--- a/coldfront/core/allocation/tasks.py
+++ b/coldfront/core/allocation/tasks.py
@@ -50,7 +50,7 @@ def update_statuses():
         sub_obj.status = expired_status_choice
         sub_obj.save()
 
-    logger.info("Allocations set to expired: {}".format(allocations_to_expire.count()))
+    logger.info(f"Allocations set to expired: {allocations_to_expire.count()}")
 
 
 def send_eula_reminders():

--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -43,7 +43,7 @@ class AllocationModelTests(TestCase):
 
     def test_allocation_str(self):
         """test that allocation str method returns correct string"""
-        allocation_str = "%s (%s)" % (self.allocation.get_parent_resource.name, self.allocation.project.pi)
+        allocation_str = f"{self.allocation.get_parent_resource.name} ({self.allocation.project.pi})"
         self.assertEqual(str(self.allocation), allocation_str)
 
 

--- a/coldfront/core/allocation/tests/test_views.py
+++ b/coldfront/core/allocation/tests/test_views.py
@@ -96,7 +96,7 @@ class AllocationListViewTest(AllocationViewBaseTest):
     @classmethod
     def setUpTestData(cls):
         """Set up users and project for testing"""
-        super(AllocationListViewTest, cls).setUpTestData()
+        super().setUpTestData()
         cls.additional_allocations = [AllocationFactory() for i in list(range(100))]
         for allocation in cls.additional_allocations:
             allocation.resources.add(ResourceFactory(name="holylfs09/tier1"))

--- a/coldfront/core/allocation/utils.py
+++ b/coldfront/core/allocation/utils.py
@@ -16,7 +16,7 @@ def set_allocation_user_status_to_error(allocation_user_pk):
 
 
 def generate_guauge_data_from_usage(name, value, usage):
-    label = "%s: %.2f of %.2f" % (name, usage, value)
+    label = f"{name}: {usage:.2f} of {value:.2f}"
 
     try:
         percent = (usage / value) * 100

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -323,12 +323,7 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
         if action == "auto-approve":
             messages.success(
                 request,
-                "Allocation to {} has been ACTIVATED for {} {} ({})".format(
-                    allocation_obj.get_parent_resource,
-                    allocation_obj.project.pi.first_name,
-                    allocation_obj.project.pi.last_name,
-                    allocation_obj.project.pi.username,
-                ),
+                f"Allocation to {allocation_obj.get_parent_resource} has been ACTIVATED for {allocation_obj.project.pi.first_name} {allocation_obj.project.pi.last_name} ({allocation_obj.project.pi.username})",
             )
             return HttpResponseRedirect(reverse("allocation-request-list"))
 
@@ -573,7 +568,7 @@ class AllocationListView(LoginRequiredMixin, ListView):
         order_by = self.request.GET.get("order_by")
         if order_by:
             direction = self.request.GET.get("direction")
-            filter_parameters_with_order_by = filter_parameters + "order_by=%s&direction=%s&" % (order_by, direction)
+            filter_parameters_with_order_by = filter_parameters + f"order_by={order_by}&direction={direction}&"
         else:
             filter_parameters_with_order_by = filter_parameters
 
@@ -1699,12 +1694,7 @@ class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormVi
 
             messages.success(
                 request,
-                "Allocation change request to {} has been DENIED for {} {} ({})".format(
-                    allocation_change_obj.allocation.resources.first(),
-                    allocation_change_obj.allocation.project.pi.first_name,
-                    allocation_change_obj.allocation.project.pi.last_name,
-                    allocation_change_obj.allocation.project.pi.username,
-                ),
+                f"Allocation change request to {allocation_change_obj.allocation.resources.first()} has been DENIED for {allocation_change_obj.allocation.project.pi.first_name} {allocation_change_obj.allocation.project.pi.last_name} ({allocation_change_obj.allocation.project.pi.username})",
             )
 
             send_allocation_customer_email(
@@ -1784,12 +1774,7 @@ class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormVi
 
             messages.success(
                 request,
-                "Allocation change request to {} has been APPROVED for {} {} ({})".format(
-                    allocation_change_obj.allocation.get_parent_resource,
-                    allocation_change_obj.allocation.project.pi.first_name,
-                    allocation_change_obj.allocation.project.pi.last_name,
-                    allocation_change_obj.allocation.project.pi.username,
-                ),
+                f"Allocation change request to {allocation_change_obj.allocation.get_parent_resource} has been APPROVED for {allocation_change_obj.allocation.project.pi.first_name} {allocation_change_obj.allocation.project.pi.last_name} ({allocation_change_obj.allocation.project.pi.username})",
             )
 
             allocation_change_approved.send(

--- a/coldfront/core/attribute_expansion.py
+++ b/coldfront/core/attribute_expansion.py
@@ -44,7 +44,7 @@ def get_attriblist_str(attribute_name, resources=[], allocations=[]):
     attriblist attributes are found, we return None.
     """
 
-    attriblist_name = "{aname}{suffix}".format(aname=attribute_name, suffix=ATTRIBUTE_EXPANSION_ATTRIBLIST_SUFFIX)
+    attriblist_name = f"{attribute_name}{ATTRIBUTE_EXPANSION_ATTRIBLIST_SUFFIX}"
     attriblist = None
 
     # Check resources first
@@ -115,9 +115,7 @@ def get_attribute_parameter_value(argument, attribute_parameter_dict, error_text
         else:
             # Bad string literal
             logger.warning(
-                "Bad string literal '{}' found while processing {}; missing final single quote".format(
-                    argument, error_text
-                )
+                f"Bad string literal '{argument}' found while processing {error_text}; missing final single quote"
             )
             return None
 
@@ -167,11 +165,7 @@ def get_attribute_parameter_value(argument, attribute_parameter_dict, error_text
             value = float(argument)
             return value
         except ValueError:
-            logger.warning(
-                "Unable to evaluate argument '{arg}' while processing {etxt}, returning None".format(
-                    arg=argument, etxt=error_text
-                )
-            )
+            logger.warning(f"Unable to evaluate argument '{argument}' while processing {error_text}, returning None")
             return None
 
     # Should not reach here
@@ -214,12 +208,12 @@ def process_attribute_parameter_operation(opcode, oldvalue, argument, error_text
     """
     # Argument should never be None
     if argument is None:
-        logger.warning("Operator {}= acting on None argument in {}, returning None".format(opcode, error_text))
+        logger.warning(f"Operator {opcode}= acting on None argument in {error_text}, returning None")
         return None
     # Assignment and default operations allow oldvalue to be None
     if oldvalue is None:
         if opcode != ":" and opcode != "|":
-            logger.warning("Operator {}= acting on oldvalue=None in {}, returning None".format(opcode, error_text))
+            logger.warning(f"Operator {opcode}= acting on oldvalue=None in {error_text}, returning None")
             return None
 
     try:
@@ -242,9 +236,7 @@ def process_attribute_parameter_operation(opcode, oldvalue, argument, error_text
                 return newval
             else:
                 logger.warning(
-                    "Operator {}= acting on parameter of type {} in {}, returning None".format(
-                        opcode, type(oldvalue), error_text
-                    )
+                    f"Operator {opcode}= acting on parameter of type {type(oldvalue)} in {error_text}, returning None"
                 )
                 return None
         if opcode == "-":
@@ -260,17 +252,13 @@ def process_attribute_parameter_operation(opcode, oldvalue, argument, error_text
             if argument == "floor":
                 newval = math.floor(oldvalue)
             else:
-                logger.error(
-                    "Unrecognized function named {} in {}= for {}, returning None".format(argument, opcode, error_text)
-                )
+                logger.error(f"Unrecognized function named {argument} in {opcode}= for {error_text}, returning None")
                 return None
         # If reached here, we do not recognize opcode
-        logger.error("Unrecognized operation {}= in {}, returning None".format(opcode, error_text))
+        logger.error(f"Unrecognized operation {opcode}= in {error_text}, returning None")
     except Exception:
         logger.warning(
-            "Error performing operator {op}= on oldvalue='{old}' and argument={arg} in {errtext}".format(
-                op=opcode, old=oldvalue, arg=argument, errtext=error_text
-            )
+            f"Error performing operator {opcode}= on oldvalue='{oldvalue}' and argument={argument} in {error_text}"
         )
         return None
 
@@ -320,9 +308,9 @@ def process_attribute_parameter_string(
         # No '=' found, so invalid format of parmstr
         # Log error and return unmodified attribute_parameter_dict
         logger.error(
-            "Invalid parameter string '{pstr}', no '=', while "
+            f"Invalid parameter string '{parameter_string}', no '=', while "
             "creating attribute parameter dictionary for expanding "
-            "attribute {aname}".format(aname=attribute_name, pstr=parameter_string)
+            f"attribute {attribute_name}"
         )
         return attribute_parameter_dict
     pname = tmp[0]
@@ -338,8 +326,8 @@ def process_attribute_parameter_string(
         value = argument
     else:
         # Extra text to display in diagnostics if error occurs
-        error_text = "processing attribute_parameter_string={pstr} for expansion of attribute {aname}".format(
-            pstr=parameter_string, aname=attribute_name
+        error_text = (
+            f"processing attribute_parameter_string={parameter_string} for expansion of attribute {attribute_name}"
         )
         value = get_attribute_parameter_value(
             argument=argument,
@@ -463,7 +451,7 @@ def expand_attribute(raw_value, attribute_name, attriblist_string, resources=[],
         # referencing a parameter not defined in apdict to divide by
         # zero errors in processing apdict.  We just log it and then
         # return raw_value
-        logger.error("Error expanding {aname}: {error}".format(aname=attribute_name, error=xcept))
+        logger.error(f"Error expanding {attribute_name}: {xcept}")
         return raw_value
 
 
@@ -485,7 +473,7 @@ def convert_type(value, type_name, error_text="unknown"):
     future "Attribute Expanded ..." types.
     """
     if type_name is None:
-        logger.error("No AttributeType found for {}".format(error_text))
+        logger.error(f"No AttributeType found for {error_text}")
         return value
 
     if type_name.endswith("Text"):

--- a/coldfront/core/field_of_science/management/commands/import_field_of_science_data.py
+++ b/coldfront/core/field_of_science/management/commands/import_field_of_science_data.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         self.stdout.write("Adding field of science ...")
         file_path = os.path.join(app_commands_dir, "data", "field_of_science_data.csv")
         FieldOfScience.objects.all().delete()
-        with open(file_path, "r") as fp:
+        with open(file_path) as fp:
             for line in fp:
                 pk, parent_id, is_selectable, description, fos_nsf_id, fos_nsf_abbrev, directorate_fos_id = (
                     line.strip().split("\t")

--- a/coldfront/core/grant/admin.py
+++ b/coldfront/core/grant/admin.py
@@ -58,7 +58,7 @@ class GrantAdmin(SimpleHistoryAdmin):
     ]
 
     def Project_PI(self, obj):
-        return "{} {} ({})".format(obj.project.pi.first_name, obj.project.pi.last_name, obj.project.pi.username)
+        return f"{obj.project.pi.first_name} {obj.project.pi.last_name} ({obj.project.pi.username})"
 
     def Funding_Agency(self, obj):
         if obj.funding_agency.name == "Other":

--- a/coldfront/core/grant/forms.py
+++ b/coldfront/core/grant/forms.py
@@ -18,19 +18,17 @@ class GrantForm(ModelForm):
             "project",
         ]
         labels = {
-            "percent_credit": "Percent credit to {}".format(CENTER_NAME),
-            "direct_funding": "Direct funding to {}".format(CENTER_NAME),
+            "percent_credit": f"Percent credit to {CENTER_NAME}",
+            "direct_funding": f"Direct funding to {CENTER_NAME}",
         }
         help_texts = {
             "percent_credit": "Percent credit as entered in the sponsored projects form for grant submission as financial credit to the department/unit in the credit distribution section. Enter only digits, decimals, percent symbols, or spaces.",
-            "direct_funding": "Funds budgeted specifically for {} services, hardware, software, and/or personnel. Enter only digits, decimals, commas, dollar signs, or spaces.".format(
-                CENTER_NAME
-            ),
+            "direct_funding": f"Funds budgeted specifically for {CENTER_NAME} services, hardware, software, and/or personnel. Enter only digits, decimals, commas, dollar signs, or spaces.",
             "total_amount_awarded": "Enter only digits, decimals, commas, dollar signs, or spaces.",
         }
 
     def __init__(self, *args, **kwargs):
-        super(GrantForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields["funding_agency"].queryset = self.fields["funding_agency"].queryset.order_by("name")
         self.fields["grant_start"].widget.attrs["class"] = "datepicker"
         self.fields["grant_end"].widget.attrs["class"] = "datepicker"

--- a/coldfront/core/grant/models.py
+++ b/coldfront/core/grant/models.py
@@ -152,7 +152,7 @@ class Grant(TimeStampedModel):
         """
 
         if self.role == "PI":
-            return "{} {}".format(self.project.pi.first_name, self.project.pi.last_name)
+            return f"{self.project.pi.first_name} {self.project.pi.last_name}"
         else:
             return self.grant_pi_full_name
 

--- a/coldfront/core/grant/views.py
+++ b/coldfront/core/grant/views.py
@@ -191,7 +191,7 @@ class GrantDeleteGrantsView(LoginRequiredMixin, UserPassesTestMixin, TemplateVie
                     grant_obj.delete()
                     grants_deleted_count += 1
 
-            messages.success(request, "Deleted {} grants from project.".format(grants_deleted_count))
+            messages.success(request, f"Deleted {grants_deleted_count} grants from project.")
         else:
             for error in formset.errors:
                 messages.error(request, error)

--- a/coldfront/core/project/admin.py
+++ b/coldfront/core/project/admin.py
@@ -77,10 +77,10 @@ class ProjectUserAdmin(SimpleHistoryAdmin):
         return textwrap.shorten(obj.project.title, width=50)
 
     def PI(self, obj):
-        return "{} {} ({})".format(obj.project.pi.first_name, obj.project.pi.last_name, obj.project.pi.username)
+        return f"{obj.project.pi.first_name} {obj.project.pi.last_name} ({obj.project.pi.username})"
 
     def User(self, obj):
-        return "{} {} ({})".format(obj.user.first_name, obj.user.last_name, obj.user.username)
+        return f"{obj.user.first_name} {obj.user.last_name} ({obj.user.username})"
 
     def get_fields(self, request, obj):
         if obj is None:
@@ -229,7 +229,7 @@ class ProjectAttributeAdmin(SimpleHistoryAdmin):
         return obj.project.status
 
     def pi(self, obj):
-        return "{} {} ({})".format(obj.project.pi.first_name, obj.project.pi.last_name, obj.project.pi.username)
+        return f"{obj.project.pi.first_name} {obj.project.pi.last_name} ({obj.project.pi.username})"
 
     def project(self, obj):
         return textwrap.shorten(obj.project.title, width=50)
@@ -341,7 +341,7 @@ class ProjectAdmin(SimpleHistoryAdmin):
     ]
 
     def PI(self, obj):
-        return "{} {} ({})".format(obj.pi.first_name, obj.pi.last_name, obj.pi.username)
+        return f"{obj.pi.first_name} {obj.pi.last_name} ({obj.pi.username})"
 
     def get_fields(self, request, obj):
         if obj is None:
@@ -398,4 +398,4 @@ class ProjectReviewAdmin(SimpleHistoryAdmin):
     list_filter = ("status",)
 
     def PI(self, obj):
-        return "{} {} ({})".format(obj.project.pi.first_name, obj.project.pi.last_name, obj.project.pi.username)
+        return f"{obj.project.pi.first_name} {obj.project.pi.last_name} ({obj.project.pi.username})"

--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -110,11 +110,9 @@ class ProjectReviewEmailForm(forms.Form):
     def __init__(self, pk, *args, **kwargs):
         super().__init__(*args, **kwargs)
         project_review_obj = get_object_or_404(ProjectReview, pk=int(pk))
-        self.fields["email_body"].initial = "Dear {} {} \n{}".format(
-            project_review_obj.project.pi.first_name,
-            project_review_obj.project.pi.last_name,
-            EMAIL_DIRECTOR_PENDING_PROJECT_REVIEW_EMAIL,
-        )
+        self.fields[
+            "email_body"
+        ].initial = f"Dear {project_review_obj.project.pi.first_name} {project_review_obj.project.pi.last_name} \n{EMAIL_DIRECTOR_PENDING_PROJECT_REVIEW_EMAIL}"
         self.fields["cc"].initial = ", ".join([EMAIL_DIRECTOR_EMAIL_ADDRESS] + EMAIL_ADMIN_LIST)
 
 
@@ -127,7 +125,7 @@ class ProjectAttributeAddForm(forms.ModelForm):
         }
 
     def __init__(self, *args, **kwargs):
-        super(ProjectAttributeAddForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         user = kwargs.get("initial").get("user")
         queryset = self.fields["proj_attr_type"].queryset.select_related("attribute_type").order_by(Lower("name"))
         self.fields["proj_attr_type"].queryset = queryset if user.is_superuser else queryset.filter(is_private=False)
@@ -187,5 +185,5 @@ class ProjectCreationForm(forms.ModelForm):
         fields = ["title", "description", "field_of_science"]
 
     def __init__(self, *args, **kwargs):
-        super(ProjectCreationForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields["field_of_science"].widget.attrs["class"] = "fos-select2"

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -471,7 +471,7 @@ class ProjectUser(TimeStampedModel):
     history = HistoricalRecords()
 
     def __str__(self):
-        return "%s %s (%s)" % (self.user.first_name, self.user.last_name, self.user.username)
+        return f"{self.user.first_name} {self.user.last_name} ({self.user.username})"
 
     class Meta:
         unique_together = ("user", "project")
@@ -519,7 +519,7 @@ class ProjectAttributeType(TimeStampedModel):
     history = HistoricalRecords()
 
     def __str__(self):
-        return "%s (%s)" % (self.name, self.attribute_type.name)
+        return f"{self.name} ({self.attribute_type.name})"
 
     def __repr__(self) -> str:
         return str(self)
@@ -559,7 +559,7 @@ class ProjectAttribute(TimeStampedModel):
             .exclude(pk=self.pk)
             .exists()
         ):
-            raise ValidationError("'{}' attribute already exists for this project.".format(self.proj_attr_type))
+            raise ValidationError(f"'{self.proj_attr_type}' attribute already exists for this project.")
 
         expected_value_type = self.proj_attr_type.attribute_type.name.strip()
 
@@ -575,7 +575,7 @@ class ProjectAttribute(TimeStampedModel):
             validator.validate_date()
 
     def __str__(self):
-        return "%s" % (self.proj_attr_type.name)
+        return f"{self.proj_attr_type.name}"
 
 
 class ProjectAttributeUsage(TimeStampedModel):
@@ -591,4 +591,4 @@ class ProjectAttributeUsage(TimeStampedModel):
     history = HistoricalRecords()
 
     def __str__(self):
-        return "{}: {}".format(self.project_attribute.proj_attr_type.name, self.value)
+        return f"{self.project_attribute.proj_attr_type.name}: {self.value}"

--- a/coldfront/core/project/tests/test_views.py
+++ b/coldfront/core/project/tests/test_views.py
@@ -68,7 +68,7 @@ class ProjectDetailViewTest(ProjectViewTestBase):
     @classmethod
     def setUpTestData(cls):
         """Set up users and project for testing"""
-        super(ProjectDetailViewTest, cls).setUpTestData()
+        super().setUpTestData()
         cls.url = f"/project/{cls.project.pk}/"
 
     def test_projectdetail_access(self):
@@ -134,7 +134,7 @@ class ProjectCreateTest(ProjectViewTestBase):
     @classmethod
     def setUpTestData(cls):
         """Set up users and project for testing"""
-        super(ProjectCreateTest, cls).setUpTestData()
+        super().setUpTestData()
         cls.url = "/project/create/"
 
     def test_project_access(self):
@@ -153,7 +153,7 @@ class ProjectAttributeCreateTest(ProjectViewTestBase):
     @classmethod
     def setUpTestData(cls):
         """Set up users and project for testing"""
-        super(ProjectAttributeCreateTest, cls).setUpTestData()
+        super().setUpTestData()
         int_attributetype = PAttributeTypeFactory(name="Int")
         cls.int_projectattributetype = ProjectAttributeTypeFactory(attribute_type=int_attributetype)
         cls.url = f"/project/{cls.project.pk}/project-attribute-create/"
@@ -211,7 +211,7 @@ class ProjectAttributeUpdateTest(ProjectViewTestBase):
     @classmethod
     def setUpTestData(cls):
         """Set up users and project for testing"""
-        super(ProjectAttributeUpdateTest, cls).setUpTestData()
+        super().setUpTestData()
         cls.projectattribute = ProjectAttributeFactory(
             value=36238, proj_attr_type=cls.projectattributetype, project=cls.project
         )
@@ -233,7 +233,7 @@ class ProjectAttributeDeleteTest(ProjectViewTestBase):
     @classmethod
     def setUpTestData(cls):
         """set up users and project for testing"""
-        super(ProjectAttributeDeleteTest, cls).setUpTestData()
+        super().setUpTestData()
         cls.projectattribute = ProjectAttributeFactory(
             value=36238, proj_attr_type=cls.projectattributetype, project=cls.project
         )
@@ -256,7 +256,7 @@ class ProjectListViewTest(ProjectViewTestBase):
     @classmethod
     def setUpTestData(cls):
         """Set up users and project for testing"""
-        super(ProjectListViewTest, cls).setUpTestData()
+        super().setUpTestData()
         # add 100 projects to test pagination, permissions, search functionality
         additional_projects = [ProjectFactory() for i in list(range(100))]
         # cls.additional_projects = [p for p in additional_projects if p.pi.last_name != cls.project.pi.last_name]

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -341,9 +341,9 @@ class ProjectListView(LoginRequiredMixin, ListView):
                 if value:
                     if isinstance(value, list):
                         for ele in value:
-                            filter_parameters += "{}={}&".format(key, ele)
+                            filter_parameters += f"{key}={ele}&"
                     else:
-                        filter_parameters += "{}={}&".format(key, value)
+                        filter_parameters += f"{key}={value}&"
             context["project_search_form"] = project_search_form
         else:
             filter_parameters = None
@@ -352,7 +352,7 @@ class ProjectListView(LoginRequiredMixin, ListView):
         order_by = self.request.GET.get("order_by")
         if order_by:
             direction = self.request.GET.get("direction")
-            filter_parameters_with_order_by = filter_parameters + "order_by=%s&direction=%s&" % (order_by, direction)
+            filter_parameters_with_order_by = filter_parameters + f"order_by={order_by}&direction={direction}&"
         else:
             filter_parameters_with_order_by = filter_parameters
 
@@ -483,9 +483,9 @@ class ProjectArchivedListView(LoginRequiredMixin, ListView):
                 if value:
                     if isinstance(value, list):
                         for ele in value:
-                            filter_parameters += "{}={}&".format(key, ele)
+                            filter_parameters += f"{key}={ele}&"
                     else:
-                        filter_parameters += "{}={}&".format(key, value)
+                        filter_parameters += f"{key}={value}&"
             context["project_search_form"] = project_search_form
         else:
             filter_parameters = None
@@ -494,7 +494,7 @@ class ProjectArchivedListView(LoginRequiredMixin, ListView):
         order_by = self.request.GET.get("order_by")
         if order_by:
             direction = self.request.GET.get("direction")
-            filter_parameters_with_order_by = filter_parameters + "order_by=%s&direction=%s&" % (order_by, direction)
+            filter_parameters_with_order_by = filter_parameters + f"order_by={order_by}&direction={direction}&"
         else:
             filter_parameters_with_order_by = filter_parameters
 
@@ -925,7 +925,7 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
                         [user_obj.email],
                     )
 
-            messages.success(request, "Added {} users to project.".format(added_users_count))
+            messages.success(request, f"Added {added_users_count} users to project.")
         else:
             if not formset.is_valid():
                 for error in formset.errors:
@@ -1022,9 +1022,9 @@ class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
                     project_obj.remove_user(user_obj, signal_sender=self.__class__)
 
             if remove_users_count == 1:
-                messages.success(request, "Removed {} user from project.".format(remove_users_count))
+                messages.success(request, f"Removed {remove_users_count} user from project.")
             else:
-                messages.success(request, "Removed {} users from project.".format(remove_users_count))
+                messages.success(request, f"Removed {remove_users_count} users from project.")
         else:
             for error in formset.errors:
                 messages.error(request, error)
@@ -1201,7 +1201,7 @@ class ProjectReviewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
         context["project_review_form"] = project_review_form
         context["project_users"] = ", ".join(
             [
-                "{} {}".format(ele.user.first_name, ele.user.last_name)
+                f"{ele.user.first_name} {ele.user.last_name}"
                 for ele in project_obj.projectuser_set.filter(status__name="Active").order_by("user__last_name")
             ]
         )
@@ -1230,7 +1230,7 @@ class ProjectReviewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
 
         domain_url = get_domain_url(self.request)
         project_review_list_url = "{}{}".format(domain_url, reverse("project-review-list"))
-        project_url = "{}{}".format(domain_url, project_obj.get_absolute_url())
+        project_url = f"{domain_url}{project_obj.get_absolute_url()}"
 
         email_context = {
             "project": project_obj,
@@ -1295,7 +1295,7 @@ class ProjectReviewCompleteView(LoginRequiredMixin, UserPassesTestMixin, View):
         project_review_obj.project.project_needs_review = False
         project_review_obj.save()
 
-        messages.success(request, "Project review for {} has been completed".format(project_review_obj.project.title))
+        messages.success(request, f"Project review for {project_review_obj.project.title} has been completed")
 
         return HttpResponseRedirect(reverse("project-review-list"))
 
@@ -1348,11 +1348,7 @@ class ProjectReviewEmailView(LoginRequiredMixin, UserPassesTestMixin, FormView):
 
         messages.success(
             self.request,
-            "Email sent to {} {} ({})".format(
-                project_review_obj.project.pi.first_name,
-                project_review_obj.project.pi.last_name,
-                project_review_obj.project.pi.username,
-            ),
+            f"Email sent to {project_review_obj.project.pi.first_name} {project_review_obj.project.pi.last_name} ({project_review_obj.project.pi.username})",
         )
         return super().form_valid(form)
 
@@ -1515,7 +1511,7 @@ class ProjectAttributeDeleteView(LoginRequiredMixin, UserPassesTestMixin, Templa
 
                     proj_attr.delete()
 
-            messages.success(request, "Deleted {} attributes from project.".format(attributes_deleted_count))
+            messages.success(request, f"Deleted {attributes_deleted_count} attributes from project.")
         else:
             for error in formset.errors:
                 messages.error(request, error)

--- a/coldfront/core/publication/tests/tests.py
+++ b/coldfront/core/publication/tests/tests.py
@@ -52,7 +52,7 @@ class TestPublication(TestCase):
 
     def setUp(self):
         self.data = self.Data()
-        self.unique_id_generator = ("unique_id_{}".format(id) for id in itertools.count())
+        self.unique_id_generator = (f"unique_id_{id}" for id in itertools.count())
 
     def test_fields_generic(self):
         self.assertEqual(0, len(Publication.objects.all()))
@@ -168,7 +168,7 @@ class TestDataRetrieval(TestCase):
             bibtexparser_cls.return_value.parse.side_effect = mock_parse
 
             as_text = Mock(spec_set=bibtexparser.bibdatabase.as_text)
-            as_text.side_effect = lambda bib_entry: "as_text({})".format(bib_entry)
+            as_text.side_effect = lambda bib_entry: f"as_text({bib_entry})"
 
             self.crossref = crossref
             self.bibtexparser_cls = bibtexparser_cls
@@ -178,7 +178,7 @@ class TestDataRetrieval(TestCase):
         def patch(self):
             def dotpath(qualname):
                 module_under_test = coldfront.core.publication.views
-                return "{}.{}".format(module_under_test.__name__, qualname)
+                return f"{module_under_test.__name__}.{qualname}"
 
             with contextlib.ExitStack() as stack:
                 patches = [

--- a/coldfront/core/publication/views.py
+++ b/coldfront/core/publication/views.py
@@ -115,9 +115,7 @@ class PublicationSearchResultView(LoginRequiredMixin, UserPassesTestMixin, Templ
 
             elif source.name == "adsabs":
                 try:
-                    url = "http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode={}&data_type=BIBTEX".format(
-                        unique_id
-                    )
+                    url = f"http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode={unique_id}&data_type=BIBTEX"
                     r = requests.get(url, timeout=5)
                     bp = BibTexParser(interpolate_strings=False)
                     bib_database = bp.parse(r.text)
@@ -168,7 +166,7 @@ class PublicationSearchResultView(LoginRequiredMixin, UserPassesTestMixin, Templ
         else:
             # fallback: clearly indicate that data was absent
             source_name = matching_source_obj.name
-            journal = "[no journal info from {}]".format(source_name.upper())
+            journal = f"[no journal info from {source_name.upper()}]"
 
         pub_dict = {}
         pub_dict["author"] = author
@@ -409,7 +407,7 @@ class PublicationDeletePublicationsView(LoginRequiredMixin, UserPassesTestMixin,
                     publication_obj.delete()
                     publications_deleted_count += 1
 
-            messages.success(request, "Deleted {} publications from project.".format(publications_deleted_count))
+            messages.success(request, f"Deleted {publications_deleted_count} publications from project.")
         else:
             for error in formset.errors:
                 messages.error(request, error)

--- a/coldfront/core/resource/forms.py
+++ b/coldfront/core/resource/forms.py
@@ -46,7 +46,7 @@ class ResourceAttributeCreateForm(forms.ModelForm):
         fields = "__all__"
 
     def __init__(self, *args, **kwargs):
-        super(ResourceAttributeCreateForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields["resource_attribute_type"].queryset = self.fields["resource_attribute_type"].queryset.order_by(
             Lower("name")
         )

--- a/coldfront/core/resource/models.py
+++ b/coldfront/core/resource/models.py
@@ -230,7 +230,7 @@ class Resource(TimeStampedModel):
         return None
 
     def __str__(self):
-        return "%s (%s)" % (self.name, self.resource_type.name)
+        return f"{self.name} ({self.resource_type.name})"
 
     def natural_key(self):
         return [self.name]
@@ -255,19 +255,19 @@ class ResourceAttribute(TimeStampedModel):
         expected_value_type = self.resource_attribute_type.attribute_type.name.strip()
 
         if expected_value_type == "Int" and not self.value.isdigit():
-            raise ValidationError('Invalid Value "%s". Value must be an integer.' % (self.value))
+            raise ValidationError(f'Invalid Value "{self.value}". Value must be an integer.')
         elif expected_value_type == "Active/Inactive" and self.value not in ["Active", "Inactive"]:
-            raise ValidationError('Invalid Value "%s". Allowed inputs are "Active" or "Inactive".' % (self.value))
+            raise ValidationError(f'Invalid Value "{self.value}". Allowed inputs are "Active" or "Inactive".')
         elif expected_value_type == "Public/Private" and self.value not in ["Public", "Private"]:
-            raise ValidationError('Invalid Value "%s". Allowed inputs are "Public" or "Private".' % (self.value))
+            raise ValidationError(f'Invalid Value "{self.value}". Allowed inputs are "Public" or "Private".')
         elif expected_value_type == "Date":
             try:
                 datetime.strptime(self.value.strip(), "%m/%d/%Y")
             except ValueError:
-                raise ValidationError('Invalid Value "%s". Date must be in format MM/DD/YYYY' % (self.value))
+                raise ValidationError(f'Invalid Value "{self.value}". Date must be in format MM/DD/YYYY')
 
     def __str__(self):
-        return "%s: %s (%s)" % (self.resource_attribute_type, self.value, self.resource)
+        return f"{self.resource_attribute_type}: {self.value} ({self.resource})"
 
     def typed_value(self):
         """

--- a/coldfront/core/resource/views.py
+++ b/coldfront/core/resource/views.py
@@ -184,7 +184,7 @@ class ResourceAttributeDeleteView(LoginRequiredMixin, UserPassesTestMixin, Templ
                     resource_attribute = ResourceAttribute.objects.get(pk=form_data["pk"])
                     resource_attribute.delete()
 
-            messages.success(request, "Deleted {} attributes from resource.".format(attributes_deleted_count))
+            messages.success(request, f"Deleted {attributes_deleted_count} attributes from resource.")
         else:
             for error in formset.errors:
                 messages.error(request, error)
@@ -289,9 +289,9 @@ class ResourceListView(LoginRequiredMixin, ListView):
                 if value:
                     if isinstance(value, list):
                         for ele in value:
-                            filter_parameters += "{}={}&".format(key, ele)
+                            filter_parameters += f"{key}={ele}&"
                     else:
-                        filter_parameters += "{}={}&".format(key, value)
+                        filter_parameters += f"{key}={value}&"
             context["resource_search_form"] = resource_search_form
         else:
             filter_parameters = None
@@ -300,7 +300,7 @@ class ResourceListView(LoginRequiredMixin, ListView):
         order_by = self.request.GET.get("order_by")
         if order_by:
             direction = self.request.GET.get("direction")
-            filter_parameters_with_order_by = filter_parameters + "order_by=%s&direction=%s&" % (order_by, direction)
+            filter_parameters_with_order_by = filter_parameters + f"order_by={order_by}&direction={direction}&"
         else:
             filter_parameters_with_order_by = filter_parameters
 

--- a/coldfront/core/test_helpers/decorators.py
+++ b/coldfront/core/test_helpers/decorators.py
@@ -11,7 +11,7 @@ def _skipUnlessEnvDefined(varname, reason=None):
     skip = varname not in os.environ
 
     if skip and reason is None:
-        reason = "Automatically skipped. {} is not defined".format(varname)
+        reason = f"Automatically skipped. {varname} is not defined"
 
     return functools.partial(unittest.skipIf, skip, reason)
 

--- a/coldfront/core/test_helpers/factories.py
+++ b/coldfront/core/test_helpers/factories.py
@@ -87,7 +87,7 @@ class UserFactory(DjangoModelFactory):
     last_name = factory.Faker("last_name")
     # username = factory.Faker('username')
     username = factory.LazyAttribute(lambda o: f"{o.first_name}{o.last_name}")
-    email = factory.LazyAttribute(lambda o: "%s@example.com" % o.username)
+    email = factory.LazyAttribute(lambda o: f"{o.username}@example.com")
 
 
 class UserProfileFactory(DjangoModelFactory):

--- a/coldfront/core/utils/common.py
+++ b/coldfront/core/utils/common.py
@@ -24,7 +24,7 @@ def import_from_settings(attr, *args):
             return getattr(settings, attr, args[0])
         return getattr(settings, attr)
     except AttributeError:
-        raise ImproperlyConfigured("Setting {0} not found".format(attr))
+        raise ImproperlyConfigured(f"Setting {attr} not found")
 
 
 def get_domain_url(request):

--- a/coldfront/core/utils/mail.py
+++ b/coldfront/core/utils/mail.py
@@ -152,8 +152,8 @@ def send_allocation_eula_customer_email(
     ctx = email_template_context()
     ctx["resource"] = allocation_obj.get_parent_resource
     ctx["url"] = url
-    ctx["allocation_user"] = "{} {} ({})".format(
-        allocation_user.user.first_name, allocation_user.user.last_name, allocation_user.user.username
+    ctx["allocation_user"] = (
+        f"{allocation_user.user.first_name} {allocation_user.user.last_name} ({allocation_user.user.username})"
     )
     if include_eula:
         ctx["eula"] = allocation_obj.get_eula()

--- a/coldfront/core/utils/mixins/views.py
+++ b/coldfront/core/utils/mixins/views.py
@@ -32,7 +32,7 @@ class SnakeCaseTemplateNameMixin:
         app_label = self.model._meta.app_label
         model_name = self.model.__name__
 
-        return ["{}/{}{}.html".format(app_label, to_snake(model_name), self.template_name_suffix)]
+        return [f"{app_label}/{to_snake(model_name)}{self.template_name_suffix}.html"]
 
 
 class ProjectInContextMixin:

--- a/coldfront/plugins/freeipa/management/commands/freeipa_check.py
+++ b/coldfront/plugins/freeipa/management/commands/freeipa_check.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
 
     def writerow(self, row):
         try:
-            self.stdout.write("{0: <12}{1: <20}{2: <30}{3}".format(*row))
+            self.stdout.write("{: <12}{: <20}{: <30}{}".format(*row))
         except BrokenPipeError:
             devnull = os.open(os.devnull, os.O_WRONLY)
             os.dup2(devnull, sys.stdout.fileno())

--- a/coldfront/plugins/freeipa/management/commands/freeipa_expire_users.py
+++ b/coldfront/plugins/freeipa/management/commands/freeipa_expire_users.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
 
     def writerow(self, row):
         try:
-            self.stdout.write("{0: <20}{1: <15}{2}".format(*row))
+            self.stdout.write("{: <20}{: <15}{}".format(*row))
         except BrokenPipeError:
             devnull = os.open(os.devnull, os.O_WRONLY)
             os.dup2(devnull, sys.stdout.fileno())

--- a/coldfront/plugins/freeipa/search.py
+++ b/coldfront/plugins/freeipa/search.py
@@ -25,7 +25,7 @@ class LDAPUserSearch(UserSearch):
         self.FREEIPA_USER_SEARCH_BASE = import_from_settings("FREEIPA_USER_SEARCH_BASE", "cn=users,cn=accounts")
         self.FREEIPA_KTNAME = import_from_settings("FREEIPA_KTNAME", "")
 
-        self.server = Server("ldap://{}".format(self.FREEIPA_SERVER), use_ssl=True, connect_timeout=1)
+        self.server = Server(f"ldap://{self.FREEIPA_SERVER}", use_ssl=True, connect_timeout=1)
         if len(self.FREEIPA_KTNAME) > 0:
             logger.info("Kerberos bind enabled: %s", self.FREEIPA_KTNAME)
             # kerberos SASL/GSSAPI bind
@@ -36,7 +36,7 @@ class LDAPUserSearch(UserSearch):
             self.conn = Connection(self.server, auto_bind=True)
 
         if not self.conn.bind():
-            raise ImproperlyConfigured("Failed to bind to LDAP server: {}".format(self.conn.result))
+            raise ImproperlyConfigured(f"Failed to bind to LDAP server: {self.conn.result}")
         else:
             logger.info("LDAP bind successful: %s", self.conn.extend.standard.who_am_i())
 

--- a/coldfront/plugins/freeipa/utils.py
+++ b/coldfront/plugins/freeipa/utils.py
@@ -37,7 +37,7 @@ def ipa_bootstrap():
         api.Backend.rpcclient.connect()
     except Exception as e:
         logger.error("Failed to initialze FreeIPA lib: %s", e)
-        raise ImproperlyConfigured("Failed to initialze FreeIPA: {0}".format(e))
+        raise ImproperlyConfigured(f"Failed to initialze FreeIPA: {e}")
 
 
 def check_ipa_group_error(res):

--- a/coldfront/plugins/iquota/utils.py
+++ b/coldfront/plugins/iquota/utils.py
@@ -49,14 +49,14 @@ class Iquota:
         token = self.gssclient_token()
 
         headers = {"Authorization": "Negotiate " + token}
-        url = "https://{}:{}/quota?user={}".format(self.IQUOTA_API_HOST, self.IQUOTA_API_PORT, self.username)
+        url = f"https://{self.IQUOTA_API_HOST}:{self.IQUOTA_API_PORT}/quota?user={self.username}"
 
         r = requests.get(url, headers=headers, verify=self.IQUOTA_CA_CERT)
 
         try:
             usage = r.json()[0]
         except KeyError:
-            raise MissingQuotaError("Missing user quota for username: %s" % (self.username))
+            raise MissingQuotaError(f"Missing user quota for username: {self.username}")
         else:
             user_used = usage["used"]
             user_limit = usage["soft_limit"]
@@ -77,7 +77,7 @@ class Iquota:
 
         headers = {"Authorization": "Negotiate " + token}
 
-        url = "https://{}:{}/quota?group={}".format(self.IQUOTA_API_HOST, self.IQUOTA_API_PORT, group)
+        url = f"https://{self.IQUOTA_API_HOST}:{self.IQUOTA_API_PORT}/quota?group={group}"
 
         r = requests.get(url, headers=headers, verify=self.IQUOTA_CA_CERT)
 

--- a/coldfront/plugins/mokey_oidc/auth.py
+++ b/coldfront/plugins/mokey_oidc/auth.py
@@ -93,7 +93,7 @@ class OIDCMokeyAuthenticationBackend(OIDCAuthenticationBackend):
             return self.UserModel.objects.none()
 
     def verify_claims(self, claims):
-        verified = super(OIDCMokeyAuthenticationBackend, self).verify_claims(claims)
+        verified = super().verify_claims(claims)
 
         if len(ALLOWED_GROUPS) == 0 and len(DENY_GROUPS) == 0:
             return verified and True

--- a/coldfront/plugins/slurm/management/commands/slurm_dump.py
+++ b/coldfront/plugins/slurm/management/commands/slurm_dump.py
@@ -53,5 +53,5 @@ class Command(BaseCommand):
                 cluster.write(self.stdout)
                 continue
 
-            with open(os.path.join(out_dir, "{}.cfg".format(cluster.name)), "w") as fh:
+            with open(os.path.join(out_dir, f"{cluster.name}.cfg"), "w") as fh:
                 cluster.write(fh)

--- a/coldfront/plugins/slurm/tests/test_associations.py
+++ b/coldfront/plugins/slurm/tests/test_associations.py
@@ -21,7 +21,7 @@ class AssociationTest(TestCase):
         call_command("add_default_project_choices")
         call_command("add_default_allocation_choices")
         call_command("add_default_publication_sources")
-        super(AssociationTest, cls).setUpClass()
+        super().setUpClass()
 
     def test_allocations_to_slurm(self):
         resource = Resource.objects.get(name="University HPC")

--- a/coldfront/plugins/slurm/utils.py
+++ b/coldfront/plugins/slurm/utils.py
@@ -44,7 +44,7 @@ def _run_slurm_cmd(cmd, noop=True):
         return
 
     try:
-        result = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        result = subprocess.run(shlex.split(cmd), capture_output=True, check=True)
     except subprocess.CalledProcessError as e:
         if "Nothing deleted" in str(e.stdout):
             # We tried to delete something that didn't exist. Don't throw error
@@ -56,7 +56,7 @@ def _run_slurm_cmd(cmd, noop=True):
             return e.stdout
 
         logger.error("Slurm command failed: %s", cmd)
-        err_msg = "return_value={} stdout={} stderr={}".format(e.returncode, e.stdout, e.stderr)
+        err_msg = f"return_value={e.returncode} stdout={e.stdout} stderr={e.stderr}"
         raise SlurmError(err_msg)
 
     logger.debug("Slurm cmd: %s", cmd)

--- a/coldfront/plugins/system_monitor/utils.py
+++ b/coldfront/plugins/system_monitor/utils.py
@@ -99,12 +99,12 @@ class SystemMonitor:
             utilized_percent = round(processors_utilized[0] / processors_utilized[1] * 1000) / 10
             free_percent = round(free / processors_utilized[1] * 1000) / 10
 
-            utilized_label = "Processors Utilized: %s (%s%%)" % (processors_utilized[0], utilized_percent)
-            free_label = "Processors Free: %s (%s%%)" % (free, free_percent)
+            utilized_label = f"Processors Utilized: {processors_utilized[0]} ({utilized_percent}%)"
+            free_label = f"Processors Free: {free} ({free_percent}%)"
             utilized_value = processors_utilized[0]
             free_value = free
-            running_label = "Running: %s" % (jobs[0])
-            queued_label = "Queued: %s" % (jobs[1])
+            running_label = f"Running: {jobs[0]}"
+            queued_label = f"Queued: {jobs[1]}"
             running_value = job_numbers[0]
             queued_value = job_numbers[1]
         except Exception:

--- a/coldfront/plugins/xdmod/utils.py
+++ b/coldfront/plugins/xdmod/utils.py
@@ -53,9 +53,9 @@ def xdmod_fetch_total_cpu_hours(start, end, account, resources=None, statistics=
     if resources is None:
         resources = []
 
-    url = "{}{}".format(XDMOD_API_URL, _ENDPOINT_CORE_HOURS)
+    url = f"{XDMOD_API_URL}{_ENDPOINT_CORE_HOURS}"
     payload = _DEFAULT_PARAMS
-    payload["pi_filter"] = '"{}"'.format(account)
+    payload["pi_filter"] = f'"{account}"'
     payload["resource_filter"] = '"{}"'.format(",".join(resources))
     payload["start_date"] = start
     payload["end_date"] = end
@@ -72,7 +72,7 @@ def xdmod_fetch_total_cpu_hours(start, end, account, resources=None, statistics=
         error = r.json()
         # XXX fix me. Here we assume any json response is bad as we're
         # expecting xml but XDMoD should just return json always.
-        raise XdmodNotFoundError("Got json response but expected XML: {}".format(error))
+        raise XdmodNotFoundError(f"Got json response but expected XML: {error}")
     except json.decoder.JSONDecodeError:
         pass
     except requests.exceptions.JSONDecodeError:
@@ -81,11 +81,11 @@ def xdmod_fetch_total_cpu_hours(start, end, account, resources=None, statistics=
     try:
         root = ET.fromstring(r.text)
     except ET.ParserError as e:
-        raise XdmodError("Invalid XML data returned from XDMoD API: {}".format(e))
+        raise XdmodError(f"Invalid XML data returned from XDMoD API: {e}")
 
     rows = root.find("rows")
     if len(rows) != 1:
-        raise XdmodNotFoundError("Rows not found for {} - {}".format(account, resources))
+        raise XdmodNotFoundError(f"Rows not found for {account} - {resources}")
 
     cells = rows.find("row").findall("cell")
     if len(cells) != 2:
@@ -103,9 +103,9 @@ def xdmod_fetch_total_storage(start, end, account, resources=None, statistics="p
     payload_end = end
     if payload_end is None:
         payload_end = "2099-01-01"
-    url = "{}{}".format(XDMOD_API_URL, _ENDPOINT_CORE_HOURS)
+    url = f"{XDMOD_API_URL}{_ENDPOINT_CORE_HOURS}"
     payload = _DEFAULT_PARAMS
-    payload["pi_filter"] = '"{}"'.format(account)
+    payload["pi_filter"] = f'"{account}"'
     payload["resource_filter"] = "{}".format(",".join(resources))
     payload["start_date"] = start
     payload["end_date"] = payload_end
@@ -121,11 +121,11 @@ def xdmod_fetch_total_storage(start, end, account, resources=None, statistics="p
     try:
         root = ET.fromstring(r.text)
     except ET.ParserError as e:
-        raise XdmodError("Invalid XML data returned from XDMoD API: {}".format(e))
+        raise XdmodError(f"Invalid XML data returned from XDMoD API: {e}")
 
     rows = root.find("rows")
     if len(rows) != 1:
-        raise XdmodNotFoundError("Rows not found for {} - {}".format(account, resources))
+        raise XdmodNotFoundError(f"Rows not found for {account} - {resources}")
 
     cells = rows.find("row").findall("cell")
     if len(cells) != 2:
@@ -140,7 +140,7 @@ def xdmod_fetch_cloud_core_time(start, end, project, resources=None):
     if resources is None:
         resources = []
 
-    url = "{}{}".format(XDMOD_API_URL, _ENDPOINT_CORE_HOURS)
+    url = f"{XDMOD_API_URL}{_ENDPOINT_CORE_HOURS}"
     payload = _DEFAULT_PARAMS
     payload["project_filter"] = project
     payload["resource_filter"] = '"{}"'.format(",".join(resources))
@@ -159,18 +159,18 @@ def xdmod_fetch_cloud_core_time(start, end, project, resources=None):
         error = r.json()
         # XXX fix me. Here we assume any json response is bad as we're
         # expecting xml but XDMoD should just return json always.
-        raise XdmodNotFoundError("Got json response but expected XML: {}".format(error))
+        raise XdmodNotFoundError(f"Got json response but expected XML: {error}")
     except json.decoder.JSONDecodeError:
         pass
 
     try:
         root = ET.fromstring(r.text)
     except ET.ParserError as e:
-        raise XdmodError("Invalid XML data returned from XDMoD API: {}".format(e))
+        raise XdmodError(f"Invalid XML data returned from XDMoD API: {e}")
 
     rows = root.find("rows")
     if len(rows) != 1:
-        raise XdmodNotFoundError("Rows not found for {} - {}".format(project, resources))
+        raise XdmodNotFoundError(f"Rows not found for {project} - {resources}")
 
     cells = rows.find("row").findall("cell")
     if len(cells) != 2:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,10 +111,18 @@ required-version = ">=0.9.13"
 [tool.ruff]
 line-length = 120
 indent-width = 4
-target-version = "py312"
+target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "S308"]
+select = [
+    "E4", 
+    "E7", 
+    "E9", 
+    "F", 
+    "I", 
+    "S308",
+    "UP",
+]
 
 [tool.ruff.format]
 indent-style = "space"


### PR DESCRIPTION
This was also a bit of a doozy to implement, but it will go a long way to assuage some of the concerns that people have brought up about ColdFront have a more opinionated and consistent style going forward in the code.

Most of this was just updating things to use f-strings. Much more readable, faster, and more modern. 

This will have to be merged after #734 and #751. 