### PR TITLE
Added CodeQL scanning to GitHub actions.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main", "release**"]
+  pull_request:
+    branches: ["main", "release**"]
+
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ 'ubuntu-latest' }}
+    permissions:
+      security-events: write
+      packages: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config: |
+            paths-ignore:
+                - "coldfront/static/**"
+
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
CodeQL is a feature from GitHub that scans code for defects and vulnerabilities. 

I have used it before and it has helped out on a few occasions. I believe more (automated) eyes on the codebase reviewing PRs will be useful. 

The checks here will run on every PR to main or a release branch.

The CodeQL suite is configured to `security-extended` which primarily focuses on security related issues rather than more broad code quality checks. This suite is a bit more aggressive than the `default` suite and sometimes may contain false-positives. These can simply be dismissed by a maintainer before merging the PR. This will check the Python and Javascript code.

CodeQL scanning is free for public open-source repos (such as this one). 

The only downside is sometimes CodeQL can take a bit to run so it might slow down the CI a bit. Runs usually last a few minutes. 