### PR TITLE
document project code max length

### DIFF
--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -101,7 +101,7 @@ The following settings are ColdFront specific settings related to the core appli
 | RESEARCH_OUTPUT_ENABLE                 | Enable or disable research outputs. Default True |
 | GRANT_ENABLE                           | Enable or disable grants. Default True           |
 | PUBLICATION_ENABLE                     | Enable or disable publications. Default True     |
-| PROJECT_CODE                                 | Specifies a custom internal project identifier. Default False, provide string value to enable.|  
+| PROJECT_CODE                                 | Specifies a custom internal project identifier. Default False, provide string value to enable. Must be no longer than 10 - PROJECT_CODE_PADDING characters in length.|  
 | PROJECT_CODE_PADDING                         | Defines a optional padding value to be added before the Primary Key section of PROJECT_CODE. Default False, provide integer value to enable.|
 | PROJECT_INSTITUTION_EMAIL_MAP                | Defines a dictionary where PI domain email addresses are keys and their corresponding institutions are values. Default is False, provide key-value pairs to enable this feature.|  
 ### Database settings


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/srv/simon/venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/venv/lib/python3.12/site-packages/django/db/backends/mysql/base.py", line 75, in execute
    return self.cursor.execute(query, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/venv/lib/python3.12/site-packages/MySQLdb/cursors.py", line 179, in execute
    res = self._query(mogrified_query)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/venv/lib/python3.12/site-packages/MySQLdb/cursors.py", line 330, in _query
    db.query(q)
    ^^^^^^^^^^^
  File "/srv/simon/venv/lib/python3.12/site-packages/MySQLdb/connections.py", line 280, in query
    _mysql.connection.query(self, query)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

The above exception ((1406, "Data too long for column 'project_code' at row 1")) was the direct cause of the following exception:
...
```

https://github.com/ubccr/coldfront/blob/0657a07ff20de4386eeb00b1a2c132a8d1c943da/coldfront/core/project/models.py#L108