### PR TITLE
add local_urls to match local_settings

### DIFF
--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -34,6 +34,19 @@ You can also specify the path to `local_settings.py` using the
 COLDFRONT_CONFIG=/opt/coldfront/mysettings.py
 ```
 
+For [URL configurations](https://docs.djangoproject.com/en/dev/topics/http/urls/), you can create a python file to override ColdFront URLs:
+
+- `local_urls.py` relative to coldfront.config package
+- `/etc/coldfront/local_urls.py`
+- `local_urls.py` in the ColdFront project root
+
+You can also specify the path to `local_urls.py` using the
+`COLDFRONT_URLS` environment variable. For example:
+
+```
+COLDFRONT_URLS=/opt/coldfront/myurls.py
+```
+
 ## Simple Example
 
 Here's a very simple example demonstrating how to configure ColdFront using


### PR DESCRIPTION
Please correct me if I'm wrong:

A typical django workflow involves creating a project with `django-admin startproject`, then you get a "project directory", which is distinct from the "app directory". A django "project directory" contains `manage.py`, `settings.py`, `urls.py`, `asgi.py` , and `wsgi.py`.

Coldfront does away with the project directory and instead:
* `manage.py` is replaced with the `coldfront` binary
* `settings.py` is replaced with `coldfront/config/settings.py` which the user can extend
* `wsgi.py` is replaced with `coldfront/config/wsgi.py`
* `asgi.py` is removed
* `urls.py` is replaced with `coldfront/config/urls.py` which the user cannot extend without keeping a dirty worktree

I would like to extend the URLs config without keeping a dirty worktree, so I added `local_urls.py` which behaves exactly like `local_settings.py`.