### PR TITLE
Bug fix allocation account

### DIFF
--- a/coldfront/core/allocation/tests/test_views.py
+++ b/coldfront/core/allocation/tests/test_views.py
@@ -7,7 +7,6 @@ import logging
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
-from coldfront.core.utils.common import import_from_settings
 from coldfront.core.allocation.models import (
     AllocationChangeRequest,
     AllocationChangeStatusChoice,
@@ -27,6 +26,7 @@ from coldfront.core.test_helpers.factories import (
     ResourceFactory,
     UserFactory,
 )
+from coldfront.core.utils.common import import_from_settings
 
 logging.disable(logging.CRITICAL)
 
@@ -39,8 +39,10 @@ class AllocationViewBaseTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Test Data setup for all allocation view tests."""
+        pi_user = UserFactory()
+        pi_user.userprofile.is_pi = True
         AllocationStatusChoiceFactory(name="New")
-        cls.project = ProjectFactory(status=ProjectStatusChoiceFactory(name="Active"))
+        cls.project = ProjectFactory(pi=pi_user, status=ProjectStatusChoiceFactory(name="Active"))
         cls.allocation = AllocationFactory(project=cls.project)
         cls.allocation.resources.add(ResourceFactory(name="holylfs07/tier1"))
         # create allocation user that belongs to project
@@ -52,8 +54,8 @@ class AllocationViewBaseTest(TestCase):
         cls.proj_nonallocation_user = proj_nonallocation_user.user
         cls.admin_user = UserFactory(is_staff=True, is_superuser=True)
         manager_role = ProjectUserRoleChoiceFactory(name="Manager")
-        pi_user = ProjectUserFactory(user=cls.project.pi, project=cls.project, role=manager_role)
-        cls.pi_user = pi_user.user
+        ProjectUserFactory(user=pi_user, project=cls.project, role=manager_role)
+        cls.pi_user = pi_user
         # make a quota TB allocation attribute
         AllocationAttributeFactory(
             allocation=cls.allocation,
@@ -326,6 +328,7 @@ class AllocationNoteCreateViewTest(AllocationViewBaseTest):
     def test_allocationnotecreateview_access(self):
         self.allocation_access_tstbase(self.url)
 
+
 @override_settings(ALLOCATION_ACCOUNT_ENABLED=True)
 class AllocationAccountCreateViewTest(AllocationViewBaseTest):
     """Tests for the AllocationAccountCreateView"""
@@ -337,7 +340,7 @@ class AllocationAccountCreateViewTest(AllocationViewBaseTest):
         self.assertTrue(import_from_settings("ALLOCATION_ACCOUNT_ENABLED", False))
         self.allocation_access_tstbase(self.url)
         utils.test_user_can_access(self, self.pi_user, self.url)
-    
+
     def test_allocationaccountcreateview_get_form(self):
         self.client.force_login(self.pi_user, backend=BACKEND)
         response = self.client.get(self.url)
@@ -345,15 +348,12 @@ class AllocationAccountCreateViewTest(AllocationViewBaseTest):
 
     def test_allocationaccountcreateview_post_form(self):
         self.client.force_login(self.pi_user, backend=BACKEND)
-        valid_data = {'name': 'deptCE1234'}
+        valid_data = {"name": "deptCE1234"}
         response = self.client.post(self.url, data=valid_data, follow=True)
-        self.assertContains(response, 'deptCE1234')
+        self.assertContains(response, "deptCE1234")
 
     def test_allocationaccountcreateview_post_invalid_form(self):
         self.client.force_login(self.pi_user, backend=BACKEND)
-        invalid_data = {'name': ''}
+        invalid_data = {"name": ""}
         response = self.client.post(self.url, data=invalid_data, follow=True)
-        self.assertContains(response, 'This field is required.')
-
-
-
+        self.assertContains(response, "This field is required.")

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1642,7 +1642,7 @@ class AllocationAccountCreateView(LoginRequiredMixin, UserPassesTestMixin, Creat
             return False
         if self.request.user.is_superuser:
             return True
-        if Project.objects.filter(pi=self.request.user).exists():
+        if self.request.user.userprofile.is_pi:
             return True
 
         messages.error(self.request, "You do not have permission to add allocation attributes.")
@@ -1680,7 +1680,7 @@ class AllocationAccountListView(LoginRequiredMixin, UserPassesTestMixin, ListVie
             return False
         if self.request.user.is_superuser:
             return True
-        if Project.objects.filter(pi=self.request.user).exists():
+        if self.request.user.userprofile.is_pi:
             return True
 
         messages.error(self.request, "You do not have permission to manage invoices.")

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1638,11 +1638,11 @@ class AllocationAccountCreateView(LoginRequiredMixin, UserPassesTestMixin, Creat
     def test_func(self):
         """UserPassesTestMixin Tests"""
 
-        if not ALLOCATION_ACCOUNT_ENABLED:
+        if not import_from_settings("ALLOCATION_ACCOUNT_ENABLED", False):
             return False
         if self.request.user.is_superuser:
             return True
-        if self.request.user.userprofile.is_pi:
+        if Project.objects.filter(pi=self.request.user).exists():
             return True
 
         messages.error(self.request, "You do not have permission to add allocation attributes.")
@@ -1650,14 +1650,14 @@ class AllocationAccountCreateView(LoginRequiredMixin, UserPassesTestMixin, Creat
 
     def form_invalid(self, form):
         response = super().form_invalid(form)
-        if self.request.is_ajax():
+        if self.request.headers.get("x-requested-with") == "XMLHttpRequest":
             return JsonResponse(form.errors, status=400)
         return response
 
     def form_valid(self, form):
         form.instance.user = self.request.user
         response = super().form_valid(form)
-        if self.request.is_ajax():
+        if self.request.headers.get("x-requested-with") == "XMLHttpRequest":
             data = {
                 "pk": self.object.pk,
             }
@@ -1676,11 +1676,11 @@ class AllocationAccountListView(LoginRequiredMixin, UserPassesTestMixin, ListVie
     def test_func(self):
         """UserPassesTestMixin Tests"""
 
-        if not ALLOCATION_ACCOUNT_ENABLED:
+        if not import_from_settings("ALLOCATION_ACCOUNT_ENABLED", False):
             return False
         if self.request.user.is_superuser:
             return True
-        if self.request.user.userprofile.is_pi:
+        if Project.objects.filter(pi=self.request.user).exists():
             return True
 
         messages.error(self.request, "You do not have permission to manage invoices.")


### PR DESCRIPTION
This PR addresses the issue reported here: https://github.com/ubccr/coldfront/issues/791
It also adds tests for this view.

A couple of things worth noting:
Although the main change was the change from 'request.is_ajax' to 'request.get("x-requested-with") == "XMLHttpRequest"', a couple of changes were made to enable testing.

I changed the way ALLOCATION_ACCOUNT_ENABLED was accessed from settings to enable testing. Originally, this value is assigned to a constant at the top of the file, so that it is only evaluated on import. However, this view is only accessible when this setting is assigned the non-default value. Using 'import_from_settings' in the view allows us to inject different values for the setting at test time using the 'override_settings' annotation.

I also changed the setup in the test for creation of the pi user to enable request.user.userprofile.is_pi to return True for a PI user.
