### PR TITLE
fix issue 793: Sum of char field

### DIFF
--- a/coldfront/core/portal/tests/test_views.py
+++ b/coldfront/core/portal/tests/test_views.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import logging
+
+from django.test import TestCase
+
+logging.disable(logging.CRITICAL)
+
+
+class PortalViewBaseTest(TestCase):
+    """Base class for portal view tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Test Data setup for all portal view tests."""
+        pass
+
+
+class CenterSummaryViewTest(PortalViewBaseTest):
+    """Tests for center summary view"""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up users and project for testing"""
+        cls.url = "/center-summary"
+        super(PortalViewBaseTest, cls).setUpTestData()
+
+    def test_centersummary_renders(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Active Allocations and Users")
+        self.assertContains(response, "Resources and Allocations Summary")
+        self.assertNotContains(response, "We're having a bit of system trouble at the moment. Please check back soon!")

--- a/coldfront/core/portal/views.py
+++ b/coldfront/core/portal/views.py
@@ -7,7 +7,8 @@ from collections import Counter
 
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import intcomma
-from django.db.models import Count, Q, Sum
+from django.db.models import Count, FloatField, Q, Sum
+from django.db.models.functions import Cast
 from django.shortcuts import render
 from django.views.decorators.cache import cache_page
 
@@ -137,7 +138,9 @@ def center_summary(request):
 
     # Grants Card
     total_grants_by_agency_sum = list(
-        Grant.objects.values("funding_agency__name").annotate(total_amount=Sum("total_amount_awarded"))
+        Grant.objects.values("funding_agency__name").annotate(
+            total_amount=Sum(Cast("total_amount_awarded", FloatField()))
+        )
     )
 
     total_grants_by_agency_count = list(


### PR DESCRIPTION
bugfix for [issue 793](https://github.com/ubccr/coldfront/issues/793)

In this PR, in coldfront.core.portal.views center_summary, the "total_amount_awarded" field is cast from CharField to FloatField before Sum is applied.

As there was no current test for the portal module, added a simple test that shows a user can retrieve the page and that section headers appear on the page.