### PR TITLE
feature: hide field of science with setting

### DIFF
--- a/coldfront/config/core.py
+++ b/coldfront/config/core.py
@@ -25,6 +25,11 @@ GRANT_ENABLE = ENV.bool("GRANT_ENABLE", default=True)
 PUBLICATION_ENABLE = ENV.bool("PUBLICATION_ENABLE", default=True)
 
 # ------------------------------------------------------------------------------
+# Hide Field of Science. Hide Field of Science related functionality if True
+# ------------------------------------------------------------------------------
+FIELD_OF_SCIENCE_HIDE = ENV.bool("FIELD_OF_SCIENCE_HIDE", default=False)
+
+# ------------------------------------------------------------------------------
 # Enable Project Review
 # ------------------------------------------------------------------------------
 PROJECT_ENABLE_PROJECT_REVIEW = ENV.bool("PROJECT_ENABLE_PROJECT_REVIEW", default=True)
@@ -64,6 +69,7 @@ SETTINGS_EXPORT += [
     "PUBLICATION_ENABLE",
     "INVOICE_ENABLED",
     "PROJECT_ENABLE_PROJECT_REVIEW",
+    "FIELD_OF_SCIENCE_HIDE",
 ]
 
 ADMIN_COMMENTS_SHOW_EMPTY = ENV.bool("ADMIN_COMMENTS_SHOW_EMPTY", default=True)

--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -27,12 +27,14 @@ urlpatterns = [
     path("", portal_views.home, name="home"),
     path("center-summary", portal_views.center_summary, name="center-summary"),
     path("allocation-summary", portal_views.allocation_summary, name="allocation-summary"),
-    path("allocation-by-fos", portal_views.allocation_by_fos, name="allocation-by-fos"),
     path("user/", include("coldfront.core.user.urls")),
     path("project/", include("coldfront.core.project.urls")),
     path("allocation/", include("coldfront.core.allocation.urls")),
     path("resource/", include("coldfront.core.resource.urls")),
 ]
+
+if not settings.FIELD_OF_SCIENCE_HIDE:
+    urlpatterns.append(path("allocation-by-fos", portal_views.allocation_by_fos, name="allocation-by-fos"))
 
 if settings.GRANT_ENABLE:
     urlpatterns.append(path("grant/", include("coldfront.core.grant.urls")))

--- a/coldfront/core/portal/templates/portal/center_summary.html
+++ b/coldfront/core/portal/templates/portal/center_summary.html
@@ -59,6 +59,7 @@ Center Summary
 <!-- End Grants -->
 {% endif %}
 
+{% if not settings.FIELD_OF_SCIENCE_HIDE %}
 <!-- Start Allocation by Field of Science -->
 <div class="card mb-3 border-primary">
   <div class="card-header bg-primary text-white">
@@ -72,6 +73,7 @@ Center Summary
   </div>
 </div>
 <!-- End Allocation by Field of Science -->
+{% endif %}
 
 <!-- Start Allocation Charts -->
 <div class="card mb-3 border-primary">

--- a/coldfront/core/portal/tests/test_views.py
+++ b/coldfront/core/portal/tests/test_views.py
@@ -4,7 +4,9 @@
 
 import logging
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
+
+from coldfront.core.utils.common import import_from_settings
 
 logging.disable(logging.CRITICAL)
 
@@ -33,3 +35,20 @@ class CenterSummaryViewTest(PortalViewBaseTest):
         self.assertContains(response, "Active Allocations and Users")
         self.assertContains(response, "Resources and Allocations Summary")
         self.assertNotContains(response, "We're having a bit of system trouble at the moment. Please check back soon!")
+
+    def test_centersummary_renders_field_of_science_not_hidden(self):
+        self.assertFalse(import_from_settings("FIELD_OF_SCIENCE_HIDE", True))
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<!-- Start Allocation by Field of Science -->")
+        # sanity check for other chart
+        self.assertContains(response, "<!-- Start Allocation Charts -->")
+
+    @override_settings(FIELD_OF_SCIENCE_HIDE=True)
+    def test_centersummary_renders_field_of_science_hidden(self):
+        self.assertTrue(import_from_settings("FIELD_OF_SCIENCE_HIDE", False))
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "<!-- Start Allocation by Field of Science -->")
+        # sanity check for other chart
+        self.assertContains(response, "<!-- Start Allocation Charts -->")

--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -4,6 +4,8 @@
 
 import datetime
 
+from crispy_forms.helper import FormHelper, Layout
+from crispy_forms.layout import Field
 from django import forms
 from django.db.models.functions import Lower
 from django.shortcuts import get_object_or_404
@@ -27,6 +29,25 @@ class ProjectSearchForm(forms.Form):
     username = forms.CharField(label=USERNAME, max_length=100, required=False)
     field_of_science = forms.CharField(label=FIELD_OF_SCIENCE, max_length=100, required=False)
     show_all_projects = forms.BooleanField(initial=False, required=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        # form tag is in templates
+        self.helper.form_tag = False
+        if import_from_settings("FIELD_OF_SCIENCE_HIDE", False):
+            self.helper.layout = Layout(
+                Field("last_name"),
+                Field("username"),
+                Field("show_all_projects"),
+            )
+        else:
+            self.helper.layout = Layout(
+                Field("last_name"),
+                Field("username"),
+                Field("field_of_science"),
+                Field("show_all_projects"),
+            )
 
 
 class ProjectAddUserForm(forms.Form):
@@ -180,7 +201,24 @@ class ProjectAttributeUpdateForm(forms.Form):
             proj_attr.clean()
 
 
-class ProjectCreationForm(forms.ModelForm):
+class ProjectUpdateForm(forms.ModelForm):
     class Meta:
         model = Project
-        fields = ["title", "description", "field_of_science"]
+        exclude = []
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        # form tag is in templates
+        self.helper.form_tag = False
+        if import_from_settings("FIELD_OF_SCIENCE_HIDE", False):
+            self.helper.layout = Layout(
+                Field("title"),
+                Field("description"),
+            )
+        else:
+            self.helper.layout = Layout(
+                Field("title"),
+                Field("description"),
+                Field("field_of_science"),
+            )

--- a/coldfront/core/project/templates/project/project_archive.html
+++ b/coldfront/core/project/templates/project/project_archive.html
@@ -22,7 +22,9 @@ Archive Project
       <a href="mailto:{{ project.pi.email }}"><i class="far fa-envelope" aria-hidden="true"></i><span class="sr-only">Email</span></a>
     </h3>
     <p class="card-text text-justify"><strong>Description: </strong>{{ project.description }}</p>
-    <p class="card-text text-justify"><strong>Field of Science: </strong>{{ project.field_of_science }}</p>
+    {% if not settings.FIELD_OF_SCIENCE_HIDE %}
+        <p class="card-text text-justify"><strong>Field of Science: </strong>{{ project.field_of_science }}</p>
+    {% endif %}
     <p class="card-text text-justify"><strong>Status: </strong>{{ project.status}}</p>
   </div>
 </div>

--- a/coldfront/core/project/templates/project/project_archived_list.html
+++ b/coldfront/core/project/templates/project/project_archived_list.html
@@ -33,7 +33,7 @@ Project List
       <div id="collapseOne" class="collapse {{expand_accordion}}" data-parent="#accordion">
         <div class="card-body">
           <form id="filter_form" method="GET" action="{% url 'project-archived-list' %}">
-            {{ project_search_form|crispy }}
+            {% crispy project_search_form project_search_form.helper %}
             <input type="submit" class="btn btn-primary" value="Search">
             <button id="form_reset_button" type="button" class="btn btn-secondary">Reset</button>
           </form>
@@ -61,11 +61,13 @@ Project List
             <a href="?order_by=pi__username&direction=des&{{filter_parameters}}"><i class="fas fa-sort-down" aria-hidden="true"></i><span class="sr-only">Sort PI desc</span></a>
           </th>
           <th scope="col">Title and Description</th>
-          <th scope="col" class="text-nowrap">
-            Field of Science
-            <a href="?order_by=field_of_science&direction=asc&{{filter_parameters}}"><i class="fas fa-sort-up" aria-hidden="true"></i><span class="sr-only">Sort Field of Science asc</span></a>
-            <a href="?order_by=field_of_science&direction=des&{{filter_parameters}}"><i class="fas fa-sort-down" aria-hidden="true"></i><span class="sr-only">Sort Field of Science desc</span></a>
-          </th>
+          {% if not settings.FIELD_OF_SCIENCE_HIDE %}
+            <th scope="col" class="text-nowrap">
+              Field of Science
+              <a href="?order_by=field_of_science&direction=asc&{{filter_parameters}}"><i class="fas fa-sort-up" aria-hidden="true"></i><span class="sr-only">Sort Field of Science asc</span></a>
+              <a href="?order_by=field_of_science&direction=des&{{filter_parameters}}"><i class="fas fa-sort-down" aria-hidden="true"></i><span class="sr-only">Sort Field of Science desc</span></a>
+            </th>
+          {% endif %}
           <th scope="col" class="text-nowrap">
             Status
             <a href="?order_by=status&direction=asc&{{filter_parameters}}"><i class="fas fa-sort-up" aria-hidden="true"></i><span class="sr-only">Sort Status asc</span></a>
@@ -84,7 +86,9 @@ Project List
             <td>{{ project.pi.username }}</td>
             <td style="text-align: justify; text-justify: inter-word;"><strong>Title: </strong> {{ project.title }}
               <br> <strong>Description: </strong>{{ project.description }}</td>
-            <td>{{ project.field_of_science.description }}</td>
+            {% if not settings.FIELD_OF_SCIENCE_HIDE %}
+                <td>{{ project.field_of_science.description }}</td>
+            {% endif %}
             <td>{{ project.status.name }}</td>
             {% if PROJECT_INSTITUTION_EMAIL_MAP %}
                 <p class="card-text text-justify"><strong>Institution: </strong>{{ project.institution }}</p>

--- a/coldfront/core/project/templates/project/project_create_form.html
+++ b/coldfront/core/project/templates/project/project_create_form.html
@@ -11,14 +11,18 @@ Create Project
 {% block content %}
  <form method="post">
   {% csrf_token %}
-  {{ form|crispy }}
+  {% crispy form form.helper %}
   <input class="btn btn-primary" type="submit" value="Save" />
   <a class="btn btn-secondary" href="{% url 'project-list' %}" role="button">Cancel</a>
 </form>
 
+{% if not settings.FIELD_OF_SCIENCE_HIDE %}
 <script>
   $(document).ready(function() {
     $('#id_field_of_science').select2();
   });
 </script>
+{% endif %}
+
 {% endblock %}
+

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -75,7 +75,9 @@ Project Detail
     {% else %}
         <p class="card-text text-justify"><strong>ID: </strong>{{ project.id }}</p>
     {% endif %}
-    <p class="card-text text-justify"><strong>Field of Science: </strong>{{ project.field_of_science }}</p>
+    {% if not settings.FIELD_OF_SCIENCE_HIDE %}
+        <p class="card-text text-justify"><strong>Field of Science: </strong>{{ project.field_of_science }}</p>
+    {% endif %}
     <p class="card-text text-justify"><strong>Project Status: </strong>{{ project.status }}
         {% if project.last_project_review and  project.last_project_review.status.name == 'Pending'%}
           <span class="badge badge-pill badge-info">project review pending</span>

--- a/coldfront/core/project/templates/project/project_list.html
+++ b/coldfront/core/project/templates/project/project_list.html
@@ -34,7 +34,7 @@ Project List
       <div id="collapseOne" class="collapse {{expand_accordion}}" data-parent="#accordion">
         <div class="card-body">
           <form id="filter_form" method="GET" action="{% url 'project-list' %}" autocomplete="off">
-            {{ project_search_form|crispy }}
+            {% crispy project_search_form project_search_form.helper %}
             <input type="submit" class="btn btn-primary" value="Search">
             <button id="form_reset_button" type="button" class="btn btn-secondary">Reset</button>
           </form>
@@ -61,11 +61,13 @@ Project List
             <a href="?order_by=pi__username&direction=des&{{filter_parameters}}"><i class="fas fa-sort-down" aria-hidden="true"></i><span class="sr-only">Sort PI desc</span></a>
           </th>
           <th scope="col">Title</th>
-          <th scope="col" class="text-nowrap">
-            Field of Science
-            <a href="?order_by=field_of_science&direction=asc&{{filter_parameters}}"><i class="fas fa-sort-up" aria-hidden="true"></i><span class="sr-only">Sort Field of Science asc</span></a>
-            <a href="?order_by=field_of_science&direction=des&{{filter_parameters}}"><i class="fas fa-sort-down" aria-hidden="true"></i><span class="sr-only">Sort Field of Science desc</span></a>
-          </th>
+          {% if not settings.FIELD_OF_SCIENCE_HIDE %}
+              <th scope="col" class="text-nowrap">
+                Field of Science
+                <a href="?order_by=field_of_science&direction=asc&{{filter_parameters}}"><i class="fas fa-sort-up" aria-hidden="true"></i><span class="sr-only">Sort Field of Science asc</span></a>
+                <a href="?order_by=field_of_science&direction=des&{{filter_parameters}}"><i class="fas fa-sort-down" aria-hidden="true"></i><span class="sr-only">Sort Field of Science desc</span></a>
+              </th>
+          {% endif %}
           <th scope="col" class="text-nowrap">
             Status
             <a href="?order_by=status&direction=asc&{{filter_parameters}}"><i class="fas fa-sort-up" aria-hidden="true"></i><span class="sr-only">Sort Status asc</span></a>
@@ -90,7 +92,9 @@ Project List
             {% endif %}
             <td>{{ project.pi.username }}</td>
             <td style="text-align: justify; text-justify: inter-word;">{{ project.title }}</td>
-            <td>{{ project.field_of_science.description }}</td>
+            {% if not settings.FIELD_OF_SCIENCE_HIDE %}
+                <td>{{ project.field_of_science.description }}</td>
+            {% endif %}
             <td>{{ project.status.name }}</td>
             {% if PROJECT_INSTITUTION_EMAIL_MAP %}
                 <td>{{ project.institution }}</td>

--- a/coldfront/core/project/templates/project/project_update_form.html
+++ b/coldfront/core/project/templates/project/project_update_form.html
@@ -11,14 +11,18 @@ Update Project
 {% block content %}
 <form method="post">
   {% csrf_token %}
-  {{ form|crispy }}
+  {% crispy form form.helper %}
   <input class="btn btn-primary" type="submit" value="Save" />
   <a class="btn btn-secondary" href="{% url 'project-detail' object.pk %}" role="button">Cancel</a>
 </form>
 
+{% if not settings.FIELD_OF_SCIENCE_HIDE %}
 <script>
   $(document).ready(function() {
     $('#id_field_of_science').select2();
   });
 </script>
+{% endif %}
+
 {% endblock %}
+

--- a/coldfront/core/project/tests/test_views.py
+++ b/coldfront/core/project/tests/test_views.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from coldfront.core.project.models import ProjectUserStatusChoice
 from coldfront.core.test_helpers import utils
@@ -114,6 +114,18 @@ class ProjectDetailViewTest(ProjectViewTestBase):
         # non-manager user cannot see add notification button
         utils.page_does_not_contain_for_user(self, self.project_user, self.url, "Add Notification")
 
+    @override_settings(FIELD_OF_SCIENCE_HIDE=True)
+    def test_project_detail_field_of_science_hidden(self):
+        """Test that the setting FIELD_OF_SCIENCE_HIDE=True hides the field of science field on the project detail form."""
+        response = utils.login_and_get_page(self.client, self.admin_user, self.url)
+        self.assertNotContains(response, "Field of Science:")
+
+    @override_settings(FIELD_OF_SCIENCE_HIDE=False)
+    def test_project_detail_field_of_science_visible(self):
+        """Test that the setting FIELD_OF_SCIENCE_HIDE=False shows the field of science field on the project detail form."""
+        response = utils.login_and_get_page(self.client, self.admin_user, self.url)
+        self.assertContains(response, "Field of Science:")
+
 
 class ProjectCreateTest(ProjectViewTestBase):
     """Tests for project create view"""
@@ -132,6 +144,18 @@ class ProjectCreateTest(ProjectViewTestBase):
         utils.test_user_cannot_access(self, self.pi_user, self.url)
         utils.test_user_cannot_access(self, self.project_user, self.url)
         utils.test_user_cannot_access(self, self.nonproject_user, self.url)
+
+    @override_settings(FIELD_OF_SCIENCE_HIDE=True)
+    def test_project_create_field_of_science_hidden(self):
+        """Test that the setting FIELD_OF_SCIENCE_HIDE=True hides the field of science field on the project create form."""
+        response = utils.login_and_get_page(self.client, self.admin_user, self.url)
+        self.assertNotContains(response, "Field of science")
+
+    @override_settings(FIELD_OF_SCIENCE_HIDE=False)
+    def test_project_create_field_of_science_visible(self):
+        """Test that the setting FIELD_OF_SCIENCE_HIDE=False shows the field of science field on the project create form."""
+        response = utils.login_and_get_page(self.client, self.admin_user, self.url)
+        self.assertContains(response, "Field of science")
 
 
 class ProjectAttributeCreateTest(ProjectViewTestBase):
@@ -303,6 +327,29 @@ class ProjectListViewTest(ProjectViewTestBase):
         response = utils.login_and_get_page(self.client, self.admin_user, url)
         self.assertEqual(len(response.context["object_list"]), 1)
 
+    @override_settings(FIELD_OF_SCIENCE_HIDE=True)
+    def test_project_list_search_field_of_science_hidden(self):
+        """Test that project list search works when field_of_science is hidden."""
+        url_base = self.url + "?show_all_projects=on"
+        url = f"{url_base}&last_name={self.project.pi.last_name}"
+        # search by project project_title
+        response = utils.login_and_get_page(self.client, self.admin_user, url)
+        self.assertEqual(len(response.context["object_list"]), 1)
+
+    @override_settings(FIELD_OF_SCIENCE_HIDE=True)
+    def test_project_list_field_of_science_hidden(self):
+        """Test that the setting FIELD_OF_SCIENCE_HIDE=True hides the field of science field on the search form."""
+        url = self.url
+        response = utils.login_and_get_page(self.client, self.admin_user, url)
+        self.assertNotContains(response, "Field of Science")
+
+    @override_settings(FIELD_OF_SCIENCE_HIDE=False)
+    def test_project_list_field_of_science_visible(self):
+        """Test that the setting FIELD_OF_SCIENCE_HIDE=False shows the field of science field on the search form."""
+        url = self.url
+        response = utils.login_and_get_page(self.client, self.admin_user, url)
+        self.assertContains(response, "Field of Science")
+
 
 class ProjectRemoveUsersViewTest(ProjectViewTestBase):
     """Tests for ProjectRemoveUsersView"""
@@ -327,6 +374,18 @@ class ProjectUpdateViewTest(ProjectViewTestBase):
         """test access to project update page"""
         self.project_access_tstbase(self.url)
 
+    @override_settings(FIELD_OF_SCIENCE_HIDE=True)
+    def test_project_update_field_of_science_hidden(self):
+        """Test that the setting FIELD_OF_SCIENCE_HIDE=True hides the field of science field on the project update form."""
+        response = utils.login_and_get_page(self.client, self.admin_user, self.url)
+        self.assertNotContains(response, "Field of science")
+
+    @override_settings(FIELD_OF_SCIENCE_HIDE=False)
+    def test_project_update_field_of_science_visible(self):
+        """Test that the setting FIELD_OF_SCIENCE_HIDE=False shows the field of science field on the project update form."""
+        response = utils.login_and_get_page(self.client, self.admin_user, self.url)
+        self.assertContains(response, "Field of science")
+
 
 class ProjectReviewListViewTest(ProjectViewTestBase):
     """Tests for ProjectReviewListView"""
@@ -350,6 +409,18 @@ class ProjectArchivedListViewTest(ProjectViewTestBase):
     def test_projectarchivedlistview_access(self):
         """test access to project archived list page"""
         self.project_access_tstbase(self.url)
+
+    @override_settings(FIELD_OF_SCIENCE_HIDE=True)
+    def test_projectarchivedlistview_field_of_science_hidden(self):
+        """Test that the setting FIELD_OF_SCIENCE_HIDE=True hides the field of science field on the project archived list search form."""
+        response = utils.login_and_get_page(self.client, self.admin_user, self.url)
+        self.assertNotContains(response, "Field of Science")
+
+    @override_settings(FIELD_OF_SCIENCE_HIDE=False)
+    def test_projectarchivedlistview_field_of_science_visible(self):
+        """Test that the setting FIELD_OF_SCIENCE_HIDE=False shows the field of science field on the project archived list search form."""
+        response = utils.login_and_get_page(self.client, self.admin_user, self.url)
+        self.assertContains(response, "Field of Science")
 
 
 class ProjectNoteCreateViewTest(ProjectViewTestBase):

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -39,11 +39,11 @@ from coldfront.core.project.forms import (
     ProjectAttributeAddForm,
     ProjectAttributeDeleteForm,
     ProjectAttributeUpdateForm,
-    ProjectCreationForm,
     ProjectRemoveUserForm,
     ProjectReviewEmailForm,
     ProjectReviewForm,
     ProjectSearchForm,
+    ProjectUpdateForm,
     ProjectUserUpdateForm,
 )
 from coldfront.core.project.models import (
@@ -301,7 +301,7 @@ class ProjectListView(LoginRequiredMixin, ListView):
                 )
 
             # Field of Science
-            if data.get("field_of_science"):
+            if data.get("field_of_science", ""):
                 projects = projects.filter(field_of_science__description__icontains=data.get("field_of_science"))
 
         else:
@@ -568,7 +568,7 @@ class ProjectArchiveProjectView(LoginRequiredMixin, UserPassesTestMixin, Templat
 class ProjectCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     model = Project
     template_name_suffix = "_create_form"
-    form_class = ProjectCreationForm
+    form_class = ProjectUpdateForm
 
     def test_func(self):
         """UserPassesTestMixin Tests"""
@@ -615,11 +615,7 @@ class ProjectCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
 class ProjectUpdateView(SuccessMessageMixin, LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     model = Project
     template_name_suffix = "_update_form"
-    fields = [
-        "title",
-        "description",
-        "field_of_science",
-    ]
+    form_class = ProjectUpdateForm
     success_message = "Project updated."
 
     def test_func(self):


### PR DESCRIPTION
This PR adds the setting FIELD_OF_SCIENCE_HIDE that removes or hides references to Field of Science from all pages when True. It defaults to False, so that the default behavior of Coldfront does not change. It does not remove the field of science field from the Project model.

In many cases, references to the field of science were removed by simply adding conditional inclusion of the field on respective templates. This includes the allocations by field of science graphic on the center-summary page. Additionally, references to relevant fields in javascript are also handled.

In the cases of the ProjectSearchForm and the ProjectCreationForm (renamed ProjectUpdateForm), the django crispy-forms FormHelper object was used to dynamically include/exclude the Field of Science search field.

The ProjectUpdateView was assigned the same form_class as the ProjectCreateView so that they share fields.

Tests test inclusion or exclusion of the Field of Science depending on the setting using the @override_settings decorator.