### PR TITLE
Add more allocation info on the add user project page

### DIFF
--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -40,39 +40,12 @@ class ProjectAddUserForm(forms.Form):
 
 
 class ProjectAddUsersToAllocationForm(forms.Form):
-    allocation = forms.MultipleChoiceField(
-        widget=forms.CheckboxSelectMultiple(attrs={"checked": "checked"}), required=False
-    )
-
-    def __init__(self, request_user, project_pk, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        project_obj = get_object_or_404(Project, pk=project_pk)
-
-        allocation_query_set = project_obj.allocation_set.filter(
-            resources__is_allocatable=True,
-            is_locked=False,
-            status__name__in=["Active", "New", "Renewal Requested", "Payment Pending", "Payment Requested", "Paid"],
-        )
-        allocation_choices = [
-            (
-                allocation.id,
-                "%s (%s) %s"
-                % (
-                    allocation.get_parent_resource.name,
-                    allocation.get_parent_resource.resource_type.name,
-                    allocation.description if allocation.description else "",
-                ),
-            )
-            for allocation in allocation_query_set
-        ]
-        allocation_choices_sorted = []
-        allocation_choices_sorted = sorted(allocation_choices, key=lambda x: x[1][0].lower())
-        allocation_choices.insert(0, ("__select_all__", "Select All"))
-        if allocation_query_set:
-            self.fields["allocation"].choices = allocation_choices_sorted
-            self.fields["allocation"].help_text = "<br/>Select allocations to add selected users to."
-        else:
-            self.fields["allocation"].widget = forms.HiddenInput()
+    pk = forms.IntegerField(disabled=True)
+    selected = forms.BooleanField(initial=False, required=False)
+    resource = forms.CharField(max_length=50, disabled=True)
+    details = forms.CharField(max_length=300, disabled=True, required=False)
+    resource_type = forms.CharField(max_length=50, disabled=True)
+    status = forms.CharField(max_length=50, disabled=True)
 
 
 class ProjectRemoveUserForm(forms.Form):

--- a/coldfront/core/project/templates/project/add_user_search_results.html
+++ b/coldfront/core/project/templates/project/add_user_search_results.html
@@ -26,8 +26,38 @@
     <div class="card bg-light mb-3 {{div_allocation_class}}">
       <div class="card-header">Available Allocations</div>
       <div class="card-body">
-        {{allocation_form|crispy}}
+        <div class="table-responsive">
+          <table class="table table-sm table-hover">
+            <thead>
+              <tr>
+                <th><input type="checkbox" class="check" id="selectAllAllocations"></th>
+                <th scope="col">#</th>
+                <th scope="col">Resource</th>
+                <th scope="col">Details</th>
+                <th scope="col">Resource Type</th>
+                <th scope="col">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for form in allocation_formset %}
+                <tr>
+                  <td>{{ form.selected }}</td>
+                  <td><a href="{% url 'allocation-detail' form.pk.value %}" target="_blank">{{ form.pk.value }}</a></td>
+                  <td>{{ form.resource.value }}</td>
+                  <td>{{ form.details.value }}</td>
+                  <td>{{ form.resource_type.value }}</td>
+                  <td>{{ form.status.value }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>      
       </div>
+      <div class="card-footer">
+        <i class="fa fa-info-circle" aria-hidden="true"></i>
+        Select allocations to add selected users to.
+      </div>
+      {{ allocation_formset.management_form }}
     </div>
 
     <div class="table-responsive">
@@ -87,14 +117,15 @@
     }
   });
 
-  $("#id_allocationform-allocation_0").click(function () {
+  $("#selectAllAllocations").click(function () {
     $("input[name^='allocationform-']").prop('checked', $(this).prop('checked'));
   });
 
   $("input[name^='allocationform-']").click(function (ele) {
     var id = $(this).attr('id');
-    if ( id != "id_allocationform-allocation_0") {
-      $("#id_allocationform-allocation_0").prop('checked', false);
+    if ( id != "selectAllAllocations") {
+      $("#selectAllAllocations").prop('checked', false);
+    }
   });
 </script>
 


### PR DESCRIPTION
This PR takes care of #800 by making changes to the add project user to allocation form and using a formset to display the list of allocations. The new information includes a details column that uses the `get_information` function, a column that displays a URL to an allocation, and an allocation status column. The allocations section was also changed to look similar to the users section but also placed within a card.

![Screenshot_26-9-2025_11956_localhost](https://github.com/user-attachments/assets/7d574e14-14cd-434c-9406-4de7d55c3299)
