### PR TITLE
project_openldap: fix try/catch block

### DIFF
--- a/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py
+++ b/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py
@@ -144,6 +144,7 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"Exception creating vars for OpenLDAP archive action for Project {project.project_code}: {e}"
             )
+            return
 
         # if sync not permitted, notify, DN is passed to function here
         if not sync:


### PR DESCRIPTION
I noticed these pyright errors:
```
project_openldap_sync.py:153:34 - error: "archive_posixgroup_dn" is possibly unbound (reportPossiblyUnboundVariable)
project_openldap_sync.py:157:34 - error: "archive_posixgroup_dn" is possibly unbound (reportPossiblyUnboundVariable)
project_openldap_sync.py:164:48 - error: "archive_posixgroup_dn" is possibly unbound (reportPossiblyUnboundVariable)
project_openldap_sync.py:168:85 - error: "archive_ou_dn" is possibly unbound (reportPossiblyUnboundVariable)
project_openldap_sync.py:169:57 - error: "archive_ou_dn" is possibly unbound (reportPossiblyUnboundVariable)
project_openldap_sync.py:169:72 - error: "archive_openldap_ou_description" is possibly unbound (reportPossiblyUnboundVariable)
project_openldap_sync.py:172:93 - error: "archive_posixgroup_dn" is possibly unbound (reportPossiblyUnboundVariable)
project_openldap_sync.py:174:21 - error: "archive_posixgroup_dn" is possibly unbound (reportPossiblyUnboundVariable)
project_openldap_sync.py:175:21 - error: "archive_openldap_posixgroup_description" is possibly unbound (reportPossiblyUnboundVariable)
project_openldap_sync.py:176:21 - error: "archive_gid" is possibly unbound (reportPossiblyUnboundVariable)
project_openldap_sync.py:180:55 - error: "archive_posixgroup_dn" is possibly unbound (reportPossiblyUnboundVariable)
```
It seems that in the event of an exception, the sync command will print the exception and then keep running and then crash when it refers to these variables.