### PR TITLE
project_openldap: make function names more generic

### DIFF
--- a/coldfront/plugins/project_openldap/management/commands/project_openldap_check_setup.py
+++ b/coldfront/plugins/project_openldap/management/commands/project_openldap_check_setup.py
@@ -11,7 +11,7 @@ from ldap3.core.exceptions import LDAPException
 from coldfront.core.utils.common import import_from_settings
 from coldfront.plugins.project_openldap.utils import (
     PROJECT_OPENLDAP_BIND_USER,
-    ldapsearch_check_project_ou,
+    ldapsearch_check_ou,
 )
 
 """ Coldfront project_openldap plugin - django management command -  project_openldap_check_setup.py """
@@ -160,7 +160,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS(f" {PROJECT_OPENLDAP_OU} is set to {PROJECT_OPENLDAP_OU}"))
             self.stdout.write(self.style.SUCCESS(" ldapsearch..."))
             try:
-                ldapsearch_check_project_ou_result = ldapsearch_check_project_ou(PROJECT_OPENLDAP_OU)
+                ldapsearch_check_project_ou_result = ldapsearch_check_ou(PROJECT_OPENLDAP_OU)
                 if ldapsearch_check_project_ou_result and not isinstance(ldapsearch_check_project_ou_result, Exception):
                     self.stdout.write(
                         self.style.SUCCESS(
@@ -186,7 +186,7 @@ class Command(BaseCommand):
             )
             self.stdout.write(self.style.SUCCESS(" ldapsearch..."))
             try:
-                ldapsearch_check_project_ou_result = ldapsearch_check_project_ou(PROJECT_OPENLDAP_ARCHIVE_OU)
+                ldapsearch_check_project_ou_result = ldapsearch_check_ou(PROJECT_OPENLDAP_ARCHIVE_OU)
                 if ldapsearch_check_project_ou_result and not isinstance(ldapsearch_check_project_ou_result, Exception):
                     self.stdout.write(
                         self.style.SUCCESS(

--- a/coldfront/plugins/project_openldap/tasks.py
+++ b/coldfront/plugins/project_openldap/tasks.py
@@ -9,19 +9,19 @@ import logging
 from coldfront.core.project.models import ProjectUser
 from coldfront.core.utils.common import import_from_settings
 from coldfront.plugins.project_openldap.utils import (
-    add_members_to_openldap_project_posixgroup,
+    add_members_to_openldap_posixgroup,
     add_per_project_ou_to_openldap,
-    add_project_posixgroup_to_openldap,
+    add_posixgroup_to_openldap,
     allocate_project_openldap_gid,
-    archive_project_in_openldap,
     construct_dn_str,
     construct_ou_dn_str,
     construct_per_project_ou_relative_dn_str,
     construct_project_ou_description,
     construct_project_posixgroup_description,
+    move_dn_in_openldap,
     remove_dn_from_openldap,
-    remove_members_from_openldap_project_posixgroup,
-    update_project_posixgroup_in_openldap,
+    remove_members_from_openldap_posixgroup,
+    update_posixgroup_description_in_openldap,
 )
 
 # Setup logging
@@ -77,7 +77,7 @@ def add_project(project_obj):
         openldap_posixgroup_description,
     )
 
-    add_project_posixgroup_to_openldap(posixgroup_dn, openldap_posixgroup_description, gid_int)
+    add_posixgroup_to_openldap(posixgroup_dn, openldap_posixgroup_description, gid_int)
 
 
 # Coldfront archive project action
@@ -99,7 +99,7 @@ def remove_project(project_obj):
     else:
         relative_dn = construct_per_project_ou_relative_dn_str(project_obj)
         logger.info(f"Project OU {ou_dn} is going to be ARCHIVED in OpenLDAP at {PROJECT_OPENLDAP_ARCHIVE_OU}...")
-        archive_project_in_openldap(ou_dn, relative_dn, PROJECT_OPENLDAP_ARCHIVE_OU)
+        move_dn_in_openldap(ou_dn, relative_dn, PROJECT_OPENLDAP_ARCHIVE_OU)
 
 
 def update_project(project_obj):
@@ -110,7 +110,7 @@ def update_project(project_obj):
 
     logger.info("Modifying OpenLDAP entry: %s", dn)
     logger.info("Modifying OpenLDAP with description: %s", openldap_description)
-    update_project_posixgroup_in_openldap(dn, openldap_description)
+    update_posixgroup_description_in_openldap(dn, openldap_description)
 
 
 def add_user_project(project_user_pk):
@@ -126,7 +126,7 @@ def add_user_project(project_user_pk):
 
     list_memberuids = []
     list_memberuids.append(final_user_username)
-    add_members_to_openldap_project_posixgroup(dn, list_memberuids)
+    add_members_to_openldap_posixgroup(dn, list_memberuids)
 
 
 def remove_user_project(project_user_pk):
@@ -142,4 +142,4 @@ def remove_user_project(project_user_pk):
 
     list_memberuids = []
     list_memberuids.append(final_user_username)
-    remove_members_from_openldap_project_posixgroup(dn, list_memberuids)
+    remove_members_from_openldap_posixgroup(dn, list_memberuids)

--- a/coldfront/plugins/project_openldap/utils.py
+++ b/coldfront/plugins/project_openldap/utils.py
@@ -60,7 +60,7 @@ def openldap_connection(server_opt, bind_user, bind_password):
         return None
 
 
-def add_members_to_openldap_project_posixgroup(dn, list_memberuids, write=True):
+def add_members_to_openldap_posixgroup(dn, list_memberuids, write=True):
     """Add members to a posixgroup in OpenLDAP"""
     member_uid = tuple(list_memberuids)
     conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
@@ -81,7 +81,7 @@ def add_members_to_openldap_project_posixgroup(dn, list_memberuids, write=True):
         conn.unbind()
 
 
-def remove_members_from_openldap_project_posixgroup(dn, list_memberuids, write=True):
+def remove_members_from_openldap_posixgroup(dn, list_memberuids, write=True):
     """Remove members from a posixgroup in OpenLDAP"""
     member_uids_tuple = tuple(list_memberuids)
     conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
@@ -131,8 +131,8 @@ def add_per_project_ou_to_openldap(project_obj, dn, openldap_ou_description, wri
         conn.unbind()
 
 
-def add_project_posixgroup_to_openldap(dn, openldap_description, gid_int, write=True):
-    """Add a project to OpenLDAP - write a posixGroup"""
+def add_posixgroup_to_openldap(dn, openldap_description, gid_int, write=True):
+    """Add a posixGroup to OpenLDAP"""
     conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
 
     if not conn:
@@ -159,7 +159,7 @@ def add_project_posixgroup_to_openldap(dn, openldap_description, gid_int, write=
 
 # Remove a DN - e.g. DELETE a project OU or posixgroup in OpenLDAP
 def remove_dn_from_openldap(dn, write=True):
-    """Remove a project from OpenLDAP - delete a posixGroup"""
+    """Remove a DN from OpenLDAP"""
     conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
 
     if not conn:
@@ -179,7 +179,7 @@ def remove_dn_from_openldap(dn, write=True):
 
 
 # Update the project title in OpenLDAP
-def update_project_posixgroup_in_openldap(dn, openldap_description, write=True):
+def update_posixgroup_description_in_openldap(dn, openldap_description, write=True):
     """Update the description of a posixGroup in OpenLDAP"""
     conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
 
@@ -199,8 +199,8 @@ def update_project_posixgroup_in_openldap(dn, openldap_description, write=True):
 
 
 # MOVE the project to an archive OU - defined as env var
-def archive_project_in_openldap(current_dn, relative_dn, archive_ou, write=True):
-    """Move a project to the archive OU in OpenLDAP"""
+def move_dn_in_openldap(current_dn, relative_dn, destination_ou, write=True):
+    """Move a DN to another OU in OpenLDAP"""
     conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
 
     if not conn:
@@ -210,7 +210,7 @@ def archive_project_in_openldap(current_dn, relative_dn, archive_ou, write=True)
         return None
 
     try:
-        conn.modify_dn(current_dn, relative_dn, new_superior=archive_ou)
+        conn.modify_dn(current_dn, relative_dn, new_superior=destination_ou)
         conn.unbind()
     except Exception as exc_log:
         logger.info(exc_log)
@@ -236,7 +236,7 @@ def ldapsearch_check_project_dn(dn):
 
 
 # check bind user can see the Project OU or Archive OU - is also used in system setup check script
-def ldapsearch_check_project_ou(OU):
+def ldapsearch_check_ou(OU):
     """Test that ldapsearch can see an OU"""
     conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
 
@@ -253,8 +253,8 @@ def ldapsearch_check_project_ou(OU):
         conn.unbind()
 
 
-def ldapsearch_get_project_memberuids(dn):
-    """Get memberUids from a project's posixGroup"""
+def ldapsearch_get_posixgroup_memberuids(dn):
+    """Get memberUids from a posixGroup"""
     conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
 
     if not conn:
@@ -271,8 +271,8 @@ def ldapsearch_get_project_memberuids(dn):
         conn.unbind()
 
 
-def ldapsearch_get_project_description(dn):
-    """Get description from a project's posixGroup"""
+def ldapsearch_get_description(dn):
+    """Get description from an openldap entry"""
     conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
 
     if not conn:


### PR DESCRIPTION
Many of the functions in `project_openldap.utils` are generic for any LDAP entry, with unnecessarily specific names. I want to import these functions and use them for `allocation_ldap`.

All these renames were done with vscode/pylance [rename symbol](https://code.visualstudio.com/docs/editing/refactoring#_rename-symbol) feature, which promises to fix all references to a symbol across the entire codebase.

other changes:
* `update_project_posixgroup_in_openldap` -> `update_project_posixgroup_description_in_openldap` is actually *less* generic