### PR TITLE
refactor allocation status lists

### DIFF
--- a/coldfront/config/core.py
+++ b/coldfront/config/core.py
@@ -55,11 +55,124 @@ ALLOCATION_DEFAULT_ALLOCATION_LENGTH = ENV.int("ALLOCATION_DEFAULT_ALLOCATION_LE
 ALLOCATION_ACCOUNT_ENABLED = ENV.bool("ALLOCATION_ACCOUNT_ENABLED", default=False)
 ALLOCATION_ACCOUNT_MAPPING = ENV.dict("ALLOCATION_ACCOUNT_MAPPING", default={})
 
+# ------------------------------------------------------------------------------
+# Lists of statuses by which to select allocations for various situations
+# see docs/pages/config.md for more information
+# ------------------------------------------------------------------------------
+ALLOCATION_STATUSES_ALLOW_RENEW = ENV.list("ALLOCATION_STATUSES_ALLOW_RENEW", default=["Active"])
+ALLOCATION_STATUSES_DO_ACTIVATE = ENV.list("ALLOCATION_STATUSES_DO_ACTIVATE", default=["Active"])
+ALLOCATION_STATUSES_REQUIRE_EULA = ENV.list("ALLOCATION_STATUSES_REQUIRE_EULA", default=["Active"])
+ALLOCATION_STATUSES_REQUIRE_START_DATE = ENV.list("ALLOCATION_STATUSES_REQUIRE_START_DATE", default=["Active"])
+ALLOCATION_STATUSES_REQUIRE_END_DATE = ENV.list("ALLOCATION_STATUSES_REQUIRE_END_DATE", default=["Expired"])
+ALLOCATION_STATUSES_DO_DISABLE = ENV.list(
+    "ALLOCATION_STATUSES_DO_DISABLE",
+    default=["Denied", "Revoked"],
+)
+ALLOCATION_STATUSES_DO_UNSET_START_DATE_END_DATE = ENV.list(
+    "ALLOCATION_STATUSES_DO_UNSET_START_DATE_END_DATE",
+    default=["Denied", "New", "Revoked"],
+)
+ALLOCATION_STATUSES_USER_IS_ACTIVE = ENV.list(
+    "ALLOCATION_STATUSES_USER_IS_ACTIVE",
+    default=["Active", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_USER_CHOICES = ENV.list(
+    "ALLOCATION_STATUSES_USER_CHOICES",
+    default=["Approved", "Denied", "Pending"],
+)
+ALLOCATION_STATUSES_DO_REMOVE_USER = ENV.list(
+    "ALLOCATION_STATUSES_DO_REMOVE_USER",
+    default=["Active", "New", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_PAUSRV = ENV.list(
+    "ALLOCATION_STATUSES_PAUSRV",
+    default=["Active", "New", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_ALLOW_REMOVE_USER = ENV.list(
+    "ALLOCATION_STATUSES_ALLOW_REMOVE_USER",
+    default=["Active", "New", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_SHOW_ADD_REMOVE_USER = ENV.list(
+    "ALLOCATION_STATUSES_SHOW_ADD_REMOVE_USER",
+    default=["Active", "New", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_HOMEPAGE = ENV.list(
+    "ALLOCATION_STATUSES_HOMEPAGE",
+    default=["Active", "New", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_AWAITING_ADMIN_ACTION = ENV.list(
+    "ALLOCATION_STATUSES_AWAITING_ADMIN_ACTION",
+    default=["Approved", "New", "Paid", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_SHORT_RENEW_URL = ENV.list(
+    "ALLOCATION_STATUSES_SHORT_RENEW_URL",
+    default=["Payment Pending", "Payment Requested", "Unpaid"],
+)
+ALLOCATION_STATUSES_CAN_EXPIRE = ENV.list(
+    "ALLOCATION_STATUSES_CAN_EXPIRE",
+    default=["Active", "Payment Pending", "Payment Requested", "Unpaid"],
+)
+ALLOCATION_STATUSES_PAYMENT_RELATED = ENV.list(
+    "ALLOCATION_STATUSES_PAYMENT_RELATED",
+    default=["Paid", "Payment Declined", "Payment Pending", "Payment Requested"],
+)
+ALLOCATION_STATUSES_ALLOW_CHANGE = ENV.list(
+    "ALLOCATION_STATUSES_ALLOW_CHANGE",
+    default=["Active", "Paid", "Payment Pending", "Payment Requested", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_COUNT_TOWARDS_LIMIT = ENV.list(
+    "ALLOCATION_STATUSES_COUNT_TOWARDS_LIMIT",
+    default=["Active", "New", "Paid", "Payment Pending", "Payment Requested", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_SUIPBNIA = ENV.list(
+    "ALLOCATION_STATUSES_SUIPBNIA",
+    default=["Active", "New", "Paid", "Payment Pending", "Payment Requested", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_ALLOW_ADD_USER = ENV.list(
+    "ALLOCATION_STATUSES_ALLOW_ADD_USER",
+    default=["Active", "New", "Paid", "Payment Pending", "Payment Requested", "Renewal Requested"],
+)
+ALLOCATION_STATUSES_DO_REMOVE_USER_RENEW = ENV.list(
+    "ALLOCATION_STATUSES_DO_REMOVE_USER_RENEW",
+    default=[
+        "Active",
+        "Denied",
+        "New",
+        "Paid",
+        "Payment Declined",
+        "Payment Pending",
+        "Payment Requested",
+        "Renewal Requested",
+        "Unpaid",
+    ],
+)
+ALLOCATION_STATUSES_ALL = ENV.list(
+    "ALLOCATION_STATUSES_ALL",
+    # FIXME add "Approved", "Pending"
+    default=[
+        "Active",
+        "Denied",
+        "Expired",
+        "New",
+        "Paid",
+        "Payment Declined",
+        "Payment Pending",
+        "Payment Requested",
+        "Renewal Requested",
+        "Revoked",
+        "Unpaid",
+    ],
+)
+
+# ------------------------------------------------------------------------------
+
 SETTINGS_EXPORT += [
     "ALLOCATION_ACCOUNT_ENABLED",
     "ALLOCATION_DEFAULT_ALLOCATION_LENGTH",
     "ALLOCATION_ENABLE_ALLOCATION_RENEWAL",
     "ALLOCATION_EULA_ENABLE",
+    "ALLOCATION_STATUSES_ALLOW_CHANGE",
+    "ALLOCATION_STATUSES_SHOW_ADD_REMOVE_USER",
     "CENTER_HELP_URL",
     "GRANT_ENABLE",
     "INVOICE_ENABLED",

--- a/coldfront/config/plugins/freeipa.py
+++ b/coldfront/config/plugins/freeipa.py
@@ -16,3 +16,7 @@ FREEIPA_ENABLE_SIGNALS = False
 ADDITIONAL_USER_SEARCH_CLASSES = [
     "coldfront.plugins.freeipa.search.LDAPUserSearch",
 ]
+FREEIPA_ALLOCATION_STATUSES_ALLOW_REMOVE_GROUP = ENV.list(
+    "FREEIPA_ALLOCATION_STATUSES_ALLOW_REMOVE_GROUP",
+    default=["Active", "Pending"],
+)

--- a/coldfront/config/plugins/slurm.py
+++ b/coldfront/config/plugins/slurm.py
@@ -13,3 +13,4 @@ SLURM_SACCTMGR_PATH = ENV.str("SLURM_SACCTMGR_PATH", default="/usr/bin/sacctmgr"
 SLURM_NOOP = ENV.bool("SLURM_NOOP", False)
 SLURM_IGNORE_USERS = ENV.list("SLURM_IGNORE_USERS", default=["root"])
 SLURM_IGNORE_ACCOUNTS = ENV.list("SLURM_IGNORE_ACCOUNTS", default=[])
+SLURM_ALLOCATION_STATUSES = ENV.list("SLURM_ALLOCATION_STATUSES", default=["Active", "Renewal Requested"])

--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -19,6 +19,7 @@ from coldfront.core.utils.common import import_from_settings
 
 ALLOCATION_ACCOUNT_ENABLED = import_from_settings("ALLOCATION_ACCOUNT_ENABLED", False)
 ALLOCATION_CHANGE_REQUEST_EXTENSION_DAYS = import_from_settings("ALLOCATION_CHANGE_REQUEST_EXTENSION_DAYS", [])
+ALLOCATION_STATUSES_PAYMENT_RELATED = import_from_settings("ALLOCATION_STATUSES_PAYMENT_RELATED")
 
 
 class AllocationForm(forms.Form):
@@ -91,9 +92,9 @@ class AllocationUpdateForm(forms.Form):
 
 class AllocationInvoiceUpdateForm(forms.Form):
     status = forms.ModelChoiceField(
-        queryset=AllocationStatusChoice.objects.filter(
-            name__in=["Payment Pending", "Payment Requested", "Payment Declined", "Paid"]
-        ).order_by(Lower("name")),
+        queryset=AllocationStatusChoice.objects.filter(name__in=ALLOCATION_STATUSES_PAYMENT_RELATED).order_by(
+            Lower("name")
+        ),
         empty_label=None,
     )
 

--- a/coldfront/core/allocation/management/commands/add_allocation_defaults.py
+++ b/coldfront/core/allocation/management/commands/add_allocation_defaults.py
@@ -11,6 +11,10 @@ from coldfront.core.allocation.models import (
     AllocationUserStatusChoice,
     AttributeType,
 )
+from coldfront.core.utils.common import import_from_settings
+
+ALLOCATION_STATUSES_ALL = import_from_settings("ALLOCATION_STATUSES_ALL")
+ALLOCATION_STATUSES_USER_CHOICES = import_from_settings("ALLOCATION_STATUSES_USER_CHOICES")
 
 
 class Command(BaseCommand):
@@ -20,26 +24,10 @@ class Command(BaseCommand):
         for attribute_type in ("Date", "Float", "Int", "Text", "Yes/No", "No", "Attribute Expanded Text"):
             AttributeType.objects.get_or_create(name=attribute_type)
 
-        for choice in (
-            "Active",
-            "Denied",
-            "Expired",
-            "New",
-            "Paid",
-            "Payment Pending",
-            "Payment Requested",
-            "Payment Declined",
-            "Renewal Requested",
-            "Revoked",
-            "Unpaid",
-        ):
+        for choice in ALLOCATION_STATUSES_ALL:
             AllocationStatusChoice.objects.get_or_create(name=choice)
 
-        for choice in (
-            "Pending",
-            "Approved",
-            "Denied",
-        ):
+        for choice in ALLOCATION_STATUSES_USER_CHOICES:
             AllocationChangeStatusChoice.objects.get_or_create(name=choice)
 
         for choice in ("Active", "Error", "Removed", "PendingEULA", "DeclinedEULA"):

--- a/coldfront/core/allocation/tasks.py
+++ b/coldfront/core/allocation/tasks.py
@@ -34,17 +34,14 @@ EMAIL_ADMIN_LIST = import_from_settings("EMAIL_ADMIN_LIST")
 
 EMAIL_ALLOCATION_EULA_IGNORE_OPT_OUT = import_from_settings("EMAIL_ALLOCATION_EULA_IGNORE_OPT_OUT")
 
+ALLOCATION_STATUSES_CAN_EXPIRE = import_from_settings("ALLOCATION_STATUSES_CAN_EXPIRE")
+ALLOCATION_STATUSES_SHORT_RENEW_URL = import_from_settings("ALLOCATION_STATUSES_SHORT_RENEW_URL")
+
 
 def update_statuses():
     expired_status_choice = AllocationStatusChoice.objects.get(name="Expired")
     allocations_to_expire = Allocation.objects.filter(
-        status__name__in=[
-            "Active",
-            "Payment Pending",
-            "Payment Requested",
-            "Unpaid",
-        ],
-        end_date__lt=datetime.datetime.now().date(),
+        status__name__in=ALLOCATION_STATUSES_CAN_EXPIRE, end_date__lt=datetime.datetime.now().date()
     )
     for sub_obj in allocations_to_expire:
         sub_obj.status = expired_status_choice
@@ -97,12 +94,12 @@ def send_expiry_emails():
             for allocationuser in user.allocationuser_set.all():
                 allocation = allocationuser.allocation
 
-                if (allocation.status.name in ["Active", "Payment Pending", "Payment Requested", "Unpaid"]) and (
+                if (allocation.status.name in ALLOCATION_STATUSES_CAN_EXPIRE) and (
                     allocation.end_date == expring_in_days
                 ):
                     project_url = f"{CENTER_BASE_URL.strip('/')}/{'project'}/{allocation.project.pk}/"
 
-                    if allocation.status.name in ["Payment Pending", "Payment Requested", "Unpaid"]:
+                    if allocation.status.name in ALLOCATION_STATUSES_SHORT_RENEW_URL:
                         allocation_renew_url = f"{CENTER_BASE_URL.strip('/')}/{'allocation'}/{allocation.pk}/"
                     else:
                         allocation_renew_url = f"{CENTER_BASE_URL.strip('/')}/{'allocation'}/{allocation.pk}/{'renew'}/"

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -28,7 +28,7 @@ Allocation Detail
 
 <div class="card mb-3">
   <div class="card-header">
-    {% if allocation.is_changeable and not allocation.is_locked and is_allowed_to_update_project and allocation.status.name in 'Active, Renewal Requested, Payment Pending, Payment Requested, Paid' %}
+    {% if allocation.is_changeable and not allocation.is_locked and is_allowed_to_update_project and allocation.status.name in settings.ALLOCATION_STATUSES_ALLOW_CHANGE %}
     <div class="row">
       <div class="col">
         <h3><i class="fas fa-list" aria-hidden="true"></i> Allocation Information</h3>
@@ -330,7 +330,7 @@ Allocation Detail
     <h3 class="d-inline"><i class="fas fa-users" aria-hidden="true"></i> Users in Allocation</h3>
     <span class="badge badge-secondary">{{allocation_users.count}}</span>
     <div class="float-right">
-      {% if allocation.project.status.name != 'Archived' and is_allowed_to_update_project and allocation.status.name in 'Active,New,Renewal Requested' %}
+      {% if allocation.project.status.name != 'Archived' and is_allowed_to_update_project and allocation.status.name in settings.ALLOCATION_STATUSES_SHOW_ADD_REMOVE_USER %}
         <a class="btn btn-success" href="{% url 'allocation-add-users' allocation.pk %}" role="button">
           <i class="fas fa-user-plus" aria-hidden="true"></i> Add Users
         </a>

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -84,6 +84,21 @@ ALLOCATION_DEFAULT_ALLOCATION_LENGTH = import_from_settings("ALLOCATION_DEFAULT_
 ALLOCATION_ENABLE_CHANGE_REQUESTS_BY_DEFAULT = import_from_settings(
     "ALLOCATION_ENABLE_CHANGE_REQUESTS_BY_DEFAULT", True
 )
+ALLOCATION_STATUSES_ALLOW_ADD_USER = import_from_settings("ALLOCATION_STATUSES_ALLOW_ADD_USER")
+ALLOCATION_STATUSES_ALLOW_CHANGE = import_from_settings("ALLOCATION_STATUSES_ALLOW_CHANGE")
+ALLOCATION_STATUSES_ALLOW_REMOVE_USER = import_from_settings("ALLOCATION_STATUSES_ALLOW_REMOVE_USER")
+ALLOCATION_STATUSES_ALLOW_RENEW = import_from_settings("ALLOCATION_STATUSES_ALLOW_RENEW")
+ALLOCATION_STATUSES_AWAITING_ADMIN_ACTION = import_from_settings("ALLOCATION_STATUSES_AWAITING_ADMIN_ACTION")
+ALLOCATION_STATUSES_COUNT_TOWARDS_LIMIT = import_from_settings("ALLOCATION_STATUSES_COUNT_TOWARDS_LIMIT")
+ALLOCATION_STATUSES_DO_ACTIVATE = import_from_settings("ALLOCATION_STATUSES_DO_ACTIVATE")
+ALLOCATION_STATUSES_DO_DISABLE = import_from_settings("ALLOCATION_STATUSES_DO_DISABLE")
+ALLOCATION_STATUSES_DO_REMOVE_USER_RENEW = import_from_settings("ALLOCATION_STATUSES_DO_REMOVE_USER_RENEW")
+ALLOCATION_STATUSES_DO_UNSET_START_DATE_END_DATE = import_from_settings(
+    "ALLOCATION_STATUSES_DO_UNSET_START_DATE_END_DATE"
+)
+ALLOCATION_STATUSES_PAYMENT_RELATED = import_from_settings("ALLOCATION_STATUSES_PAYMENT_RELATED")
+ALLOCATION_STATUSES_REQUIRE_EULA = import_from_settings("ALLOCATION_STATUSES_REQUIRE_EULA")
+ALLOCATION_STATUSES_SHOW_ADD_REMOVE_USER = import_from_settings("ALLOCATION_STATUSES_SHOW_ADD_REMOVE_USER")
 
 PROJECT_ENABLE_PROJECT_REVIEW = import_from_settings("PROJECT_ENABLE_PROJECT_REVIEW", False)
 INVOICE_ENABLED = import_from_settings("INVOICE_ENABLED", False)
@@ -136,7 +151,10 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
                 allocation_user_status = get_object_or_404(
                     AllocationUser, allocation=allocation_obj, user=self.request.user
                 ).status
-                if allocation_obj.status.name == "Active" and allocation_user_status.name == "PendingEula":
+                if (
+                    allocation_obj.status.name in ALLOCATION_STATUSES_REQUIRE_EULA
+                    and allocation_user_status.name == "PendingEula"
+                ):
                     messages.info(self.request, "This allocation is active, but you must agree to the EULA to use it!")
 
             context["eulas"] = allocation_obj.get_eula()
@@ -258,7 +276,10 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
         elif action == "deny":
             allocation_obj.status = AllocationStatusChoice.objects.get(name="Denied")
 
-        if old_status != "Active" == allocation_obj.status.name:
+        if (
+            old_status not in ALLOCATION_STATUSES_DO_ACTIVATE
+            and allocation_obj.status.name in ALLOCATION_STATUSES_DO_ACTIVATE
+        ):
             if not allocation_obj.start_date:
                 allocation_obj.start_date = datetime.datetime.now()
             if "approve" in action or not allocation_obj.end_date:
@@ -284,12 +305,15 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             if action != "auto-approve":
                 messages.success(request, "Allocation Activated!")
 
-        elif old_status != allocation_obj.status.name in ["Denied", "New", "Revoked"]:
+        elif (
+            old_status != allocation_obj.status.name
+            and allocation_obj.status.name in ALLOCATION_STATUSES_DO_UNSET_START_DATE_END_DATE
+        ):
             allocation_obj.start_date = None
             allocation_obj.end_date = None
             allocation_obj.save()
 
-            if allocation_obj.status.name in ["Denied", "Revoked"]:
+            if allocation_obj.status.name in ALLOCATION_STATUSES_DO_DISABLE:
                 allocation_disable.send(sender=self.__class__, allocation_pk=allocation_obj.pk)
                 allocation_users = allocation_obj.allocationuser_set.exclude(status__name__in=["Removed", "Error"])
                 for allocation_user in allocation_users:
@@ -694,7 +718,7 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
             allocation_limit = int(allocation_limit_objs.value)
             allocation_count = project_obj.allocation_set.filter(
                 resources=resource_obj,
-                status__name__in=["Active", "New", "Renewal Requested", "Paid", "Payment Pending", "Payment Requested"],
+                status__name__in=ALLOCATION_STATUSES_COUNT_TOWARDS_LIMIT,
             ).count()
             if allocation_count >= allocation_limit:
                 form.add_error(None, format_html("Your project is at the allocation limit allowed for this resource."))
@@ -784,14 +808,7 @@ class AllocationAddUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
         message = None
         if allocation_obj.is_locked and not self.request.user.is_superuser:
             message = "You cannot modify this allocation because it is locked! Contact support for details."
-        elif allocation_obj.status.name not in [
-            "Active",
-            "New",
-            "Renewal Requested",
-            "Payment Pending",
-            "Payment Requested",
-            "Paid",
-        ]:
+        elif allocation_obj.status.name not in ALLOCATION_STATUSES_ALLOW_ADD_USER:
             message = f"You cannot add users to an allocation with status {allocation_obj.status.name}."
         if message:
             messages.error(request, message)
@@ -953,11 +970,7 @@ class AllocationRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, Templat
         message = None
         if allocation_obj.is_locked and not self.request.user.is_superuser:
             message = "You cannot modify this allocation because it is locked! Contact support for details."
-        elif allocation_obj.status.name not in [
-            "Active",
-            "New",
-            "Renewal Requested",
-        ]:
+        elif allocation_obj.status.name not in ALLOCATION_STATUSES_ALLOW_REMOVE_USER:
             message = f"You cannot remove users from a allocation with status {allocation_obj.status.name}."
         if message:
             messages.error(request, message)
@@ -1203,14 +1216,7 @@ class AllocationRequestListView(LoginRequiredMixin, UserPassesTestMixin, Templat
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        allocation_list = Allocation.objects.filter(
-            status__name__in=[
-                "New",
-                "Renewal Requested",
-                "Paid",
-                "Approved",
-            ]
-        )
+        allocation_list = Allocation.objects.filter(status__name__in=ALLOCATION_STATUSES_AWAITING_ADMIN_ACTION)
 
         allocation_renewal_dates = {}
         for allocation in allocation_list.filter(status__name="Renewal Requested"):
@@ -1248,9 +1254,7 @@ class AllocationRenewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView)
             )
             return HttpResponseRedirect(reverse("allocation-detail", kwargs={"pk": allocation_obj.pk}))
 
-        if allocation_obj.status.name not in [
-            "Active",
-        ]:
+        if allocation_obj.status.name not in ALLOCATION_STATUSES_ALLOW_RENEW:
             messages.error(request, f"You cannot renew a allocation with status {allocation_obj.status.name}.")
             return HttpResponseRedirect(reverse("allocation-detail", kwargs={"pk": allocation_obj.pk}))
 
@@ -1339,17 +1343,7 @@ class AllocationRenewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView)
 
                     elif user_status == "remove_from_project":
                         for active_allocation in allocation_obj.project.allocation_set.filter(
-                            status__name__in=(
-                                "Active",
-                                "Denied",
-                                "New",
-                                "Paid",
-                                "Payment Pending",
-                                "Payment Requested",
-                                "Payment Declined",
-                                "Renewal Requested",
-                                "Unpaid",
-                            )
+                            status__name__in=ALLOCATION_STATUSES_DO_REMOVE_USER_RENEW
                         ):
                             allocation_user_obj = active_allocation.allocationuser_set.get(user=user_obj)
                             allocation_user_obj.status = allocation_user_removed_status_choice
@@ -1393,14 +1387,7 @@ class AllocationInvoiceListView(LoginRequiredMixin, UserPassesTestMixin, ListVie
         return False
 
     def get_queryset(self):
-        allocations = Allocation.objects.filter(
-            status__name__in=[
-                "Paid",
-                "Payment Pending",
-                "Payment Requested",
-                "Payment Declined",
-            ]
-        )
+        allocations = Allocation.objects.filter(status__name__in=ALLOCATION_STATUSES_PAYMENT_RELATED)
         return allocations
 
 
@@ -1988,13 +1975,7 @@ class AllocationChangeView(LoginRequiredMixin, UserPassesTestMixin, FormView):
             messages.error(request, "You cannot request a change to a locked allocation.")
             return HttpResponseRedirect(reverse("allocation-detail", kwargs={"pk": allocation_obj.pk}))
 
-        if allocation_obj.status.name not in [
-            "Active",
-            "Renewal Requested",
-            "Payment Pending",
-            "Payment Requested",
-            "Paid",
-        ]:
+        if allocation_obj.status.name not in ALLOCATION_STATUSES_ALLOW_CHANGE:
             messages.error(
                 request, f'You cannot request a change to an allocation with status "{allocation_obj.status.name}".'
             )

--- a/coldfront/core/portal/views.py
+++ b/coldfront/core/portal/views.py
@@ -26,6 +26,7 @@ from coldfront.core.research_output.models import ResearchOutput
 from coldfront.core.utils.common import import_from_settings
 
 ALLOCATION_EULA_ENABLE = import_from_settings("ALLOCATION_EULA_ENABLE", False)
+ALLOCATION_STATUSES_HOMEPAGE = import_from_settings("ALLOCATION_STATUSES_HOMEPAGE")
 
 
 def home(request):
@@ -64,13 +65,7 @@ def home(request):
 
         allocation_list = (
             Allocation.objects.filter(
-                Q(
-                    status__name__in=[
-                        "Active",
-                        "New",
-                        "Renewal Requested",
-                    ]
-                )
+                Q(status__name__in=ALLOCATION_STATUSES_HOMEPAGE)
                 & Q(project__status__name__in=["Active", "New"])
                 & Q(project__projectuser__user=request.user)
                 & Q(

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -75,6 +75,9 @@ from coldfront.core.utils.mail import send_email, send_email_template
 EMAIL_ENABLED = import_from_settings("EMAIL_ENABLED", False)
 ALLOCATION_ENABLE_ALLOCATION_RENEWAL = import_from_settings("ALLOCATION_ENABLE_ALLOCATION_RENEWAL", True)
 ALLOCATION_DEFAULT_ALLOCATION_LENGTH = import_from_settings("ALLOCATION_DEFAULT_ALLOCATION_LENGTH", 365)
+ALLOCATION_STATUSES_DO_REMOVE_USER = import_from_settings("ALLOCATION_STATUSES_DO_REMOVE_USER")
+ALLOCATION_STATUSES_PAUSRV = import_from_settings("ALLOCATION_STATUSES_PAUSRV")
+ALLOCATION_STATUSES_ALLOW_ADD_USER = import_from_settings("ALLOCATION_STATUSES_ALLOW_ADD_USER")
 
 if EMAIL_ENABLED:
     EMAIL_DIRECTOR_EMAIL_ADDRESS = import_from_settings("EMAIL_DIRECTOR_EMAIL_ADDRESS")
@@ -696,7 +699,7 @@ class ProjectAddUsersSearchResultsView(LoginRequiredMixin, UserPassesTestMixin, 
         allocation_objs = project_obj.allocation_set.filter(
             resources__is_allocatable=True,
             is_locked=False,
-            status__name__in=["Active", "New", "Renewal Requested", "Payment Pending", "Payment Requested", "Paid"],
+            status__name__in=ALLOCATION_STATUSES_ALLOW_ADD_USER,
         )
         return [
             {
@@ -741,7 +744,7 @@ class ProjectAddUsersSearchResultsView(LoginRequiredMixin, UserPassesTestMixin, 
             context["users_already_in_project"] = users_already_in_project
 
         # The following block of code is used to hide/show the allocation div in the form.
-        if project_obj.allocation_set.filter(status__name__in=["Active", "New", "Renewal Requested"]).exists():
+        if project_obj.allocation_set.filter(status__name__in=ALLOCATION_STATUSES_PAUSRV).exists():
             div_allocation_class = "placeholder_div_class"
         else:
             div_allocation_class = "d-none"
@@ -1005,7 +1008,7 @@ class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
 
                     # get allocation to remove users from
                     allocations_to_remove_user_from = project_obj.allocation_set.filter(
-                        status__name__in=["Active", "New", "Renewal Requested"]
+                        status__name__in=ALLOCATION_STATUSES_DO_REMOVE_USER
                     )
                     for allocation in allocations_to_remove_user_from:
                         for allocation_user_obj in allocation.allocationuser_set.filter(

--- a/coldfront/core/utils/management/commands/show_users_in_project_but_not_in_allocation.py
+++ b/coldfront/core/utils/management/commands/show_users_in_project_but_not_in_allocation.py
@@ -6,6 +6,9 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from coldfront.core.project.models import Project
+from coldfront.core.utils.common import import_from_settings
+
+ALLOCATION_STATUSES_SUIPBNIA = import_from_settings("ALLOCATION_STATUSES_SUIPBNIA")
 
 base_dir = settings.BASE_DIR
 
@@ -17,9 +20,7 @@ class Command(BaseCommand):
                 project.projectuser_set.filter(status__name="Active").values_list("user__username", flat=True)
             )
             users_in_allocation = []
-            for allocation in project.allocation_set.filter(
-                status__name__in=("Active", "New", "Paid", "Payment Pending", "Payment Requested", "Renewal Requested")
-            ):
+            for allocation in project.allocation_set.filter(status__name__in=ALLOCATION_STATUSES_SUIPBNIA):
                 users_in_allocation.extend(
                     allocation.allocationuser_set.filter(status__name="Active").values_list("user__username", flat=True)
                 )

--- a/coldfront/plugins/slurm/associations.py
+++ b/coldfront/plugins/slurm/associations.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 
+from coldfront.config.plugins.slurm import SLURM_ALLOCATION_STATUSES
 from coldfront.core.resource.models import Resource
 from coldfront.plugins.slurm.utils import (
     SLURM_ACCOUNT_ATTRIBUTE_NAME,
@@ -114,7 +115,7 @@ class SlurmCluster(SlurmBase):
         cluster = SlurmCluster(name, specs)
 
         # Process allocations
-        for allocation in resource.allocation_set.filter(status__name__in=["Active", "Renewal Requested"]):
+        for allocation in resource.allocation_set.filter(status__name__in=SLURM_ALLOCATION_STATUSES):
             cluster.add_allocation(allocation, user_specs=user_specs)
 
         # Process child resources
@@ -122,7 +123,7 @@ class SlurmCluster(SlurmBase):
         for r in children:
             partition_specs = r.get_attribute_list(SLURM_SPECS_ATTRIBUTE_NAME)
             partition_user_specs = r.get_attribute_list(SLURM_USER_SPECS_ATTRIBUTE_NAME)
-            for allocation in r.allocation_set.filter(status__name__in=["Active", "Renewal Requested"]):
+            for allocation in r.allocation_set.filter(status__name__in=SLURM_ALLOCATION_STATUSES):
                 cluster.add_allocation(allocation, specs=partition_specs, user_specs=partition_user_specs)
 
         return cluster

--- a/docs/pages/config.md
+++ b/docs/pages/config.md
@@ -122,6 +122,36 @@ The following settings are ColdFront specific settings related to the core appli
 | PROJECT_CODE                                 | Specifies a custom internal project identifier. Default False, provide string value to enable. Must be no longer than 10 - PROJECT_CODE_PADDING characters in length.|  
 | PROJECT_CODE_PADDING                         | Defines a optional padding value to be added before the Primary Key section of PROJECT_CODE. Default False, provide integer value to enable.|
 | PROJECT_INSTITUTION_EMAIL_MAP                | Defines a dictionary where PI domain email addresses are keys and their corresponding institutions are values. Default is False, provide key-value pairs to enable this feature.|  
+
+### Allocation Selection Settings
+
+| Name                                               | Description                                                                                         | Has Setting | Has Environment Variable |
+|:---------------------------------------------------|:----------------------------------------------------------------------------------------------------|-------------|--------------------------|
+| `ALLOCATION_STATUSES_ALL`                          | Internal use only                                                                                   | yes         | yes                      |
+| `ALLOCATION_STATUSES_ALLOW_ADD_USER`               | PIs are allowed to add users from allocations with these statuses                                   | yes         | yes                      |
+| `ALLOCATION_STATUSES_ALLOW_CHANGE`                 | PIs are allowed to make changes to allocations with these statuses                                  | yes         | yes                      |
+| `ALLOCATION_STATUSES_ALLOW_REMOVE_USER`            | PIs are allowed to remove users from allocations with these statuses                                | yes         | yes                      |
+| `ALLOCATION_STATUSES_ALLOW_RENEW`                  | PIs are allowed to renew allocations with these statuses                                            | yes         | yes                      |
+| `ALLOCATION_STATUSES_AWAITING_ADMIN_ACTION`        | Allocations with these statuses are displayed to admins in the "allocation requests" page           | yes         | yes                      |
+| `ALLOCATION_STATUSES_CAN_EXPIRE`                   | Allocations with these statuses are automatically expired                                           | yes         | yes                      |
+| `ALLOCATION_STATUSES_COUNT_TOWARDS_LIMIT`          | Allocations with these statuses count towards the allocation limit                                  | yes         | yes                      |
+| `ALLOCATION_STATUSES_DO_ACTIVATE` | When an allocation changes from a status not in this list to a status in this list, it triggers the `allocation_activate`, `allocation_add_user` signals for plugin automation | yes | yes |
+| `ALLOCATION_STATUSES_DO_DISABLE` | When an allocation changes from a status not in this list to a status in this list, it triggers the `allocation_disable`, `allocation_remove_user` signals for plugin automation. Must be a subset of `ALLOCATION_STATUSES_DO_UNSET_START_DATE_END_DATE` | yes | yes |
+| `ALLOCATION_STATUSES_DO_REMOVE_USER`               | When removing a user from a project, that user is also removed from allocations with these statuses | yes         | yes                      |
+| `ALLOCATION_STATUSES_DO_REMOVE_USER_RENEW`         | Same as `ALLOCATION_STATUSES_DO_REMOVE_USER` but only applies while renewing an allocation. FIXME   | yes         | yes                      |
+| `ALLOCATION_STATUSES_DO_UNSET_START_DATE_END_DATE` | Allocations have their start and end dates unset when they reach with these statuses                | yes         | yes                      |
+| `ALLOCATION_STATUSES_HOMEPAGE`.                    | Allocations with these statuses are displayed on the home page                                      | yes         | yes                      |
+| `ALLOCATION_STATUSES_PAYMENT_RELATED`              | Allocations with these statuses are displayed to admins in the "allocations invoice list" page      | yes         | yes                      |
+| `ALLOCATION_STATUSES_PAUSRV`                       | Internal use only. See `ProjectAddUsersSearchResultsView`                                           |             |                          |
+| `ALLOCATION_STATUSES_REQUIRE_END_DATE`             | Allocations with these statuses must have an end date                                               | yes         | yes                      |
+| `ALLOCATION_STATUSES_REQUIRE_EULA`                 | Allocations with these statuses display a EULA warning if `ALLOCATION_EULA_ENABLE` is true          | yes         | yes                      |
+| `ALLOCATION_STATUSES_REQUIRE_START_DATE`           | Allocations with these statuses must have a start date                                              | yes         | yes                      |
+| `ALLOCATION_STATUSES_SHOW_ADD_REMOVE_USER`         | Add/Remove user buttons are displayed for allocations with these statuses.                          | yes         | yes                      |
+| `ALLOCATION_STATUSES_SHORT_RENEW_URL`              | Internal use only. See `coldfront.core.allocation.tasks.send_expiry_emails`                         | yes         | yes                      |
+| `ALLOCATION_STATUSES_SUIPBNIA`                     | Internal use only. See `show_users_in_project_but_not_in_allocation`                                | yes         | yes                      |
+| `ALLOCATION_STATUSES_USER_CHOICES`                 | Choices displayed when an unprivileged user attempts to change an allocation's status               | yes         | yes                      |
+| `ALLOCATION_STATUSES_USER_IS_ACTIVE`               | Internal use only. See `AllocationUser.is_active`                                                   | yes         | yes                      |
+
 ### Database settings
 
 The following settings configure the database server to use, if not set will default to using SQLite:
@@ -242,6 +272,7 @@ For more info on [ColdFront plugins](plugin/existing_plugins.md) (Django apps)
 | SLURM_NOOP            | Enable/disable noop. Default False   |
 | SLURM_IGNORE_USERS    | List of user accounts to ignore when generating Slurm associations |
 | SLURM_IGNORE_ACCOUNTS | List of Slurm accounts to ignore when generating Slurm associations |
+| SLURM_ALLOCATION_STATUSES | List of Allocation statuses to generate Slurm associations for |
 
 #### XDMoD
 
@@ -259,6 +290,7 @@ For more info on [ColdFront plugins](plugin/existing_plugins.md) (Django apps)
 | FREEIPA_SERVER           | Hostname of FreeIPA server                |
 | FREEIPA_USER_SEARCH_BASE | User search base dn                       |
 | FREEIPA_ENABLE_SIGNALS   | Enable/Disable signals. Default False     |
+| FREEIPA_ALLOCATION_STATUSES_ALLOW_REMOVE_GROUP | The freeipa plugin is allowed to remove a user group for an allocation with one of these statuses | yes | yes |
 
 #### iquota
 


### PR DESCRIPTION
[The list of allocation statuses](https://docs.coldfront.dev/en/stable/howto/allocations/statuses/) is long and rather confusing. Coldfront's behavior with respect to these statuses is inconsistent. It seems as though the list of statuses has grown over time, and some statuses were added without also being accounted for in various filters and conditionals. This isn't surprising because accounting for all statuses in all filters and conditionals is a lot of work. I think many of these statuses would be more appropriate as [tags](https://github.com/ubccr/coldfront/pull/795).

I have a [discussion post about allocation statuses](https://github.com/ubccr/coldfront/discussions/859) where I describe how I think they are supposed to work.

Assuming the above rules are followed, Coldfront's behavior is still surprising in many situations:
* If an allocation changes from status `Active` to status `Expired`, the `allocation_disable` and `allocation_remove_user` signals will not be triggered, so plugins cannot respond. These signals trigger only when an allocation changes to statuses `Denied` or `Revoked`.
* If a PI removes a user from their project, that user will be removed from all their project's allocations, except allocations with status `Expired` or `Revoked`.
* Allocations with statuses `New`, `Paid`, `Payment Pending`, and `Payment Requested` count towards the allocation limit, but allocations with statuses `Approved`, `Payment Declined`, `Pending`, and `Unpaid` do not.
* The start date cannot be removed from an allocation with status `Active`, but it can be removed from an allocation with status `Renewal Requested`.
* The end date cannot be removed from an allocation with status `Expired`, but it can be removed from an allocation with status `Revoked`.

This PR does not change this behavior in any way, instead it organizes the behavior for all situations in one file, so it can be easily understood. This PR also makes this behavior configurable, which is a nice bonus.

The tests all pass. For reference, here are the tests that fail if I make all the allocation status lists into empty lists:

<details>

```
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
FFF..FFF................F......FFF............F.............................................................s..............sssss...
======================================================================
FAIL: test_status_is_active_and_no_end_date_has_validation_error (coldfront.core.allocation.tests.test_models.AllocationModelCleanMethodTests.test_status_is_active_and_no_end_date_has_validation_error)
Test that an allocation with status 'active' and no end date raises a validation error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_models.py", line 114, in test_status_is_active_and_no_end_date_has_validation_error
    with self.assertRaises(ValidationError):
AssertionError: ValidationError not raised

======================================================================
FAIL: test_status_is_active_and_no_start_date_has_validation_error (coldfront.core.allocation.tests.test_models.AllocationModelCleanMethodTests.test_status_is_active_and_no_start_date_has_validation_error)
Test that an allocation with status 'active' and no start date raises a validation error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_models.py", line 106, in test_status_is_active_and_no_start_date_has_validation_error
    with self.assertRaises(ValidationError):
AssertionError: ValidationError not raised

======================================================================
FAIL: test_status_is_active_and_start_date_after_end_date_has_validation_error (coldfront.core.allocation.tests.test_models.AllocationModelCleanMethodTests.test_status_is_active_and_start_date_after_end_date_has_validation_error)
Test that an allocation with status 'active' and start date after end date raises a validation error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_models.py", line 125, in test_status_is_active_and_start_date_after_end_date_has_validation_error
    with self.assertRaises(ValidationError):
AssertionError: ValidationError not raised

======================================================================
FAIL: test_status_is_expired_and_end_date_not_past_has_validation_error (coldfront.core.allocation.tests.test_models.AllocationModelCleanMethodTests.test_status_is_expired_and_end_date_not_past_has_validation_error)
Test that an allocation with status 'expired' and end date in the future raises a validation error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_models.py", line 68, in test_status_is_expired_and_end_date_not_past_has_validation_error
    with self.assertRaises(ValidationError):
AssertionError: ValidationError not raised

======================================================================
FAIL: test_status_is_expired_and_no_end_date_has_validation_error (coldfront.core.allocation.tests.test_models.AllocationModelCleanMethodTests.test_status_is_expired_and_no_end_date_has_validation_error)
Test that an allocation with status 'expired' and no end date raises a validation error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_models.py", line 59, in test_status_is_expired_and_no_end_date_has_validation_error
    with self.assertRaises(ValidationError):
AssertionError: ValidationError not raised

======================================================================
FAIL: test_status_is_expired_and_start_date_after_end_date_has_validation_error (coldfront.core.allocation.tests.test_models.AllocationModelCleanMethodTests.test_status_is_expired_and_start_date_after_end_date_has_validation_error)
Test that an allocation with status 'expired' and start date after end date raises a validation error.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_models.py", line 79, in test_status_is_expired_and_start_date_after_end_date_has_validation_error
    with self.assertRaises(ValidationError):
AssertionError: ValidationError not raised

======================================================================
FAIL: test_allocationaddusersview_access (coldfront.core.allocation.tests.test_views.AllocationAddUsersViewTest.test_allocationaddusersview_access)
Test access to AllocationAddUsersView
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_views.py", line 332, in test_allocationaddusersview_access
    self.allocation_access_tstbase(self.url)
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_views.py", line 69, in allocation_access_tstbase
    utils.test_logged_out_redirect_to_login(self, url)
  File "/srv/simon/src/coldfront/coldfront/core/test_helpers/utils.py", line 40, in test_logged_out_redirect_to_login
    test_case.assertRedirects(response, f"/user/login?next={page}")
  File "/srv/simon/src/coldfront/.venv/lib/python3.12/site-packages/django/test/testcases.py", line 555, in assertRedirects
    self.assertEqual(
AssertionError: 302 != 200 : Couldn't retrieve redirection page '/allocation/1/': response code was 302 (expected 200)

======================================================================
FAIL: test_allocationchangeview_access (coldfront.core.allocation.tests.test_views.AllocationChangeViewTest.test_allocationchangeview_access)
Test get request
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_views.py", line 172, in test_allocationchangeview_access
    self.allocation_access_tstbase(self.url)
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_views.py", line 69, in allocation_access_tstbase
    utils.test_logged_out_redirect_to_login(self, url)
  File "/srv/simon/src/coldfront/coldfront/core/test_helpers/utils.py", line 40, in test_logged_out_redirect_to_login
    test_case.assertRedirects(response, f"/user/login?next={page}")
  File "/srv/simon/src/coldfront/.venv/lib/python3.12/site-packages/django/test/testcases.py", line 555, in assertRedirects
    self.assertEqual(
AssertionError: 302 != 200 : Couldn't retrieve redirection page '/allocation/1/': response code was 302 (expected 200)

======================================================================
FAIL: test_allocationchangeview_post_extension (coldfront.core.allocation.tests.test_views.AllocationChangeViewTest.test_allocationchangeview_post_extension)
Test post request to extend end date
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_views.py", line 183, in test_allocationchangeview_post_extension
    self.assertContains(response, "Allocation change request successfully submitted.")
  File "/srv/simon/src/coldfront/.venv/lib/python3.12/site-packages/django/test/testcases.py", line 660, in assertContains
    self.assertTrue(
AssertionError: False is not true : Couldn't find 'Allocation change request successfully submitted.' in response

======================================================================
FAIL: test_allocationchangeview_post_no_change (coldfront.core.allocation.tests.test_views.AllocationChangeViewTest.test_allocationchangeview_post_no_change)
Post request with no change should not go through
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_views.py", line 193, in test_allocationchangeview_post_no_change
    self.assertContains(response, "You must request a change")
  File "/srv/simon/src/coldfront/.venv/lib/python3.12/site-packages/django/test/testcases.py", line 660, in assertContains
    self.assertTrue(
AssertionError: False is not true : Couldn't find 'You must request a change' in response

======================================================================
FAIL: test_allocationremoveusersview_access (coldfront.core.allocation.tests.test_views.AllocationRemoveUsersViewTest.test_allocationremoveusersview_access)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_views.py", line 355, in test_allocationremoveusersview_access
    self.allocation_access_tstbase(self.url)
  File "/srv/simon/src/coldfront/coldfront/core/allocation/tests/test_views.py", line 69, in allocation_access_tstbase
    utils.test_logged_out_redirect_to_login(self, url)
  File "/srv/simon/src/coldfront/coldfront/core/test_helpers/utils.py", line 40, in test_logged_out_redirect_to_login
    test_case.assertRedirects(response, f"/user/login?next={page}")
  File "/srv/simon/src/coldfront/.venv/lib/python3.12/site-packages/django/test/testcases.py", line 555, in assertRedirects
    self.assertEqual(
AssertionError: 302 != 200 : Couldn't retrieve redirection page '/allocation/1/': response code was 302 (expected 200)

----------------------------------------------------------------------
Ran 131 tests in 3.297s

FAILED (failures=11, skipped=6)
Destroying test database for alias 'default'...
```

</details>

Future work:
* a few `FIXME` comments have been added, these should be fixed as soon as this PR goes through
    * I would just fix them in this PR, but I want the scope of this PR to be limited to purely refactoring, no behavior changes
* many of these status lists should be combined and simplified
    * I would personally like to see the status list reduced to just `New`, `Active`, `Inactive`, with all other statuses becoming tags
* some of the above behavior should probably be changed
* if I am right about how these statuses were meant to be used, I would like to add it to the documentation, and I would like to see enforcement that they are used this way
* `ALLOCATION_STATUSES_UNSET_START_DATE_END_DATE` and `ALLOCATION_STATUSES_DO_DISABLE` should be separate conditionals, rather than having one nested in the other
* `ALLOCATION_STATUSES_DO_REMOVE_USER` and `ALLOCATION_STATUSES_DO_REMOVE_USER_RENEW` should not both exist, the same list should be used in both places. (https://github.com/coldfront/coldfront/issues/857#issuecomment-3457839085)