### PR TITLE
project_openldap: improve utils

### DIFF
--- a/coldfront/plugins/project_openldap/utils.py
+++ b/coldfront/plugins/project_openldap/utils.py
@@ -6,8 +6,11 @@
 
 import logging
 import textwrap
+from typing import Any, Tuple
 
-from ldap3 import MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE, Connection, Server, Tls
+from ldap3 import ALL_ATTRIBUTES, BASE, MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE, Connection, Server, Tls
+from ldap3.core.exceptions import LDAPException
+from ldap3.utils.log import ERROR, set_library_log_detail_level
 
 from coldfront.core.utils.common import import_from_settings
 
@@ -30,8 +33,10 @@ PROJECT_OPENLDAP_DESCRIPTION_TITLE_LENGTH = import_from_settings("PROJECT_OPENLD
 # provide a sensible default locally to stop the openldap description being too long
 MAX_OPENLDAP_DESCRIPTION_LENGTH = 250
 
-# Note: SASL not provided currently
+# activate ldap3's builtin logging
+set_library_log_detail_level(ERROR)
 
+# Note: SASL not provided currently
 tls = None
 if PROJECT_OPENLDAP_USE_TLS:
     tls = Tls(
@@ -50,241 +55,132 @@ server = Server(
 logger = logging.getLogger(__name__)
 
 
-def openldap_connection(server_opt, bind_user, bind_password):
-    """Open connection to OpenLDAP"""
-    try:
-        connection = Connection(server_opt, bind_user, bind_password, auto_bind=True)
-        return connection
-    except Exception as e:
-        logger.error("Could not connect to OpenLDAP server: %s", e)
-        return None
-
-
 def add_members_to_openldap_posixgroup(dn, list_memberuids, write=True):
-    """Add members to a posixgroup in OpenLDAP"""
-    member_uid = tuple(list_memberuids)
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    if not write:
-        return None
-
-    try:
-        for user in member_uid:
-            add_username = user
-            conn.modify(dn, {"memberUid": [(MODIFY_ADD, [add_username])]})
-    except Exception as exc_log:
-        logger.info(exc_log)
-    finally:
-        conn.unbind()
+    """
+    * Add members to a posixgroup in OpenLDAP
+    * if not `write`, adds log message and does nothing
+    * Should not raise any exceptions
+    * returns `True` if skipped or successful, `False` if failed
+    """
+    _ldap_write_wrapper(Connection.modify, dn, {"memberUid": [(MODIFY_ADD, list_memberuids)]}, write=write)
 
 
 def remove_members_from_openldap_posixgroup(dn, list_memberuids, write=True):
-    """Remove members from a posixgroup in OpenLDAP"""
-    member_uids_tuple = tuple(list_memberuids)
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    if not write:
-        return None
-
-    try:
-        for user in member_uids_tuple:
-            remove_username = user
-            conn.modify(dn, {"memberUid": [(MODIFY_DELETE, [remove_username])]})
-    except Exception as exc_log:
-        logger.info(exc_log)
-    finally:
-        conn.unbind()
+    """
+    * Remove members from a posixgroup in OpenLDAP
+    * if not `write`, adds log message and does nothing
+    * Should not raise any exceptions
+    * returns `True` if skipped or successful, `False` if failed
+    """
+    _ldap_write_wrapper(Connection.modify, dn, {"memberUid": [(MODIFY_DELETE, list_memberuids)]}, write=write)
 
 
 def add_per_project_ou_to_openldap(project_obj, dn, openldap_ou_description, write=True):
-    """Add a per project OU to OpenLDAP - write an OU for a project"""
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    if not write:
-        return None
-
-    # project code is used for ou, other components were supplied from construction methods to this function
-    try:
-        project_code_str = project_obj.project_code
-        ou = f"{project_code_str}"
-        conn.add(
-            dn,
-            ["top", "organizationalUnit"],
-            {"ou": ou, "description": openldap_ou_description},
-        )
-    except Exception as exc_log:
-        logger.error("Project OU: DN to write...")
-        logger.error(f"dn - {dn}")
-        logger.error("Attributes to write...")
-        logger.error(f"OU description - {openldap_ou_description}")
-        logger.error(exc_log)
-    finally:
-        conn.unbind()
+    """
+    * Add a per project OU to OpenLDAP - write an OU for a project
+    * if not `write`, adds log message and does nothing
+    * Should not raise any exceptions
+    * returns `True` if skipped or successful, `False` if failed
+    """
+    _ldap_write_wrapper(
+        Connection.add,
+        dn,
+        ["top", "organizationalUnit"],
+        {"ou": project_obj.project_code, "description": openldap_ou_description},
+        write=write,
+    )
 
 
 def add_posixgroup_to_openldap(dn, openldap_description, gid_int, write=True):
-    """Add a posixGroup to OpenLDAP"""
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    if not write:
-        return None
-
-    try:
-        conn.add(
-            dn,
-            "posixGroup",
-            {"description": openldap_description, "gidNumber": gid_int},
-        )
-    except Exception as exc_log:
-        logger.error("Project posixgroup: DN to write...")
-        logger.error(f"dn - {dn}")
-        logger.error("Attributes to write...")
-        logger.error(f"posixGroup description - {openldap_description} gidNumber - {gid_int}")
-        logger.error(exc_log)
-    finally:
-        conn.unbind()
+    """
+    * Add a posixGroup to OpenLDAP
+    * if not `write`, adds log message and does nothing
+    * Should not raise any exceptions
+    * returns `True` if skipped or successful, `False` if failed
+    """
+    _ldap_write_wrapper(
+        Connection.add,
+        dn,
+        "posixGroup",
+        {"description": openldap_description, "gidNumber": gid_int},
+        write=write,
+    )
 
 
 # Remove a DN - e.g. DELETE a project OU or posixgroup in OpenLDAP
 def remove_dn_from_openldap(dn, write=True):
-    """Remove a DN from OpenLDAP"""
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    if not write:
-        return None
-
-    try:
-        conn.delete(dn)
-    except Exception as exc_log:
-        logger.info(exc_log)
-    finally:
-        conn.unbind()
+    """
+    * Remove a DN from OpenLDAP
+    * if not `write`, adds log message and does nothing
+    * Should not raise any exceptions
+    * returns `True` if skipped or successful, `False` if failed
+    """
+    _ldap_write_wrapper(Connection.delete, dn, write=write)
 
 
 # Update the project title in OpenLDAP
 def update_posixgroup_description_in_openldap(dn, openldap_description, write=True):
-    """Update the description of a posixGroup in OpenLDAP"""
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    if not write:
-        return None
-
-    try:
-        conn.modify(dn, {"description": [(MODIFY_REPLACE, [openldap_description])]})
-    except Exception as exc_log:
-        logger.info(exc_log)
-    finally:
-        conn.unbind()
+    """
+    * Update the description of a posixGroup in OpenLDAP
+    * if not `write`, adds log message and does nothing
+    * Should not raise any exceptions
+    * returns `True` if skipped or successful, `False` if failed
+    """
+    _ldap_write_wrapper(Connection.modify, dn, {"description": [(MODIFY_REPLACE, [openldap_description])]}, write=write)
 
 
 # MOVE the project to an archive OU - defined as env var
 def move_dn_in_openldap(current_dn, relative_dn, destination_ou, write=True):
-    """Move a DN to another OU in OpenLDAP"""
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    if not write:
-        return None
-
-    try:
-        conn.modify_dn(current_dn, relative_dn, new_superior=destination_ou)
-    except Exception as exc_log:
-        logger.info(exc_log)
-    finally:
-        conn.unbind()
+    """
+    * Move a DN to another OU in OpenLDAP
+    * if not `write`, adds log message and does nothing
+    * Should not raise any exceptions
+    * returns `True` if skipped or successful, `False` if failed
+    """
+    _ldap_write_wrapper(Connection.modify_dn, current_dn, relative_dn, new_superior=destination_ou, write=write)
 
 
 def ldapsearch_check_project_dn(dn):
-    """Check a distinguished name exists and represents a project (posixGroup)"""
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    try:
-        ldapsearch_check_project_dn_result = conn.search(dn, "(objectclass=posixGroup)")
-        return ldapsearch_check_project_dn_result
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
-    finally:
-        conn.unbind()
+    """
+    * Check a distinguished name exists and represents a project (posixGroup)
+    * raises `LDAPException` if the `ldap3.Connection` cannot be established or if the `ldap3.Result` code is nonzero
+    """
+    _, success = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE)
+    return success
 
 
 # check bind user can see the Project OU or Archive OU - is also used in system setup check script
 def ldapsearch_check_ou(OU):
-    """Test that ldapsearch can see an OU"""
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    try:
-        ldapsearch_check_project_ou_result = conn.search(OU, "(objectclass=organizationalUnit)")
-        return ldapsearch_check_project_ou_result
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
-    finally:
-        conn.unbind()
+    """
+    * Test that ldapsearch can see an OU
+    * raises `LDAPException` if the `ldap3.Connection` cannot be established or if the `ldap3.Result` code is nonzero
+    """
+    _, success = _ldap_read_wrapper(Connection.search, OU, "(objectclass=organizationalUnit)", BASE)
+    return success
 
 
 def ldapsearch_get_posixgroup_memberuids(dn):
-    """Get memberUids from a posixGroup"""
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    try:
-        conn.search(dn, "(objectclass=posixGroup)", attributes=["memberUid"])
-        ldapsearch_project_memberuids_entries = conn.entries
-        return ldapsearch_project_memberuids_entries
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
-    finally:
-        conn.unbind()
+    """
+    * Get memberUids from a project's posixGroup
+    * raises `LDAPException` if the `ldap3.Connection` cannot be established or if the `ldap3.Result` code is nonzero
+    * raises `KeyError` if the `entries` attribute of the `ldap3.Connection` is empty
+    """
+    conn, _ = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE, attributes=ALL_ATTRIBUTES)
+    if len(conn.entries) == 0:
+        raise KeyError(dn)
+    return conn.entries
 
 
 def ldapsearch_get_description(dn):
-    """Get description from an openldap entry"""
-    conn = openldap_connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD)
-
-    if not conn:
-        return
-
-    try:
-        conn.search(dn, "(objectclass=posixGroup)", attributes=["description"])
-        ldapsearch_project_description_entries = conn.entries
-        # list with single entry, get description
-        ldapsearch_project_description = ldapsearch_project_description_entries[0].description
-        return ldapsearch_project_description
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
-    finally:
-        conn.unbind()
+    """
+    * Get description from an openldap entry
+    * raises `LDAPException` if the `ldap3.Connection` cannot be established or if the `ldap3.Result` code is nonzero
+    * raises `KeyError` if the `entries` attribute of the `ldap3.Connection` is empty
+    """
+    conn, _ = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE, attributes=["description"])
+    if len(conn.entries) == 0:
+        raise KeyError(dn)
+    return conn.entries
 
 
 """
@@ -312,106 +208,120 @@ def allocate_project_openldap_gid(project_pk, PROJECT_OPENLDAP_GID_START):
 
 def construct_ou_dn_str(project_obj):
     """Create a distinguished name (dn) for a per project ou"""
-    try:
-        project_code_str = project_obj.project_code
-        dn = f"ou={project_code_str},{PROJECT_OPENLDAP_OU}"
-        return dn
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
+    return f"ou={project_obj.project_code},{PROJECT_OPENLDAP_OU}"
 
 
 def construct_ou_archived_dn_str(project_obj):
     """Create a distinguished name (dn) for a per project ou - archived"""
-    try:
-        project_code_str = project_obj.project_code
-        dn = f"ou={project_code_str},{PROJECT_OPENLDAP_ARCHIVE_OU}"
-        return dn
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
+    return f"ou={project_obj.project_code},{PROJECT_OPENLDAP_ARCHIVE_OU}"
 
 
 def construct_dn_str(project_obj):
     """Create a distinguished name (dn) for a project posixgroup in a per project ou, in the projects ou"""
-    try:
-        project_code_str = project_obj.project_code
-        dn = f"cn={project_code_str},ou={project_code_str},{PROJECT_OPENLDAP_OU}"
-        return dn
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
+    return f"cn={project_obj.project_code},ou={project_obj.project_code},{PROJECT_OPENLDAP_OU}"
 
 
 def construct_dn_archived_str(project_obj):
     """Create a distinguished name (dn) for a project posixgroup in a per project ou, in the archive ou"""
-    try:
-        project_code_str = project_obj.project_code
-        dn = f"cn={project_code_str},ou={project_code_str},{PROJECT_OPENLDAP_ARCHIVE_OU}"
-        return dn
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
+    return f"cn={project_obj.project_code},ou={project_obj.project_code},{PROJECT_OPENLDAP_ARCHIVE_OU}"
 
 
 def construct_per_project_ou_relative_dn_str(project_obj):
     """Create a relative distinguished name (rdn) for a project ou - required when moving this object to a new superior e.g. archive ou"""
-    try:
-        project_code_str = project_obj.project_code
-        relative_dn = f"ou={project_code_str}"
-        return relative_dn
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
+    return f"ou={project_obj.project_code}"
 
 
 def construct_project_ou_description(project_obj):
     """Create a description for a per project OU"""
-    try:
-        project_code_str = project_obj.project_code
-        description = f"OU for project {project_code_str}"
-        return description
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
+    return f"OU for project {project_obj.project_code}"
 
 
 def construct_project_posixgroup_description(project_obj):
     """Create a description for a project's posixGroup"""
+    pi = project_obj.pi
+
+    # if title is too long shorten
+    if len(project_obj.title) > PROJECT_OPENLDAP_DESCRIPTION_TITLE_LENGTH:
+        truncated_title = textwrap.shorten(
+            project_obj.title,
+            PROJECT_OPENLDAP_DESCRIPTION_TITLE_LENGTH,
+            placeholder="...",
+        )
+        title = truncated_title
+    else:
+        title = project_obj.title
+
+    description = ""
+
+    # if institution feature activated use in OpenLDAP description
+    if hasattr(project_obj, "institution"):
+        institution = project_obj.institution
+        # set to NotDefined if empty
+        if project_obj.institution in [None, ""]:
+            institution = "NotDefined"
+        # setup description with institution var
+        description = f"INSTITUTE: {institution} | PI: {pi} | TITLE: {title}"
+    else:
+        # setup description without institution var
+        description = f"PI: {pi} | TITLE: {title}"
+
+    # also deal with the combined  description field, if it gets too long
+    if len(description) > MAX_OPENLDAP_DESCRIPTION_LENGTH:
+        truncated_description = textwrap.shorten(description, MAX_OPENLDAP_DESCRIPTION_LENGTH, placeholder="...")
+        description = truncated_description
+
+    return description
+
+
+def _ldap_write_wrapper(func, *args, write=True, **kwargs) -> bool:
+    """
+    * if not `write`, adds log message and does nothing
+    * inserts an `ldap3.Connection` as the 1st argument to `func`
+        * `func` should probably be a method of `ldap3.Connection` whose 1st argument is `self`
+    * exceptions are caught and logged
+    * returns `True` if skipped or successful, `False` if failed
+    """
+    logger_extra_data = dict(funcname=func.__name__, args=args, kwargs=kwargs)
+    if write:
+        logger.info("dry run, skipping...", stack_info=True, extra=logger_extra_data)
+        return True
     try:
-        pi = project_obj.pi
+        conn = Connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD, auto_bind=True)
+    except LDAPException:
+        logger.exception("Failed to open LDAP connection", exc_info=True, extra=logger_extra_data)
+        return False
+    try:
+        func(conn, *args, **kwargs)
+    except Exception:
+        logger.exception("An unexpected exception occurred!", exc_info=True, extra=logger_extra_data)
+        return False
+    finally:
+        conn.unbind()
+    if conn.result["result"] != 0:
+        logger.error("LDAP operation failed!", stack_info=True, extra=logger_extra_data)
+        return False
+    return True
 
-        # if title is too long shorten
-        if len(project_obj.title) > PROJECT_OPENLDAP_DESCRIPTION_TITLE_LENGTH:
-            truncated_title = textwrap.shorten(
-                project_obj.title,
-                PROJECT_OPENLDAP_DESCRIPTION_TITLE_LENGTH,
-                placeholder="...",
-            )
-            title = truncated_title
-        else:
-            title = project_obj.title
 
-        description = ""
-
-        # if institution feature activated use in OpenLDAP description
-        if hasattr(project_obj, "institution"):
-            institution = project_obj.institution
-            # set to NotDefined if empty
-            if project_obj.institution in [None, ""]:
-                institution = "NotDefined"
-            # setup description with institution var
-            description = f"INSTITUTE: {institution} | PI: {pi} | TITLE: {title}"
-        else:
-            # setup description without institution var
-            description = f"PI: {pi} | TITLE: {title}"
-
-        # also deal with the combined  description field, if it gets too long
-        if len(description) > MAX_OPENLDAP_DESCRIPTION_LENGTH:
-            truncated_description = textwrap.shorten(description, MAX_OPENLDAP_DESCRIPTION_LENGTH, placeholder="...")
-            description = truncated_description
-
-        return description
-    except Exception as exc_log:
-        logger.info(exc_log)
-        return None
+def _ldap_read_wrapper(func, *args, **kwargs) -> Tuple[Connection, Any]:
+    """
+    * inserts an `ldap3.Connection` as the 1st argument to `func`
+        * `func` should probably be a method of `ldap3.Connection` whose 1st argument is `self`
+    * raises `LDAPException` if the ldap3.Connection cannot be established or if the ldap3.Result code is nonzero
+    * returns (ldap3.Connection, whatever `func` returns)
+        * you should probably inspect the `entries` attributes of the `ldap3.Connection`
+    """
+    conn = Connection(
+        server,
+        PROJECT_OPENLDAP_BIND_USER,
+        PROJECT_OPENLDAP_BIND_PASSWORD,
+        auto_bind=True,
+        read_only=True,
+    )
+    try:
+        output = func(conn, *args, **kwargs)
+    finally:
+        conn.unbind()
+    if conn.result["result"] != 0:
+        raise LDAPException(conn.result)
+    return conn, output


### PR DESCRIPTION
## Changes
problems solved:
* the utils do not check whether an LDAP operation was successful
    * [the docs](https://ldap3.readthedocs.io/en/latest/connection.html#result) says you have to check `connection.result`
    * `connection.result["result"]` holds [lots of possible failure codes](https://ldap.com/ldap-result-code-reference/)
* the `ldapsearch_*` utils mask errors and return `None`, and there are no extra checks for `None`
    * this means the masked error should lead to another uncaught `TypeError` when that `None` makes its way into future logic
    * it would be much easier to debug if the original error were preserved
 * some utils break up modifications into a loop, which prevents `ldap3` from ensuring predictable results:
    > Due to the requirement for atomicity in applying the list of modifications in the Modify Request, the client may expect that no modifications have been performed if the Modify Response received indicates any sort of error, and that all requested modifications have been performed if the Modify Response indicates successful completion of the Modify operation. ([source](https://ldap3.readthedocs.io/en/latest/modify.html#the-modify-operation ))
* `check_ou` would download the contents of the entire subtree under the OU, now it only queries for the OU itself (search scope = base)

also:
* removed lots of boilerplate
* enabled [ldap3's builtin logging feature](https://ldap3.readthedocs.io/en/latest/logging.html)
* added exception info, argument info, stack trace info to log messages
* added a boolean return value to many utils to indicate success
* removed try/except from functions which aren't expected to raise an exception
* enabled `read_only` option when binding for read-only purposes (per @ds-04's suggestion)

## Thoughts

Because the error handling is stricter, it's possible that a site has existing problems which aren't being reported, which will now be reported. The "reading" functions (`ldapsearch_*`) now raise exceptions where they used to return `None`, and they now raise excceptions (`KeyError` or `LDAPException`) where they used to return empty results. I was unable to find a definitive answer on whether or not uncaught exceptions are allowed: please advise.

## Future work

* add type hints
    * this was left out to help the github diff algorithm show changes in a sane way