### PR TITLE
show resource description in allocation creation form

### DIFF
--- a/coldfront/core/allocation/templates/allocation/allocation_create.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_create.html
@@ -61,17 +61,20 @@ Request New Allocation
 </div>
 
 {{ resources_form_default_quantities|json_script:"resources-form-default-quantities" }}
+{{ resources_form_descriptions|json_script:"resources-form-description" }}
 {{ resources_form_label_texts|json_script:"resources-form-label-texts" }}
 {{ resources_with_accounts|json_script:"resources-with-accounts" }}
 {{ resources_with_eula|json_script:"resources-with-eula" }}
 
 <script>
   var resources_form_default_quantities = JSON.parse(document.getElementById('resources-form-default-quantities').textContent);
+  var resources_form_description = JSON.parse(document.getElementById('resources-form-description').textContent);
   var resources_form_label_texts = JSON.parse(document.getElementById('resources-form-label-texts').textContent);
   var resources_with_accounts = JSON.parse(document.getElementById('resources-with-accounts').textContent);
   var resources_with_eula = JSON.parse(document.getElementById('resources-with-eula').textContent);
 
   $(document).ready(function () {
+    $('<p id="resource_description"></p>').insertAfter($("#div_id_resource"))
     $('<br><input id="selectAll" class="check" type="checkbox"> <strong>Select All Users</strong>').insertAfter($("#div_id_users > label"))
     $("#id_resource").trigger('change');
 
@@ -139,6 +142,14 @@ Request New Allocation
 
   $("#id_resource").change(function () {
     var resource_id = $("#id_resource option:selected").val();
+    if (resources_form_description[resource_id]) {
+      $('#resource_description').html(resources_form_description[resource_id])
+      $('#resource_description').show()
+    } else {
+      $('#resource_description').html("")
+      $('#resource_description').hide()
+    }
+
     if (resources_form_default_quantities[resource_id]) {
       var label = $('label[for="id_quantity"]');
       if (resources_form_label_texts[resource_id]) {

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -631,9 +631,10 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
 
         user_resources = get_user_resources(self.request.user)
         resources_form_default_quantities = {}
+        resources_form_descriptions = {}
         resources_form_label_texts = {}
         resources_with_eula = {}
-        attr_names = ("quantity_default_value", "quantity_label", "eula")
+        attr_names = ("quantity_default_value", "form_description", "quantity_label", "eula")
         for resource in user_resources:
             for attr_name in attr_names:
                 query = Q(resource_attribute_type__name=attr_name)
@@ -641,12 +642,15 @@ class AllocationCreateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                     value = resource.resourceattribute_set.get(query).value
                     if attr_name == "quantity_default_value":
                         resources_form_default_quantities[resource.id] = int(value)
+                    if attr_name == "form_description":
+                        resources_form_descriptions[resource.id] = value
                     if attr_name == "quantity_label":
                         resources_form_label_texts[resource.id] = value
                     if attr_name == "eula":
                         resources_with_eula[resource.id] = value
 
         context["resources_form_default_quantities"] = resources_form_default_quantities
+        context["resources_form_descriptions"] = resources_form_descriptions
         context["resources_form_label_texts"] = resources_form_label_texts
         context["resources_with_eula"] = resources_with_eula
         context["resources_with_accounts"] = list(


### PR DESCRIPTION
demo:

<img width="759" height="406" alt="image" src="https://github.com/user-attachments/assets/b2ba20ad-7438-45df-a2ad-531eabc6e970" />

Where the resource description is this:

> Please specify the lifespan of the quota as well as the speed type. [test link](https://google.com/)