### PR TITLE
dont hide errors

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -884,6 +884,8 @@ class AllocationAddUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
         else:
             for error in formset.errors:
                 messages.error(request, error)
+            for error in formset.non_form_errors():
+                messages.error(request, error)
 
         return redirect(allocation_obj)
 
@@ -986,6 +988,8 @@ class AllocationRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, Templat
             messages.success(request, f"Removed {remove_users_count} {user_plural} from allocation.")
         else:
             for error in formset.errors:
+                messages.error(request, error)
+            for error in formset.non_form_errors():
                 messages.error(request, error)
 
         return redirect(allocation_obj)
@@ -1092,6 +1096,8 @@ class AllocationAttributeDeleteView(LoginRequiredMixin, UserPassesTestMixin, Tem
             messages.success(request, f"Deleted {attributes_deleted_count} attributes from allocation.")
         else:
             for error in formset.errors:
+                messages.error(request, error)
+            for error in formset.non_form_errors():
                 messages.error(request, error)
 
         return redirect(allocation_obj)
@@ -1300,6 +1306,8 @@ class AllocationRenewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView)
         else:
             if not formset.is_valid():
                 for error in formset.errors:
+                    messages.error(request, error)
+                for error in formset.non_form_errors():
                     messages.error(request, error)
         return redirect(allocation_obj.project)
 
@@ -1558,6 +1566,8 @@ class AllocationDeleteInvoiceNoteView(LoginRequiredMixin, UserPassesTestMixin, T
         else:
             for error in formset.errors:
                 messages.error(request, error)
+            for error in formset.non_form_errors():
+                messages.error(request, error)
 
         return HttpResponseRedirect(reverse_lazy("allocation-invoice-detail", kwargs={"pk": allocation_obj.pk}))
 
@@ -1772,6 +1782,8 @@ class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormVi
 
         if not allocation_change_form.is_valid() or (allocation_attributes_to_change and not formset.is_valid()):
             for error in allocation_change_form.errors:
+                messages.error(request, error)
+            for error in formset.non_form_errors():
                 messages.error(request, error)
             if allocation_attributes_to_change:
                 attribute_errors = ""
@@ -1995,6 +2007,8 @@ class AllocationChangeView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                 attribute_errors = ""
                 for error in form.errors:
                     messages.error(request, error)
+                for error in formset.non_form_errors():
+                    messages.error(request, error)
                 for error in formset.errors:
                     if error:
                         attribute_errors += error.get("__all__")
@@ -2141,6 +2155,8 @@ class AllocationAttributeEditView(LoginRequiredMixin, UserPassesTestMixin, FormV
                 if error:
                     attribute_errors += error.get("__all__")
             messages.error(request, attribute_errors)
+            for error in formset.non_form_errors():
+                messages.error(request, error)
             error_redirect = HttpResponseRedirect(reverse("allocation-attribute-edit", kwargs={"pk": pk}))
             return error_redirect
 

--- a/coldfront/core/grant/views.py
+++ b/coldfront/core/grant/views.py
@@ -192,6 +192,8 @@ class GrantDeleteGrantsView(LoginRequiredMixin, UserPassesTestMixin, TemplateVie
         else:
             for error in formset.errors:
                 messages.error(request, error)
+            for error in formset.non_form_errors():
+                messages.error(request, error)
 
         return HttpResponseRedirect(reverse("project-detail", kwargs={"pk": project_obj.pk}))
 
@@ -319,6 +321,8 @@ class GrantReportView(LoginRequiredMixin, UserPassesTestMixin, ListView):
             return response
         else:
             for error in formset.errors:
+                messages.error(request, error)
+            for error in formset.non_form_errors():
                 messages.error(request, error)
             return HttpResponseRedirect(reverse("grant-report"))
 

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -908,9 +908,13 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
             if not formset.is_valid():
                 for error in formset.errors:
                     messages.error(request, error)
+                for error in formset.non_form_errors():
+                    messages.error(request, error)
 
             if not allocation_formset.is_valid():
                 for error in allocation_formset.errors:
+                    messages.error(request, error)
+                for error in allocation_formset.non_form_errors():
                     messages.error(request, error)
 
         return redirect(project_obj)
@@ -1005,6 +1009,8 @@ class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
                 messages.success(request, "Removed {} users from project.".format(remove_users_count))
         else:
             for error in formset.errors:
+                messages.error(request, error)
+            for error in formset.non_form_errors():
                 messages.error(request, error)
 
         return redirect(project_obj)
@@ -1500,6 +1506,8 @@ class ProjectAttributeDeleteView(LoginRequiredMixin, UserPassesTestMixin, Templa
             messages.success(request, "Deleted {} attributes from project.".format(attributes_deleted_count))
         else:
             for error in formset.errors:
+                messages.error(request, error)
+            for error in formset.non_form_errors():
                 messages.error(request, error)
 
         return HttpResponseRedirect(reverse("project-detail", kwargs={"pk": pk}))

--- a/coldfront/core/publication/views.py
+++ b/coldfront/core/publication/views.py
@@ -278,6 +278,8 @@ class PublicationAddView(LoginRequiredMixin, UserPassesTestMixin, View):
         else:
             for error in formset.errors:
                 messages.error(request, error)
+            for error in formset.non_form_errors():
+                messages.error(request, error)
 
         return HttpResponseRedirect(reverse("project-detail", kwargs={"pk": project_pk}))
 
@@ -412,6 +414,8 @@ class PublicationDeletePublicationsView(LoginRequiredMixin, UserPassesTestMixin,
         else:
             for error in formset.errors:
                 messages.error(request, error)
+            for error in formset.non_form_errors():
+                messages.error(request, error)
 
         return HttpResponseRedirect(reverse("project-detail", kwargs={"pk": project_obj.pk}))
 
@@ -500,6 +504,8 @@ class PublicationExportPublicationsView(LoginRequiredMixin, UserPassesTestMixin,
             return response
         else:
             for error in formset.errors:
+                messages.error(request, error)
+            for error in formset.non_form_errors():
                 messages.error(request, error)
 
         return HttpResponseRedirect(reverse("project-detail", kwargs={"pk": project_obj.pk}))

--- a/coldfront/core/resource/views.py
+++ b/coldfront/core/resource/views.py
@@ -188,6 +188,8 @@ class ResourceAttributeDeleteView(LoginRequiredMixin, UserPassesTestMixin, Templ
         else:
             for error in formset.errors:
                 messages.error(request, error)
+            for error in formset.non_form_errors():
+                messages.error(request, error)
 
         return HttpResponseRedirect(reverse("resource-detail", kwargs={"pk": pk}))
 


### PR DESCRIPTION
You can find many mentions of `non_form_errors` in [the Django docs on formsets](https://docs.djangoproject.com/en/4.2/topics/forms/formsets/).

This is the error I ran into:

> ManagementForm data is missing or has been tampered with. Missing fields: attributeform-TOTAL_FORMS, attributeform-INITIAL_FORMS. You may need to file a bug report if the issue persists.