### PR TITLE
add tests, improve tests

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1695,6 +1695,12 @@ class AllocationAccountListView(LoginRequiredMixin, UserPassesTestMixin, ListVie
 
 
 class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormView):
+    """
+    Allows a superuser to approve or deny an AllocationChangeRequest
+    Allows a superuser to update the end_date_extension or notes of an AllocationChangeRequest
+    See AllocationAttributeEditView for updating an AllocationChangeRequest's AllocationAttributeChangeRequest
+    """
+
     formset_class = AllocationAttributeUpdateForm
     template_name = "allocation/allocation_change_detail.html"
 
@@ -1711,6 +1717,7 @@ class AllocationChangeDetailView(LoginRequiredMixin, UserPassesTestMixin, FormVi
         return False
 
     def get_allocation_attributes_to_change(self, allocation_change_obj):
+        """Find all allocation change requests for the specified allocation, format as list of dicts"""
         attributes_to_change = allocation_change_obj.allocationattributechangerequest_set.all()
 
         attributes_to_change = [
@@ -1955,6 +1962,8 @@ class AllocationChangeListView(LoginRequiredMixin, UserPassesTestMixin, Template
 
 
 class AllocationChangeView(LoginRequiredMixin, UserPassesTestMixin, FormView):
+    """Allows a user with manager permissions to create an allocation change request"""
+
     formset_class = AllocationAttributeChangeForm
     template_name = "allocation/allocation_change.html"
 
@@ -2003,6 +2012,7 @@ class AllocationChangeView(LoginRequiredMixin, UserPassesTestMixin, FormView):
         return super().dispatch(request, *args, **kwargs)
 
     def get_allocation_attributes_to_change(self, allocation_obj):
+        """Find all changeable attributes for the specified allocation, format as list of dicts"""
         attributes_to_change = allocation_obj.allocationattribute_set.filter(
             allocation_attribute_type__is_changeable=True
         )

--- a/coldfront/core/portal/tests/test_views.py
+++ b/coldfront/core/portal/tests/test_views.py
@@ -6,6 +6,8 @@ import logging
 
 from django.test import TestCase
 
+from coldfront.core.test_helpers import utils
+
 logging.disable(logging.CRITICAL)
 
 
@@ -29,7 +31,7 @@ class CenterSummaryViewTest(PortalViewBaseTest):
 
     def test_centersummary_renders(self):
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        utils.assert_response_success(self, response)
         self.assertContains(response, "Active Allocations and Users")
         self.assertContains(response, "Resources and Allocations Summary")
         self.assertNotContains(response, "We're having a bit of system trouble at the moment. Please check back soon!")

--- a/coldfront/core/test_helpers/utils.py
+++ b/coldfront/core/test_helpers/utils.py
@@ -2,6 +2,10 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+from django.contrib import messages
+from django.test import TestCase
+from requests import Response
+
 """utility functions for unit and integration testing"""
 
 
@@ -89,3 +93,13 @@ def test_user_can_access(test_case, user, page):
     """
     response = login_and_get_page(test_case.client, user, page)
     test_case.assertEqual(response.status_code, 200)
+
+
+def assert_response_success(test_case: TestCase, response: Response):
+    """Confirm that response status is 200 and response contains no error messages"""
+    test_case.assertEqual(response.status_code, 200)
+    errors = []
+    for message in response.context["messages"]:
+        if message.level >= messages.ERROR:
+            errors.append(message.message)
+    test_case.assertEqual([], errors)


### PR DESCRIPTION
While writing tests, I discovered that `allocation/views.py` likes to do `message.error` followed by `HttpResponseRedirect`, and the test cases only check `response.status_code`, which is either 200 or 301, depending on if `follow` was specified. I added a new utility to check both `response.status_code` and check for error messages.

* tests tweaked to check for error messages:
    * `test_allocationchangedetailview_post_deny`
    * `test_allocationchangeview_post_extension`
    * `test_allocationchangeview_post_no_change`
    * `test_allocationcreateview_post_zeroquantity`
    * `test_centersummary_renders`
* other test changes:
    * `test_allocationchangedetailview_access` renamed to `test_allocationchangedetailview_access_granted` to differentiate it from `test_allocationchangedetailview_access_denied`
    * `test_allocationchangeview_post_extension`:
        * created local copy of `self.post_data` to prevent this test from messing up other tests with its specific `post_data`
        * added more specific assertion
    * `AllocationViewBaseTest`:
        * added type hints to object attributes
        * added `end_date` to `cls.allocation` so that the new end date could be calculated after approving an end date extension
        * made `cls.quota_attribute.allocation_attribute_type` changeable
    * `test_allocationchangedetailview_post_deny`: tweaked to use `status.name` (string) instead of `status_id` (object primary key), more intuitive
* new tests added:
    * `test_allocationchangedetailview_access_denied`
    * `test_allocationchangedetailview_post_approve_end_date_extension`
    * `test_allocationchangedetailview_post_approve_attribute_change`
    * `test_allocationchangedetailview_post_update_end_date_extension`
    * `test_allocationchangeview_post_attribute_change`

Also added documentation to explain the diffrence between `AllocationChangeView` and `AllocationChangeDetailView`, and their `get_allocation_attributes_to_change`, which share the same name but do different things.