### PR TITLE
Add more email notifs + cleanup email code

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -75,6 +75,7 @@ from coldfront.core.utils.mail import (
     send_allocation_admin_email,
     send_allocation_customer_email,
     send_allocation_eula_customer_email,
+    send_email_template,
 )
 
 ALLOCATION_ENABLE_ALLOCATION_RENEWAL = import_from_settings("ALLOCATION_ENABLE_ALLOCATION_RENEWAL", True)
@@ -91,6 +92,7 @@ if INVOICE_ENABLED:
 ALLOCATION_ACCOUNT_ENABLED = import_from_settings("ALLOCATION_ACCOUNT_ENABLED", False)
 ALLOCATION_ACCOUNT_MAPPING = import_from_settings("ALLOCATION_ACCOUNT_MAPPING", {})
 
+EMAIL_SENDER = import_from_settings("EMAIL_SENDER")
 EMAIL_ALLOCATION_EULA_IGNORE_OPT_OUT = import_from_settings("EMAIL_ALLOCATION_EULA_IGNORE_OPT_OUT", False)
 EMAIL_ALLOCATION_EULA_CONFIRMATIONS = import_from_settings("EMAIL_ALLOCATION_EULA_CONFIRMATIONS", False)
 EMAIL_ALLOCATION_EULA_CONFIRMATIONS_CC_MANAGERS = import_from_settings(
@@ -871,19 +873,26 @@ class AllocationAddUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
 
         users_added_count = 0
 
-        if formset.is_valid():
-            for form in formset:
-                user_form_data = form.cleaned_data
-                if user_form_data["selected"]:
-                    users_added_count += 1
-                    user_obj = get_user_model().objects.get(username=user_form_data.get("username"))
-                    allocation_obj.add_user(user_obj, signal_sender=self.__class__)
-
-            user_plural = "user" if users_added_count == 1 else "users"
-            messages.success(request, f"Added {users_added_count} {user_plural} to allocation.")
-        else:
+        if not formset.is_valid():
             for error in formset.errors:
                 messages.error(request, error)
+            return redirect
+        for form in formset:
+            user_form_data = form.cleaned_data
+            if user_form_data["selected"]:
+                users_added_count += 1
+                user_obj = get_user_model().objects.get(username=user_form_data.get("username"))
+                allocation_obj.add_user(user_obj, signal_sender=self.__class__)
+                if allocation_obj.allocationuser_set.get(user=user_obj).status.name == "Active":
+                    send_email_template(
+                        "You have been added to an allocation",
+                        "email/user_added_to_allocation.txt",
+                        {"user": user_obj, "allocation": allocation_obj},
+                        [user_obj.email],
+                    )
+
+        user_plural = "user" if users_added_count == 1 else "users"
+        messages.success(request, f"Added {users_added_count} {user_plural} to allocation.")
 
         return redirect(allocation_obj)
 

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -309,6 +309,27 @@ We do not have information about your research. Please provide a detailed descri
     def get_absolute_url(self):
         return reverse("project-detail", kwargs={"pk": self.pk})
 
+    def get_user_emails(self, ignore_disabled_notifications=False) -> set[str]:
+        """Gets a set of user emails for notifications.
+
+        Params:
+            ignore_disabled_notifications (bool): If True, include project users
+                that have enable_notifications off.
+
+        Returns:
+            set: A set of user emails for notifications.
+        """
+        filter_options = {
+            "status__name": "Active",
+        }
+        if not ignore_disabled_notifications:
+            filter_options["enable_notifications"] = True
+
+        project_users = self.projectuser_set.filter(**filter_options)
+        user_emails = set(project_users.values_list("user__email", flat=True))
+        user_emails.add(self.pi.email)
+        return user_emails
+
 
 class ProjectAdminComment(TimeStampedModel):
     """A project admin comment is a comment that an admin can make on a project.

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -66,13 +66,10 @@ from coldfront.core.user.utils import CombinedUserSearch
 from coldfront.core.utils.common import get_domain_url, import_from_settings
 from coldfront.core.utils.mail import send_email, send_email_template
 
-EMAIL_ENABLED = import_from_settings("EMAIL_ENABLED", False)
 ALLOCATION_ENABLE_ALLOCATION_RENEWAL = import_from_settings("ALLOCATION_ENABLE_ALLOCATION_RENEWAL", True)
 ALLOCATION_DEFAULT_ALLOCATION_LENGTH = import_from_settings("ALLOCATION_DEFAULT_ALLOCATION_LENGTH", 365)
 
-if EMAIL_ENABLED:
-    EMAIL_DIRECTOR_EMAIL_ADDRESS = import_from_settings("EMAIL_DIRECTOR_EMAIL_ADDRESS")
-    EMAIL_SENDER = import_from_settings("EMAIL_SENDER")
+EMAIL_DIRECTOR_EMAIL_ADDRESS = import_from_settings("EMAIL_DIRECTOR_EMAIL_ADDRESS")
 
 PROJECT_CODE = import_from_settings("PROJECT_CODE", False)
 PROJECT_CODE_PADDING = import_from_settings("PROJECT_CODE_PADDING", False)
@@ -557,6 +554,16 @@ class ProjectArchiveProjectView(LoginRequiredMixin, UserPassesTestMixin, Templat
         # project signals
         project_archive.send(sender=self.__class__, project_obj=project)
 
+        # send email to project members
+        email_recipients = project.get_user_emails()
+
+        send_email_template(
+            "Project has been archived",
+            "email/project_archived.txt",
+            {"project": project},
+            email_recipients,
+        )
+
         for allocation in project.allocation_set.filter(status__name="Active"):
             allocation.status = allocation_status_expired
             allocation.end_date = end_date
@@ -900,18 +907,33 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
                     role_choice = user_form_data.get("role")
                     project_obj.add_user(user_obj, role_choice, signal_sender=self.__class__)
 
+                    email_context = {
+                        "user": user_obj,
+                        "project": project_obj,
+                        "allocations": [],
+                    }
+
                     for allocation in allocations_selected_objs:
                         allocation.add_user(user_obj, signal_sender=self.__class__)
+                        if allocation.allocationuser_set.get(user=user_obj).status.name == "Active":
+                            email_context["allocations"].append(allocation)
+
+                    send_email_template(
+                        "You have been added to a project",
+                        "email/user_added_to_project.txt",
+                        email_context,
+                        [user_obj.email],
+                    )
 
             messages.success(request, "Added {} users to project.".format(added_users_count))
         else:
             if not formset.is_valid():
                 for error in formset.errors:
                     messages.error(request, error)
-
             if not allocation_formset.is_valid():
                 for error in allocation_formset.errors:
                     messages.error(request, error)
+            return redirect(project_obj)
 
         return redirect(project_obj)
 
@@ -1192,44 +1214,40 @@ class ProjectReviewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
 
         project_review_status_choice = ProjectReviewStatusChoice.objects.get(name="Pending")
 
-        if project_review_form.is_valid():
-            form_data = project_review_form.cleaned_data
-            project_review_obj = ProjectReview.objects.create(
-                project=project_obj,
-                reason_for_not_updating_project=form_data.get("reason"),
-                status=project_review_status_choice,
-            )
-
-            project_obj.force_review = False
-            project_obj.save()
-
-            domain_url = get_domain_url(self.request)
-            project_review_list_url = "{}{}".format(domain_url, reverse("project-review-list"))
-            project_url = "{}{}".format(domain_url, project_obj.get_absolute_url())
-
-            email_context = {
-                "project": project_obj,
-                "project_url": project_url,
-                "project_review": project_review_obj,
-                "project_review_list_url": project_review_list_url,
-            }
-
-            if EMAIL_ENABLED:
-                send_email_template(
-                    "New project review has been submitted",
-                    "email/new_project_review.txt",
-                    email_context,
-                    EMAIL_SENDER,
-                    [
-                        EMAIL_DIRECTOR_EMAIL_ADDRESS,
-                    ],
-                )
-
-            messages.success(request, "Project reviewed successfully.")
-            return redirect(project_obj)
-        else:
+        if not project_review_form.is_valid():
             messages.error(request, "There was an error in processing  your project review.")
             return redirect(project_obj)
+
+        form_data = project_review_form.cleaned_data
+        project_review_obj = ProjectReview.objects.create(
+            project=project_obj,
+            reason_for_not_updating_project=form_data.get("reason"),
+            status=project_review_status_choice,
+        )
+
+        project_obj.force_review = False
+        project_obj.save()
+
+        domain_url = get_domain_url(self.request)
+        project_review_list_url = "{}{}".format(domain_url, reverse("project-review-list"))
+        project_url = "{}{}".format(domain_url, project_obj.get_absolute_url())
+
+        email_context = {
+            "project": project_obj,
+            "project_url": project_url,
+            "project_review": project_review_obj,
+            "project_review_list_url": project_review_list_url,
+        }
+
+        send_email_template(
+            "New project review has been submitted",
+            "email/new_project_review.txt",
+            email_context,
+            [EMAIL_DIRECTOR_EMAIL_ADDRESS],
+        )
+
+        messages.success(request, "Project reviewed successfully.")
+        return redirect(project_obj)
 
 
 class ProjectReviewListView(LoginRequiredMixin, UserPassesTestMixin, ListView):

--- a/coldfront/core/user/views.py
+++ b/coldfront/core/user/views.py
@@ -25,10 +25,7 @@ from coldfront.core.utils.common import import_from_settings
 from coldfront.core.utils.mail import send_email_template
 
 logger = logging.getLogger(__name__)
-EMAIL_ENABLED = import_from_settings("EMAIL_ENABLED", False)
-if EMAIL_ENABLED:
-    EMAIL_SENDER = import_from_settings("EMAIL_SENDER")
-    EMAIL_TICKET_SYSTEM_ADDRESS = import_from_settings("EMAIL_TICKET_SYSTEM_ADDRESS")
+EMAIL_TICKET_SYSTEM_ADDRESS = import_from_settings("EMAIL_TICKET_SYSTEM_ADDRESS")
 
 
 @method_decorator(login_required, name="dispatch")
@@ -218,14 +215,12 @@ class UserUpgradeAccount(LoginRequiredMixin, UserPassesTestMixin, View):
         return super().dispatch(request, *args, **kwargs)
 
     def post(self, request):
-        if EMAIL_ENABLED:
-            send_email_template(
-                "Upgrade Account Request",
-                "email/upgrade_account_request.txt",
-                {"user": request.user},
-                EMAIL_SENDER,
-                [EMAIL_TICKET_SYSTEM_ADDRESS],
-            )
+        send_email_template(
+            "Upgrade Account Request",
+            "email/upgrade_account_request.txt",
+            {"user": request.user},
+            [EMAIL_TICKET_SYSTEM_ADDRESS],
+        )
 
         messages.success(request, "Your request has been sent")
         return HttpResponseRedirect(reverse("user-profile"))

--- a/coldfront/templates/email/project_archived.txt
+++ b/coldfront/templates/email/project_archived.txt
@@ -1,0 +1,12 @@
+Dear {{center_name}} user,
+
+A project you are a member of has been archived. Below is information about the project:
+
+Project Title: {{project.title}}
+Project URL: {{center_base_url}}{% url 'project-detail' project.pk %}
+Project PI: {{project.pi.first_name}} {{project.pi.last_name}} ({{project.pi.email}})
+
+All active allocations under this project have been expired.
+
+Thank you,
+{{ signature }}

--- a/coldfront/templates/email/user_added_to_allocation.txt
+++ b/coldfront/templates/email/user_added_to_allocation.txt
@@ -1,0 +1,15 @@
+Dear {{user.first_name}} {{user.last_name}},
+
+You have been added to an allocation under the {{allocation.project.title}} project in ColdFront.
+
+You can access the allocation here:
+{% with resource=allocation.resources.all|first %}{{resource.name}}{% endwith %} ({{center_base_url}}{% url 'allocation-detail' allocation.pk %})
+
+If you are a student or collaborator under this project, you are receiving this notice as a courtesy. If you would like
+to opt out of future notifications, instructions can be found here: {{ opt_out_instruction_url }}
+
+If you believe you have been sent this email in error, please contact
+the project PI at {{allocation.project.pi.email}}.
+
+Thank you,
+{{ signature }}

--- a/coldfront/templates/email/user_added_to_project.txt
+++ b/coldfront/templates/email/user_added_to_project.txt
@@ -1,0 +1,18 @@
+Dear {{user.first_name}} {{user.last_name}},
+
+You have been added to the {{project.title}} project in ColdFront.{% if allocations %}
+You've also been added to {{allocations|length}} allocation(s).{% endif %}
+
+You can access the resources here:
+{{project.title}} ({{center_base_url}}{% url 'project-detail' project.pk %})
+{% for allocation in allocations %}{% with resource=allocation.resources.all|first %}{{resource.name}}{% endwith %} ({{center_base_url}}{% url 'allocation-detail' allocation.pk %})
+{% endfor %}
+
+If you are a student or collaborator under this project, you are receiving this notice as a courtesy. If you would like
+to opt out of future notifications, instructions can be found here: {{ opt_out_instruction_url }}
+
+If you believe you have been sent this email in error, please contact
+the project PI at {{project.pi.email}}.
+
+Thank you,
+{{ signature }}


### PR DESCRIPTION
Adds email notifications:
- To a user when they're added to a project
- To a user when they're added to an allocation

Does some cleanup:
- Remove redundant checks for `EMAIL_ENABLED`
- Set default for `sender` to `EMAIL_SENDER`

I think the entire email/notification system needs a revamp (make use of signals, probably?), but this PR may help other centers who are looking for more email notifications.