### PR TITLE
fix flaky tests

### DIFF
--- a/coldfront/core/test_helpers/factories.py
+++ b/coldfront/core/test_helpers/factories.py
@@ -141,7 +141,6 @@ class ProjectStatusChoiceFactory(DjangoModelFactory):
 class ProjectFactory(DjangoModelFactory):
     class Meta:
         model = Project
-        django_get_or_create = ("title",)
 
     pi = SubFactory(UserFactory)
     title = factory.Faker("project_title")
@@ -254,7 +253,6 @@ class AllocationStatusChoiceFactory(DjangoModelFactory):
 class AllocationFactory(DjangoModelFactory):
     class Meta:
         model = Allocation
-        django_get_or_create = ("project",)
 
     justification = factory.Faker("sentence")
     status = SubFactory(AllocationStatusChoiceFactory)


### PR DESCRIPTION
Fixes https://github.com/ubccr/coldfront/issues/852



### Error 1

https://github.com/ubccr/coldfront/blob/692b9d77c1d6a0d5f42af44ce4f3b60acc64cbdc/coldfront/plugins/api/tests.py#L94

`alloc` has 2 attributes because when it was created in `setUpTestData`, it actually wasn't created, an already existing allocation (with an already existing attribute) was reused. After calling `AllocationAttributeFactory` in `setUpTestData`, `alloc` now has 2 attributes. 

`AllocationFactory` is configured to re-use objects with the specified project. From what I have read, it only really makes sense to use `django_get_or_create` when there should obviously only be one such model. That is not the case for `Allocation`, there can be multiple allocations for the same project.

### Error 2

https://github.com/ubccr/coldfront/blob/692b9d77c1d6a0d5f42af44ce4f3b60acc64cbdc/coldfront/plugins/api/tests.py#L128

Similar to error 1, the project created in `setUpTestData` was actually reused, resulting in 2 attirbutes. I think what happens is that `Faker.fake("project_title")` generates the same title multiple times.

I am fairly confident that this is fixed because I ran the test suite ~60 times before the patch and 60 times after. Before 21/61 failed, and after, 0/62 failed.