### PR TITLE
Database Query Reductions

### DIFF
--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -133,7 +133,7 @@ class AllocationSearchForm(forms.Form):
     )
     resource_name = forms.ModelMultipleChoiceField(
         label="Resource Name",
-        queryset=Resource.objects.filter(is_allocatable=True).order_by(Lower("name")),
+        queryset=Resource.objects.select_related("resource_type").filter(is_allocatable=True).order_by(Lower("name")),
         required=False,
     )
     allocation_attribute_name = forms.ModelChoiceField(

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -155,7 +155,9 @@ class Allocation(TimeStampedModel):
         """
 
         html_string = escape("")
-        for attribute in self.allocationattribute_set.all():
+        for attribute in self.allocationattribute_set.select_related(
+            "allocation_attribute_type", "allocationattributeusage"
+        ).all():
             if attribute.allocation_attribute_type.name in ALLOCATION_ATTRIBUTE_VIEW_LIST:
                 html_substring = format_html("{}: {} <br>", attribute.allocation_attribute_type.name, attribute.value)
                 html_string += html_substring
@@ -212,15 +214,15 @@ class Allocation(TimeStampedModel):
         Returns:
             Resource: the parent resource for the allocation
         """
-
-        if self.resources.count() == 1:
-            return self.resources.first()
+        resources = self.resources.select_related("resource_type")
+        if len(resources) == 1:
+            return resources.first()
         else:
-            parent = self.resources.order_by(*ALLOCATION_RESOURCE_ORDERING).first()
+            parent = resources.order_by(*ALLOCATION_RESOURCE_ORDERING).first()
             if parent:
                 return parent
             # Fallback
-            return self.resources.first()
+            return resources.first()
 
     def get_attribute(self, name, expand=True, typed=True, extra_allocations=[]):
         """

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -54,16 +54,18 @@ Allocation Detail
             <td><a href="{% url 'project-detail' allocation.project.pk %}">{{ allocation.project }}</a></td>
           </tr>
           <tr>
-            <th scope="row" class="text-nowrap">Resource{{ allocation.resources.all|pluralize }} in allocation:</th>
+            {% with allocation.get_resources_as_list as resources_as_list %}
+            <th scope="row" class="text-nowrap">Resource{{ resources_as_list|pluralize }} in allocation:</th>
             <td>
-              {% if allocation.get_resources_as_list %}
-                {% for resource in allocation.get_resources_as_list %}
+              {% if resources_as_list %}
+                {% for resource in resources_as_list %}
                   <a href="{% url 'resource-detail' resource.pk %}">{{ resource }}</a> <br>
                 {% endfor %}
-            {% else %}
-              None
-            {% endif %}
+              {% else %}
+                None
+              {% endif %}
             </td>
+            {% endwith %}
           </tr>
           {% if request.user.is_superuser %}
             <tr>

--- a/coldfront/core/grant/views.py
+++ b/coldfront/core/grant/views.py
@@ -213,7 +213,7 @@ class GrantReportView(LoginRequiredMixin, UserPassesTestMixin, ListView):
         messages.error(self.request, "You do not have permission to view all grants.")
 
     def get_grants(self):
-        grants = Grant.objects.prefetch_related("project", "project__pi").all().order_by("-total_amount_awarded")
+        grants = Grant.objects.select_related("project", "project__pi").all().order_by("-total_amount_awarded")
         grants = [
             {
                 "pk": grant.pk,
@@ -272,7 +272,9 @@ class GrantReportView(LoginRequiredMixin, UserPassesTestMixin, ListView):
             for form in formset:
                 form_data = form.cleaned_data
                 if form_data["selected"]:
-                    grant = get_object_or_404(Grant, pk=form_data["pk"])
+                    grant = get_object_or_404(
+                        Grant.objects.select_related("project", "project__pi"), pk=form_data["pk"]
+                    )
 
                     row = [
                         grant.title,
@@ -292,9 +294,7 @@ class GrantReportView(LoginRequiredMixin, UserPassesTestMixin, ListView):
                     grants_selected_count += 1
 
             if grants_selected_count == 0:
-                grants = (
-                    Grant.objects.prefetch_related("project", "project__pi").all().order_by("-total_amount_awarded")
-                )
+                grants = Grant.objects.select_related("project", "project__pi").all().order_by("-total_amount_awarded")
                 for grant in grants:
                     row = [
                         grant.title,

--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -128,10 +128,9 @@ class ProjectAttributeAddForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(ProjectAttributeAddForm, self).__init__(*args, **kwargs)
-        user = (kwargs.get("initial")).get("user")
-        self.fields["proj_attr_type"].queryset = self.fields["proj_attr_type"].queryset.order_by(Lower("name"))
-        if not user.is_superuser:
-            self.fields["proj_attr_type"].queryset = self.fields["proj_attr_type"].queryset.filter(is_private=False)
+        user = kwargs.get("initial").get("user")
+        queryset = self.fields["proj_attr_type"].queryset.select_related("attribute_type").order_by(Lower("name"))
+        self.fields["proj_attr_type"].queryset = queryset if user.is_superuser else queryset.filter(is_private=False)
 
 
 class ProjectAttributeDeleteForm(forms.Form):

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -128,9 +128,9 @@ We do not have information about your research. Please provide a detailed descri
         Returns:
             ProjectReview: the last project review that was created for this project
         """
-
-        if self.projectreview_set.exists():
-            return self.projectreview_set.order_by("-created")[0]
+        project_review_query = self.projectreview_set.order_by("-created")
+        if project_review_query:
+            return project_review_query.first()
         else:
             return None
 
@@ -140,9 +140,9 @@ We do not have information about your research. Please provide a detailed descri
         Returns:
             Grant: the most recent grant for this project, or None if there are no grants
         """
-
-        if self.grant_set.exists():
-            return self.grant_set.order_by("-modified")[0]
+        grant_query = self.grant_set.order_by("-modified")
+        if grant_query:
+            return grant_query.first()
         else:
             return None
 
@@ -152,9 +152,9 @@ We do not have information about your research. Please provide a detailed descri
         Returns:
             Publication: the most recent publication for this project, or None if there are no publications
         """
-
-        if self.publication_set.exists():
-            return self.publication_set.order_by("-created")[0]
+        publication_query = self.publication_set.order_by("-created")
+        if publication_query:
+            return publication_query.first()
         else:
             return None
 

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -196,16 +196,19 @@ Project Detail
           <tbody>
             {% for allocation in allocations %}
             <tr>
-              <td>{{ allocation.get_parent_resource.name }}</td>
-              <td>{{ allocation.get_parent_resource.resource_type.name }}</td>
+              {% with allocation.get_parent_resource as parent_resource %}
+              <td>{{ parent_resource.name }}</td>
+              <td>{{ parent_resource.resource_type.name }}</td>
               {% if user_allocation_status|get_value_by_index:forloop.counter0 == 'PendingEULA' %}
               <td class="test-nowrap"><a href="{% url 'allocation-review-eula' allocation.pk %}">Review and Accept EULA to activate</a> </td>
               {% else %}
-              {% if allocation.get_information != '' %} 
-              <td class="text-nowrap">{{allocation.get_information}}</td>
+              {% with allocation.get_information as allocation_information %}
+              {% if allocation_information != '' %} 
+              <td class="text-nowrap">{{allocation_information}}</td>
               {% else %}
               <td class="text-nowrap">{{allocation.description|default_if_none:""}}</td>
               {% endif %}
+              {% endwith %}
               {% endif %}
               {% if allocation.status.name == 'Active' %}
               {% if user_allocation_status|get_value_by_index:forloop.counter0 == 'PendingEULA' %}
@@ -232,9 +235,10 @@ Project Detail
                   </span>
                   </a>
                 {% endif %}
-                {% if allocation.get_parent_resource.get_ondemand_status == 'Yes' and ondemand_url %}
+                {% if parent_resource.get_ondemand_status == 'Yes' and ondemand_url %}
                 <a href = "{{ ondemand_url }}" target="_blank"> <img src="/static/core/portal/imgs/ondemand.png" alt="ondemand cta" width="25" height="25"></a>
               {% endif %}
+              {% endwith %}
               </td>
             </tr>
             {% endfor %}
@@ -322,9 +326,11 @@ Project Detail
   <div class="card-header">
     <h3 class="d-inline" id="grants"><i class="fas fa-trophy" aria-hidden="true"></i> Grants</h3> <span class="badge badge-secondary">{{grants.count}}</span>
     <div class="float-right">
-      {% if project.latest_grant.modified %}
-        <span class="badge badge-info">Last Updated: {{project.latest_grant.modified|date:"M. d, Y"}}</span>
+      {% with project.latest_grant as latest_grant %}
+      {% if latest_grant.modified %}
+        <span class="badge badge-info">Last Updated: {{latest_grant.modified|date:"M. d, Y"}}</span>
       {% endif %}
+      {% endwith %}
       {% if project.status.name != 'Archived' and is_allowed_to_update_project %}
         <a class="btn btn-success" href="{% url 'grant-create' project.id %}" role="button"><i class="fas fa-plus" aria-hidden="true"></i> Add Grant</a>
         {% if grants %}
@@ -386,9 +392,11 @@ Project Detail
   <div class="card-header">
     <h3 class="d-inline" id="publications"><i class="fas fa-newspaper" aria-hidden="true"></i> Publications</h3> <span class="badge badge-secondary">{{publications.count}}</span>
     <div class="float-right">
-      {% if project.latest_publication.created %}
-        <span class="badge badge-info">Last Updated: {{project.latest_publication.created|date:"M. d, Y"}}</span>
+      {% with project.latest_publication as latest_publication %}
+      {% if latest_publication.created %}
+        <span class="badge badge-info">Last Updated: {{latest_publication.created|date:"M. d, Y"}}</span>
       {% endif %}
+      {% endwith %}
       {% if project.status.name != 'Archived' and is_allowed_to_update_project %}
         <a class="btn btn-success" href="{% url 'publication-search' project.pk %}" role="button"><i class="fas fa-plus" aria-hidden="true"></i> Add Publication</a>
         {% if publications %}
@@ -489,7 +497,8 @@ Project Detail
     </div>
   </div>
   <div class="card-body">
-    {% if project.projectusermessage_set.all %}
+    {% with project.projectusermessage_set.all as all_messages %}
+    {% if all_messages %}
       <div class="table-responsive">
         <table class="table table-hover">
           <thead>
@@ -500,7 +509,7 @@ Project Detail
             </tr>
           </thead>
           <tbody>
-            {% for message in project.projectusermessage_set.all %}
+            {% for message in all_messages %}
               {% if not message.is_private or request.user.is_superuser %}
             <tr>
               <td>{{ message.message }}</td>
@@ -515,6 +524,7 @@ Project Detail
     {% else %}
       <div class="alert alert-info" role="alert"><i class="fas fa-info-circle" aria-hidden="true"></i> There are no messages from system administrators.</div>
     {% endif %}
+    {% endwith %}
   </div>
 </div>
 <!-- End Admin Messages -->

--- a/coldfront/core/resource/views.py
+++ b/coldfront/core/resource/views.py
@@ -209,19 +209,21 @@ class ResourceListView(LoginRequiredMixin, ListView):
             order_by = direction + order_by
 
         resource_search_form = ResourceSearchForm(self.request.GET)
-
+        resources = Resource.objects.select_related(
+            "parent_resource", "parent_resource__resource_type", "resource_type"
+        ).all()
         if resource_search_form.is_valid():
             data = resource_search_form.cleaned_data
             if order_by == "name":
                 direction = self.request.GET.get("direction")
                 if direction == "asc":
-                    resources = Resource.objects.all().order_by(Lower("name"))
+                    resources = resources.order_by(Lower("name"))
                 elif direction == "des":
-                    resources = Resource.objects.all().order_by(Lower("name")).reverse()
+                    resources = resources.order_by(Lower("name")).reverse()
                 else:
-                    resources = Resource.objects.all().order_by(order_by)
+                    resources = resources.order_by(order_by)
             else:
-                resources = Resource.objects.all().order_by(order_by)
+                resources = resources.order_by(order_by)
 
             if data.get("show_allocatable_resources"):
                 resources = resources.filter(is_allocatable=True)
@@ -264,13 +266,13 @@ class ResourceListView(LoginRequiredMixin, ListView):
             if order_by == "name":
                 direction = self.request.GET.get("direction")
                 if direction == "asc":
-                    resources = Resource.objects.all().order_by(Lower("name"))
+                    resources = resources.order_by(Lower("name"))
                 elif direction == "des":
-                    resources = Resource.objects.all().order_by(Lower("name").reverse())
+                    resources = resources.order_by(Lower("name").reverse())
                 else:
-                    resources = Resource.objects.all().order_by(order_by)
+                    resources = resources.order_by(order_by)
             else:
-                resources = Resource.objects.all().order_by(order_by)
+                resources = resources.order_by(order_by)
         return resources.distinct()
 
     def get_context_data(self, **kwargs):

--- a/coldfront/core/utils/templatetags/common_tags.py
+++ b/coldfront/core/utils/templatetags/common_tags.py
@@ -41,15 +41,17 @@ def convert_boolean_to_icon(boolean):
 
 @register.filter
 def convert_status_to_icon(project):
-    if project.last_project_review:
-        status = project.last_project_review.status.name
+    last_project_review = project.last_project_review
+    needs_review = project.needs_review
+    if last_project_review:
+        status = last_project_review.status.name
         if status == "Pending":
             return mark_safe('<h4><span class="badge badge-info"><i class="fas fa-exclamation-circle"></i></span></h4>')
         elif status == "Completed":
             return mark_safe('<h4><span class="badge badge-success"><i class="fas fa-check-circle"></i></span></h4>')
-    elif project.needs_review and not project.last_project_review:
+    elif needs_review and not last_project_review:
         return mark_safe('<h4><span class="badge badge-danger"><i class="fas fa-question-circle"></i></span></h4>')
-    elif not project.needs_review:
+    elif not needs_review:
         return mark_safe('<h4><span class="badge badge-success"><i class="fas fa-check-circle"></i></span></h4>')
 
 


### PR DESCRIPTION
This PR involves changes to various places on the site that queries databases. When testing this out I was using a SQLite database on a fresh ColdFront install, but none of the changes should affect other databases. The motivation for this was I noticed a large number of queries ran on the home page and I decided to investigate other pages, #848. I mostly stuck to easy changes that shouldn't change the code too much. There's likely ways to rework some of the logic that cause additional database queries but I think this is a good start. One function that kept coming up that causes additional queries was the `get_parent_resource` function in the `Allocation` class, and I haven't found an easy way to handle that yet. The biggest offenders were pages that listed project, allocations, resources, etc. Some of the database queries on those pages scaled with the number of entries.

If a table of the improvements on each page is needed I can provide that once I have it finished, I've been keeping track of improvements on each individual page but haven't set up a proper table with my findings.