### PR TITLE
Add slurm help text on the home page and allocation page

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,4 @@ recursive-include coldfront/core/publication/templates *
 recursive-include coldfront/core/grant/templates *
 recursive-include coldfront/core/user/templates *
 recursive-include coldfront/core/resource/templates *
+recursive-include coldfront/plugins/slurm/templates *

--- a/coldfront/config/plugins/slurm.py
+++ b/coldfront/config/plugins/slurm.py
@@ -13,3 +13,14 @@ SLURM_SACCTMGR_PATH = ENV.str("SLURM_SACCTMGR_PATH", default="/usr/bin/sacctmgr"
 SLURM_NOOP = ENV.bool("SLURM_NOOP", False)
 SLURM_IGNORE_USERS = ENV.list("SLURM_IGNORE_USERS", default=["root"])
 SLURM_IGNORE_ACCOUNTS = ENV.list("SLURM_IGNORE_ACCOUNTS", default=[])
+SLURM_SUBMISSION_INFO = ENV.list("SLURM_SUBMISSION_INFO", default=["account"])
+SLURM_DISPLAY_SHORT_OPTION_NAMES = ENV.bool("SLURM_DISPLAY_SHORT_OPTION_NAMES", default=False)
+SLURM_SHORT_OPTION_NAMES = ENV.dict(
+    "SLURM_SHORT_OPTION_NAMES",
+    default={
+        "qos": "q",
+        "account": "A",
+        "clusters": "M",
+        "partition": "p",
+    },
+)

--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -52,6 +52,9 @@ if "coldfront.plugins.iquota" in settings.INSTALLED_APPS:
 if "mozilla_django_oidc" in settings.INSTALLED_APPS:
     urlpatterns.append(path("oidc/", include("mozilla_django_oidc.urls")))
 
+if "coldfront.plugins.slurm" in settings.INSTALLED_APPS:
+    urlpatterns.append(path("slurm/", include("coldfront.plugins.slurm.urls")))
+
 if "django_su.backends.SuBackend" in settings.AUTHENTICATION_BACKENDS:
     urlpatterns.append(path("su/", include("django_su.urls")))
 

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -274,6 +274,10 @@ Allocation Detail
   </div>
 {% endif %}
 
+{% if display_slurm_help %}
+  {% include "slurm/slurm_help_div.html" %}
+{% endif %}
+
 {% if not user_is_pending %}
 <!-- Start Allocation Change Requests -->
 <div class="card mb-3">

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -175,6 +175,7 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
         context["attributes_with_usage"] = attributes_with_usage
         context["attributes"] = attributes
         context["allocation_changes"] = allocation_changes
+        context["display_slurm_help"] = "coldfront.plugins.slurm" in settings.INSTALLED_APPS
 
         # Can the user update the project?
         context["is_allowed_to_update_project"] = allocation_obj.project.has_perm(

--- a/coldfront/core/portal/templates/portal/extra_app_templates.html
+++ b/coldfront/core/portal/templates/portal/extra_app_templates.html
@@ -5,3 +5,7 @@
 {% if 'coldfront.plugins.system_monitor' in EXTRA_APPS %}
   {% include "system_monitor/system_monitor_div.html" %} 
 {% endif %}
+
+{% if 'coldfront.plugins.slurm' in EXTRA_APPS and user.is_authenticated %}
+  {% include "slurm/full_slurm_help_div.html" %}
+{% endif %}

--- a/coldfront/plugins/slurm/templates/slurm/full_slurm_help.html
+++ b/coldfront/plugins/slurm/templates/slurm/full_slurm_help.html
@@ -1,0 +1,59 @@
+{% if slurm_info %}
+  <div class="col">
+    <div class="card mb-3">
+      <div class="card-header">
+        Submitting Slurm Jobs
+      </div>
+      <div class="card-body">
+        {% for project_pk, info in slurm_info.items %}
+          <div class="card mb-3">
+            <div class="card-header">
+              <h3 class="mb-0"><a href="{% url 'project-detail' project_pk %}">{{ info.project_title }}</a></h3>
+            </div>
+            <div class="card-body">
+              <h4><u>Interactive Jobs</u></h4>
+              <div class="table-responsive">
+                <table class="table table-bordered table-sm">
+                  {% for resources_name, submit_info in info.submit_info.items %}
+                    {% if submit_info %}
+                      <tr>
+                        <th scope="row" class="text-nowrap">{{ resources_name }}</th>
+                        <td>
+                          srun
+                          {% for option, value in submit_info.items %}
+                            {{ option }} {{ value }}
+                          {% endfor %}
+                          &lt;other options&gt;
+                        </td>
+                      </tr>
+                    {% endif %}
+                  {% endfor %}
+                </table>
+              </div>
+              <h4><u>Batch Jobs</u></h4>
+              <div class="row">
+                {% for resources_name, submit_info in info.submit_info.items %}
+                  {% if submit_info %}
+                    <div class="col-4">
+                      <hr>
+                      <strong>{{ resources_name }}</strong>
+                      <hr>
+                      <ul style="list-style-type: none; padding: 0; margin: 0;">
+                        {% for option, value in submit_info.items %}
+                          <li>
+                            #SBATCH {{ option }} {{ value }}
+                          </li>
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  {% endif %}
+                  <br>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/coldfront/plugins/slurm/templates/slurm/full_slurm_help_div.html
+++ b/coldfront/plugins/slurm/templates/slurm/full_slurm_help_div.html
@@ -1,0 +1,17 @@
+<div id="full_slurm_help"></div>
+
+<script>
+  $(document).ready(function () {
+    $.ajax({
+      url: "{% url 'full-slurm-help' %}",
+      method: "POST",
+      data: {
+        csrfmiddlewaretoken: "{{ csrf_token }}",
+      },
+      success: function(data) {
+        $('#full_slurm_help').before(data);
+        $('#full_slurm_help').remove();
+      }
+    })
+  })
+</script>

--- a/coldfront/plugins/slurm/templates/slurm/slurm_help.html
+++ b/coldfront/plugins/slurm/templates/slurm/slurm_help.html
@@ -1,0 +1,42 @@
+{% if slurm_info %}
+  <div class="card mb-3">
+    <div class="card-header">
+        <h3 class="d-inline"><i class="fas fa-info-circle" aria-hidden="true"></i> Submitting Slurm Jobs</h3>
+    </div>
+    <div class="card-body">
+        <h4 class="d-inline">Interactive Jobs</h4>
+        <hr>
+        <ul style="list-style-type: none; padding: 0; margin: 0;">
+          {% for resources_name, submit_info in slurm_info.items %}
+            {% if submit_info %}
+              <li>
+                srun
+                {% for slurm_submit_option, submit_info_value in submit_info.items %}
+                  {{ slurm_submit_option }} {{ submit_info_value }}
+                {% endfor %}
+                &lt;other options&gt;
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+        <hr>
+        <h4 class="d-inline">Batch Jobs</h4>
+        <hr>
+        <div class="row">
+          {% for resources_name, submit_info in slurm_info.items %}
+            {% if submit_info %}
+              <div class="col">
+                <ul style="list-style-type: none; padding: 0; margin: 0;">
+                  {% for slurm_submit_option, submit_info_value in submit_info.items %}
+                    <li>
+                      #SBATCH {{ slurm_submit_option }} {{ submit_info_value }}
+                    </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% endif %}
+          {% endfor %}
+        </div>
+    </div>
+  </div>
+{% endif %}

--- a/coldfront/plugins/slurm/templates/slurm/slurm_help_div.html
+++ b/coldfront/plugins/slurm/templates/slurm/slurm_help_div.html
@@ -1,0 +1,17 @@
+<div id="slurm_help"></div>
+
+<script>
+  $(document).ready(function () {
+    $.ajax({
+      url: "{% url 'slurm-help' %}",
+      method: "POST",
+      data: {
+        csrfmiddlewaretoken: "{{ csrf_token }}",
+        allocation_pk: "{{ allocation.pk }}"
+      },
+      success: function(data) {
+        $('#slurm_help').html(data);
+      }
+    })
+  })
+</script>

--- a/coldfront/plugins/slurm/urls.py
+++ b/coldfront/plugins/slurm/urls.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from django.urls import path
+
+from coldfront.plugins.slurm.views import get_full_slurm_help, get_slurm_help
+
+urlpatterns = [
+    path("full-slurm-help/", get_full_slurm_help, name="full-slurm-help"),
+    path("slurm-help/", get_slurm_help, name="slurm-help"),
+]

--- a/coldfront/plugins/slurm/views.py
+++ b/coldfront/plugins/slurm/views.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from django.contrib.auth.decorators import login_required
+from django.db.models import Prefetch
+from django.shortcuts import render
+
+from coldfront.core.allocation.models import Allocation, AllocationAttribute
+from coldfront.core.utils.common import import_from_settings
+
+SLURM_SUBMISSION_INFO = import_from_settings("SLURM_SUBMISSION_INFO", ["account"])
+SLURM_DISPLAY_SHORT_OPTION_NAMES = import_from_settings("SLURM_DISPLAY_SHORT_OPTION_NAMES", False)
+SLURM_SHORT_OPTION_NAMES = import_from_settings("SLURM_SHORT_OPTION_NAMES", {})
+
+
+@login_required
+def get_full_slurm_help(request):
+    allocation_objs = (
+        Allocation.objects.filter(
+            status__name__in=[
+                "Active",
+                "Renewal Requested",
+            ],
+            allocationuser__user=request.user,
+            allocationuser__status__name="Active",
+            project__status__name="Active",
+            allocationattribute__allocation_attribute_type__name__in=["slurm_account_name", "slurm_specs"],
+        )
+        .select_related("project")
+        .prefetch_related(
+            Prefetch(
+                lookup="allocationattribute_set",
+                queryset=AllocationAttribute.objects.filter(allocation_attribute_type__name="slurm_account_name"),
+                to_attr="slurm_account_name",
+            ),
+            Prefetch(
+                lookup="allocationattribute_set",
+                queryset=AllocationAttribute.objects.filter(allocation_attribute_type__name="slurm_specs"),
+                to_attr="slurm_specs",
+            ),
+        )
+    )
+
+    slurm_info = {}
+    for allocation_obj in allocation_objs:
+        if not slurm_info.get(allocation_obj.project_id):
+            slurm_info[allocation_obj.project_id] = {"project_title": allocation_obj.project.title, "submit_info": {}}
+        slurm_info[allocation_obj.project_id]["submit_info"].update(get_slurm_info_from_allocation(allocation_obj))
+
+    return render(request, "slurm/full_slurm_help.html", {"slurm_info": slurm_info})
+
+
+@login_required
+def get_slurm_help(request):
+    allocation_obj = (
+        Allocation.objects.filter(pk=request.POST.get("allocation_pk"))
+        .prefetch_related(
+            Prefetch(
+                lookup="allocationattribute_set",
+                queryset=AllocationAttribute.objects.filter(allocation_attribute_type__name="slurm_account_name"),
+                to_attr="slurm_account_name",
+            ),
+            Prefetch(
+                lookup="allocationattribute_set",
+                queryset=AllocationAttribute.objects.filter(allocation_attribute_type__name="slurm_specs"),
+                to_attr="slurm_specs",
+            ),
+        )
+        .first()
+    )
+    slurm_info = get_slurm_info_from_allocation(allocation_obj)
+    return render(request, "slurm/slurm_help.html", {"slurm_info": slurm_info})
+
+
+def get_slurm_info_from_allocation(allocation_obj):
+    submit_options = {}
+    resource_obj = allocation_obj.get_parent_resource
+    resource_type = resource_obj.resource_type.name
+    if resource_type == "Cluster Partition":
+        cluster_obj = resource_obj.parent_resource
+        if "clusters" in SLURM_SUBMISSION_INFO:
+            submit_options["clusters"] = cluster_obj.resourceattribute_set.get(
+                resource_attribute_type__name="slurm_cluster"
+            ).value
+        if "partition" in SLURM_SUBMISSION_INFO:
+            submit_options["partition"] = resource_obj.name.lower()
+    elif resource_type != "Cluster":
+        return {}
+
+    slurm_account = allocation_obj.slurm_account_name
+    if slurm_account:
+        if "account" in SLURM_SUBMISSION_INFO:
+            submit_options["account"] = slurm_account[0].value
+
+    slurm_specs = resource_obj.resourceattribute_set.filter(resource_attribute_type__name="slurm_specs")
+    submit_options = get_slurm_info_from_slurm_specs(slurm_specs, submit_options)
+    slurm_specs = allocation_obj.slurm_specs
+    submit_options = get_slurm_info_from_slurm_specs(slurm_specs, submit_options)
+
+    if SLURM_DISPLAY_SHORT_OPTION_NAMES:
+        submit_short_options = {}
+        for option, value in submit_options.items():
+            short_option = SLURM_SHORT_OPTION_NAMES.get(option)
+            if short_option:
+                submit_short_options["-" + short_option] = value
+            else:
+                submit_short_options["--" + option] = value
+
+        slurm_info = submit_short_options
+    else:
+        submit_long_options = {}
+        for option, value in submit_options.items():
+            submit_long_options["--" + option] = value
+
+        slurm_info = submit_long_options
+
+    return {resource_obj.name: slurm_info}
+
+
+def get_slurm_info_from_slurm_specs(slurm_specs, submit_options):
+    if slurm_specs:
+        specs = slurm_specs[0].value.replace("+", "").split(":")
+        for spec in specs:
+            spec_split = spec.split("=")
+            # Expanded attributes should be skipped
+            if len(spec_split) > 2:
+                continue
+            option, value = spec_split
+            option = option.lower()
+            if option in SLURM_SUBMISSION_INFO:
+                submit_options[option] = value
+
+    return submit_options


### PR DESCRIPTION
With the changes in #589 being almost couple a years old I decided to create a new PR to replace it, I'll place the text from it below. There's a couple of changes from the old PR with some code reorganization and database query improvements.

This PR adds text to the Slurm plugin telling users what options they need to include when submitting Slurm jobs. More details and some examples can be found in https://github.com/coldfront/coldfront/issues/572, minus the linked resources appearing, and takes care of https://github.com/coldfront/coldfront/issues/372. There are three new env variables added:

    SLURM_SUBMISSION_INFO - What options should be displayed
    SLURM_DISPLAY_SHORT_OPTION_NAMES - If the short names for the options should be displayed
    SLURM_SHORT_OPTION_NAMES - The short name for each option. If an option doesn't have a short name given here then its full name will be used

We only require the Slurm account from ColdFront when a user submits a job, so I relied on the test data for the cgray user to figure out how to show additional options.