### PR TITLE
fix plural of "match"

### DIFF
--- a/coldfront/core/project/templates/project/add_user_search_results.html
+++ b/coldfront/core/project/templates/project/add_user_search_results.html
@@ -7,7 +7,7 @@
       <strong>Found {{number_of_usernames_found}} of
       {{number_of_usernames_searched}} usernames searched.</strong>
     {% elif matches %}
-      <strong>Found {{matches|length}} match{{matches|length|pluralize}}.</strong>
+      <strong>Found {{matches|length}} match{{matches|length|pluralize:"es"}}.</strong>
     {% endif %}
     <br>
     {% if usernames_not_found %}


### PR DESCRIPTION
<img width="525" height="207" alt="image" src="https://github.com/user-attachments/assets/16f1ae93-dd8f-4414-9bb4-1fffec9f7bb6" />

https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#pluralize

> For words that require a suffix other than 's', you can provide an alternate suffix as a parameter to the filter.
>
> Example:
>
> ```
> You have {{ num_walruses }} walrus{{ num_walruses|pluralize:"es" }}.
> ```
