### PR TITLE
Add model helper functions

### DIFF
--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -7,9 +7,11 @@ import logging
 from ast import literal_eval
 from enum import Enum
 
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.urls import reverse
 from django.utils.html import escape, format_html
 from django.utils.module_loading import import_string
 from django.utils.safestring import SafeString
@@ -17,15 +19,20 @@ from model_utils.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
 
 import coldfront.core.attribute_expansion as attribute_expansion
+from coldfront.config.core import ALLOCATION_EULA_ENABLE
+from coldfront.core.allocation.signals import allocation_activate_user, allocation_remove_user
 from coldfront.core.project.models import Project, ProjectPermission
 from coldfront.core.resource.models import Resource
 from coldfront.core.utils.common import import_from_settings
+from coldfront.core.utils.mail import build_link, send_email_template
 
 logger = logging.getLogger(__name__)
 
 ALLOCATION_ATTRIBUTE_VIEW_LIST = import_from_settings("ALLOCATION_ATTRIBUTE_VIEW_LIST", [])
 ALLOCATION_FUNCS_ON_EXPIRE = import_from_settings("ALLOCATION_FUNCS_ON_EXPIRE", [])
 ALLOCATION_RESOURCE_ORDERING = import_from_settings("ALLOCATION_RESOURCE_ORDERING", ["-is_allocatable", "name"])
+
+EMAIL_SENDER = import_from_settings("EMAIL_SENDER")
 
 
 class AllocationPermission(Enum):
@@ -354,6 +361,74 @@ class Allocation(TimeStampedModel):
                     return res.get_attribute(name="eula")
         else:
             return None
+
+    def add_user(self, user, signal_sender=None):
+        """
+        Adds a user to the allocation.
+
+        If EULAs are enabled and this allocation has an associated EULA, marks the user
+            as "PendingEULA" and sends the user an email asking them to agree to the EULA.
+        Otherwise, marks the user as "Active." Also sends the `allocation_activate_user`
+            signal if the allocation status is "Active."
+
+        Params:
+            user (User): User to add.
+            signal_sender (str): Sender for the `allocation_activate_user` signal.
+        """
+        user_status = "Active"
+
+        is_pending_eula = ALLOCATION_EULA_ENABLE and self.get_eula() and not user.userprofile.is_pi
+        if is_pending_eula:
+            user_status = "PendingEULA"
+        user_status_obj = AllocationUserStatusChoice.objects.get(name=user_status)
+
+        allocation_user, _created = self.allocationuser_set.update_or_create(
+            user=user, defaults={"status": user_status_obj}
+        )
+
+        if is_pending_eula:
+            send_email_template(
+                f"Agree to EULA for {self.get_parent_resource.__str__()}",
+                "email/allocation_agree_to_eula.txt",
+                {
+                    "resource": self.get_parent_resource,
+                    "url": build_link(reverse("allocation-review-eula", kwargs={"pk": self.pk})),
+                },
+                EMAIL_SENDER,
+                [user.email],
+            )
+
+        if self.status.name == "Active" and allocation_user.status.name == "Active":
+            allocation_activate_user.send(sender=signal_sender, allocation_user_pk=allocation_user.pk)
+
+    def remove_user(self, user, signal_sender=None, ignore_user_not_found=True):
+        """
+        Marks an `AllocationUser` as 'Removed' and sends the `allocation_remove_user` signal.
+
+        Params:
+            user (User|AllocationUser): User to remove.
+            signal_sender (str): Sender for the `allocation_remove_user` signal.
+            ignore_user_not_found (bool):
+        """
+        if isinstance(user, AllocationUser):
+            allocation_user = user
+        elif isinstance(user, get_user_model()):
+            try:
+                allocation_user = self.allocationuser_set.get(user=user)
+            except AllocationUser.DoesNotExist:
+                if ignore_user_not_found:
+                    logger.warn(
+                        f"Cannot remove user={str(user)} for allocation pk={self.pk} - AllocationUser not found."
+                    )
+                    return
+                else:
+                    raise
+        allocation_user.status = AllocationUserStatusChoice.objects.get(name="Removed")
+        allocation_user.save()
+        allocation_remove_user.send(sender=signal_sender, allocation_user_pk=allocation_user.pk)
+
+    def get_absolute_url(self):
+        return reverse("allocation-detail", kwargs={"pk": self.pk})
 
 
 class AllocationAdminNote(TimeStampedModel):
@@ -723,6 +798,9 @@ class AllocationChangeRequest(TimeStampedModel):
 
     def __str__(self):
         return "%s (%s)" % (self.get_parent_resource.name, self.allocation.project.pi)
+
+    def get_absolute_url(self):
+        return reverse("allocation-change-detail", kwargs={"pk": self.pk})
 
 
 class AllocationAttributeChangeRequest(TimeStampedModel):

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -5,14 +5,17 @@
 import datetime
 from enum import Enum
 
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import MinLengthValidator
 from django.db import models
+from django.urls import reverse
 from model_utils.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
 
 from coldfront.core.field_of_science.models import FieldOfScience
+from coldfront.core.project.signals import project_activate_user, project_remove_user
 from coldfront.core.utils.common import import_from_settings
 from coldfront.core.utils.validate import AttributeValidator
 
@@ -242,6 +245,69 @@ We do not have information about your research. Please provide a detailed descri
 
     def natural_key(self):
         return (self.title,) + self.pi.natural_key()
+
+    def add_user(self, user, role_choice, signal_sender=None):
+        """
+        Adds a user to the project.
+
+        If a ProjectUser already exists, its role will be set to "Active" and its role updated.
+        Otherwise, creates a new ProjectUser.
+
+        Params:
+            user (User): User to add.
+            role_choice (ProjetUserRoleChoice): Role to give the project user.
+            signal_sender (str): Sender for the `project_activate_user` signal.
+        """
+        user_status_obj = ProjectUserStatusChoice.objects.get(name="Active")
+
+        project_user, _created = self.projectuser_set.update_or_create(
+            user=user,
+            defaults={
+                "status": user_status_obj,
+                "role": role_choice,
+            },
+        )
+
+        project_activate_user.send(sender=signal_sender, project_user_pk=project_user.pk)
+
+    def remove_user(self, user, signal_sender=None):
+        """
+        Marks a `ProjectUser` and any associated `AllocationUser`s as 'Removed'.
+
+        Params:
+            user (User|ProjectUser): User to remove.
+            signal_sender (str): Sender for the `project_remove_user` and `allocation_remove_user` signals.
+
+        Raises:
+            ProjectUser.DoesNotExist: If `user` is a `User` and that user is not found in the Project.
+
+        """
+        if isinstance(user, ProjectUser):
+            project_user = user
+        elif isinstance(user, get_user_model()):
+            project_user = self.projectuser_set.get(user=user)
+
+        for active_allocation in self.allocation_set.filter(
+            status__name__in=(
+                "Active",
+                "Denied",
+                "New",
+                "Paid",
+                "Payment Pending",
+                "Payment Requested",
+                "Payment Declined",
+                "Renewal Requested",
+                "Unpaid",
+            )
+        ):
+            active_allocation.remove_user(project_user.user, signal_sender)
+
+        project_user.status = ProjectUserStatusChoice.objects.get(name="Removed")
+        project_user.save()
+        project_remove_user.send(sender=signal_sender, project_user_pk=project_user.pk)
+
+    def get_absolute_url(self):
+        return reverse("project-detail", kwargs={"pk": self.pk})
 
 
 class ProjectAdminComment(TimeStampedModel):


### PR DESCRIPTION
Adds `remove_user()` to `Allocation`:
Marks the `AllocationUser` as removed and sends the `allocation_remove_user` signal.


Adds `remove_user()` to `Project`:
Marks the `ProjectUser` as removed and any associated `AllocationUser`s as removed.


Also adds [`get_absolute_url()`](https://docs.djangoproject.com/en/4.2/ref/models/instances/#get-absolute-url) to the `Project`, `Allocation`, and `AllocationChangeRequest` models.