### PR TITLE
condense lines

### DIFF
--- a/coldfront/core/allocation/admin.py
+++ b/coldfront/core/allocation/admin.py
@@ -34,20 +34,14 @@ class AllocationStatusChoiceAdmin(admin.ModelAdmin):
 class AllocationUserInline(admin.TabularInline):
     model = AllocationUser
     extra = 0
-    fields = (
-        "user",
-        "status",
-    )
+    fields = ("user", "status")
     raw_id_fields = ("user",)
 
 
 class AllocationAttributeInline(admin.TabularInline):
     model = AllocationAttribute
     extra = 0
-    fields = (
-        "allocation_attribute_type",
-        "value",
-    )
+    fields = ("allocation_attribute_type", "value")
 
 
 class AllocationAdminNoteInline(admin.TabularInline):
@@ -66,12 +60,7 @@ class AllocationUserNoteInline(admin.TabularInline):
 
 @admin.register(Allocation)
 class AllocationAdmin(SimpleHistoryAdmin):
-    readonly_fields_change = (
-        "project",
-        "justification",
-        "created",
-        "modified",
-    )
+    readonly_fields_change = ("project", "justification", "created", "modified")
     fields_change = (
         "project",
         "resources",
@@ -209,14 +198,7 @@ class UsageValueFilter(admin.SimpleListFilter):
 @admin.register(AllocationAttribute)
 class AllocationAttributeAdmin(SimpleHistoryAdmin):
     readonly_fields_change = ("allocation", "allocation_attribute_type", "created", "modified", "project_title")
-    fields_change = (
-        "project_title",
-        "allocation",
-        "allocation_attribute_type",
-        "value",
-        "created",
-        "modified",
-    )
+    fields_change = ("project_title", "allocation", "allocation_attribute_type", "value", "created", "modified")
     list_display = (
         "pk",
         "project",
@@ -295,20 +277,8 @@ class AllocationUserStatusChoiceAdmin(admin.ModelAdmin):
 
 @admin.register(AllocationUser)
 class AllocationUserAdmin(SimpleHistoryAdmin):
-    readonly_fields_change = (
-        "allocation",
-        "user",
-        "resource",
-        "created",
-        "modified",
-    )
-    fields_change = (
-        "allocation",
-        "user",
-        "status",
-        "created",
-        "modified",
-    )
+    readonly_fields_change = ("allocation", "user", "resource", "created", "modified")
+    fields_change = ("allocation", "user", "status", "created", "modified")
     list_display = (
         "pk",
         "project",
@@ -320,20 +290,9 @@ class AllocationUserAdmin(SimpleHistoryAdmin):
         "created",
         "modified",
     )
-    list_filter = (
-        "status",
-        "allocation__status",
-        "allocation__resources",
-    )
-    search_fields = (
-        "user__first_name",
-        "user__last_name",
-        "user__username",
-    )
-    raw_id_fields = (
-        "allocation",
-        "user",
-    )
+    list_filter = ("status", "allocation__status", "allocation__resources")
+    search_fields = ("user__first_name", "user__last_name", "user__username")
+    raw_id_fields = ("allocation", "user")
 
     def allocation_status(self, obj):
         return obj.allocation.status
@@ -421,18 +380,9 @@ class ValueFilter(admin.SimpleListFilter):
 
 @admin.register(AllocationAttributeUsage)
 class AllocationAttributeUsageAdmin(SimpleHistoryAdmin):
-    list_display = (
-        "allocation_attribute",
-        "project",
-        "project_pi",
-        "resource",
-        "value",
-    )
+    list_display = ("allocation_attribute", "project", "project_pi", "resource", "value")
     readonly_fields = ("allocation_attribute",)
-    fields = (
-        "allocation_attribute",
-        "value",
-    )
+    fields = ("allocation_attribute", "value")
     list_filter = (
         "allocation_attribute__allocation_attribute_type",
         "allocation_attribute__allocation__resources",
@@ -451,10 +401,7 @@ class AllocationAttributeUsageAdmin(SimpleHistoryAdmin):
 
 @admin.register(AllocationAccount)
 class AllocationAccountAdmin(SimpleHistoryAdmin):
-    list_display = (
-        "name",
-        "user",
-    )
+    list_display = ("name", "user")
 
 
 @admin.register(AllocationChangeStatusChoice)
@@ -464,21 +411,9 @@ class AllocationChangeStatusChoiceAdmin(admin.ModelAdmin):
 
 @admin.register(AllocationChangeRequest)
 class AllocationChangeRequestAdmin(admin.ModelAdmin):
-    list_display = (
-        "pk",
-        "allocation",
-        "status",
-        "end_date_extension",
-        "justification",
-        "notes",
-    )
+    list_display = ("pk", "allocation", "status", "end_date_extension", "justification", "notes")
 
 
 @admin.register(AllocationAttributeChangeRequest)
 class AllocationAttributeChangeRequestAdmin(admin.ModelAdmin):
-    list_display = (
-        "pk",
-        "allocation_change_request",
-        "allocation_attribute",
-        "new_value",
-    )
+    list_display = ("pk", "allocation_change_request", "allocation_attribute", "new_value")

--- a/coldfront/core/allocation/forms.py
+++ b/coldfront/core/allocation/forms.py
@@ -250,11 +250,7 @@ class AllocationChangeForm(forms.Form):
         EXTENSION_CHOICES.append((choice, "{} days".format(choice)))
 
     end_date_extension = forms.TypedChoiceField(
-        label="Request End Date Extension",
-        choices=EXTENSION_CHOICES,
-        coerce=int,
-        required=False,
-        empty_value=0,
+        label="Request End Date Extension", choices=EXTENSION_CHOICES, coerce=int, required=False, empty_value=0
     )
     justification = forms.CharField(
         label="Justification for Changes",

--- a/coldfront/core/allocation/management/commands/add_allocation_defaults.py
+++ b/coldfront/core/allocation/management/commands/add_allocation_defaults.py
@@ -37,11 +37,7 @@ class Command(BaseCommand):
         ):
             AllocationStatusChoice.objects.get_or_create(name=choice)
 
-        for choice in (
-            "Pending",
-            "Approved",
-            "Denied",
-        ):
+        for choice in ("Pending", "Approved", "Denied"):
             AllocationChangeStatusChoice.objects.get_or_create(name=choice)
 
         for choice in ("Active", "Error", "Removed", "PendingEULA", "DeclinedEULA"):

--- a/coldfront/core/allocation/migrations/0002_auto_20190718_1451.py
+++ b/coldfront/core/allocation/migrations/0002_auto_20190718_1451.py
@@ -18,9 +18,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name="allocation",
-            name="resources",
-            field=models.ManyToManyField(to="resource.Resource"),
+            model_name="allocation", name="resources", field=models.ManyToManyField(to="resource.Resource")
         ),
         migrations.AddField(
             model_name="allocation",
@@ -31,8 +29,5 @@ class Migration(migrations.Migration):
                 verbose_name="Status",
             ),
         ),
-        migrations.AlterUniqueTogether(
-            name="allocationuser",
-            unique_together={("user", "allocation")},
-        ),
+        migrations.AlterUniqueTogether(name="allocationuser", unique_together={("user", "allocation")}),
     ]

--- a/coldfront/core/allocation/migrations/0003_auto_20191018_1049.py
+++ b/coldfront/core/allocation/migrations/0003_auto_20191018_1049.py
@@ -13,14 +13,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.AddField(model_name="allocation", name="is_locked", field=models.BooleanField(default=False)),
         migrations.AddField(
-            model_name="allocation",
-            name="is_locked",
-            field=models.BooleanField(default=False),
-        ),
-        migrations.AddField(
-            model_name="historicalallocation",
-            name="is_locked",
-            field=models.BooleanField(default=False),
+            model_name="historicalallocation", name="is_locked", field=models.BooleanField(default=False)
         ),
     ]

--- a/coldfront/core/allocation/migrations/0004_auto_20211102_1017.py
+++ b/coldfront/core/allocation/migrations/0004_auto_20211102_1017.py
@@ -65,20 +65,12 @@ class Migration(migrations.Migration):
                 "ordering": ["name"],
             },
         ),
+        migrations.AddField(model_name="allocation", name="is_changeable", field=models.BooleanField(default=False)),
         migrations.AddField(
-            model_name="allocation",
-            name="is_changeable",
-            field=models.BooleanField(default=False),
+            model_name="allocationattributetype", name="is_changeable", field=models.BooleanField(default=False)
         ),
         migrations.AddField(
-            model_name="allocationattributetype",
-            name="is_changeable",
-            field=models.BooleanField(default=False),
-        ),
-        migrations.AddField(
-            model_name="historicalallocation",
-            name="is_changeable",
-            field=models.BooleanField(default=False),
+            model_name="historicalallocation", name="is_changeable", field=models.BooleanField(default=False)
         ),
         migrations.AddField(
             model_name="historicalallocationattributetype",

--- a/coldfront/core/allocation/migrations/0005_auto_20211117_1413.py
+++ b/coldfront/core/allocation/migrations/0005_auto_20211117_1413.py
@@ -9,11 +9,7 @@ from django.db import migrations
 
 def create_status_choices(apps, schema_editor):
     AllocationChangeStatusChoice = apps.get_model("allocation", "AllocationChangeStatusChoice")
-    for choice in (
-        "Pending",
-        "Approved",
-        "Denied",
-    ):
+    for choice in ("Pending", "Approved", "Denied"):
         AllocationChangeStatusChoice.objects.get_or_create(name=choice)
 
 

--- a/coldfront/core/allocation/migrations/0006_alter_historicalallocation_options_and_more.py
+++ b/coldfront/core/allocation/migrations/0006_alter_historicalallocation_options_and_more.py
@@ -77,14 +77,10 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.AlterField(
-            model_name="historicalallocation",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalallocation", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
-            model_name="historicalallocationattribute",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalallocationattribute", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
             model_name="historicalallocationattributechangerequest",
@@ -107,8 +103,6 @@ class Migration(migrations.Migration):
             field=models.DateTimeField(db_index=True),
         ),
         migrations.AlterField(
-            model_name="historicalallocationuser",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalallocationuser", name="history_date", field=models.DateTimeField(db_index=True)
         ),
     ]

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -95,10 +95,7 @@ class Allocation(TimeStampedModel):
             ("can_manage_invoice", "Can manage invoice"),
         )
 
-    project = models.ForeignKey(
-        Project,
-        on_delete=models.CASCADE,
-    )
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
     resources = models.ManyToManyField(Resource)
     status = models.ForeignKey(AllocationStatusChoice, on_delete=models.CASCADE, verbose_name="Status")
     quantity = models.IntegerField(default=1)
@@ -774,10 +771,7 @@ class AllocationChangeRequest(TimeStampedModel):
         notes (str): represents notes for users changing allocations
     """
 
-    allocation = models.ForeignKey(
-        Allocation,
-        on_delete=models.CASCADE,
-    )
+    allocation = models.ForeignKey(Allocation, on_delete=models.CASCADE)
     status = models.ForeignKey(AllocationChangeStatusChoice, on_delete=models.CASCADE, verbose_name="Status")
     end_date_extension = models.IntegerField(blank=True, null=True)
     justification = models.TextField()

--- a/coldfront/core/allocation/tasks.py
+++ b/coldfront/core/allocation/tasks.py
@@ -150,10 +150,7 @@ def send_expiry_emails():
                                 )
 
                             if allocation.project.title not in projectdict:
-                                projectdict[allocation.project.title] = (
-                                    project_url,
-                                    allocation.project.pi.username,
-                                )
+                                projectdict[allocation.project.title] = (project_url, allocation.project.pi.username)
 
         if email_receiver_list:
             send_email_template(

--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -13,11 +13,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
-from coldfront.core.allocation.models import (
-    Allocation,
-    AllocationStatusChoice,
-    AllocationUser,
-)
+from coldfront.core.allocation.models import Allocation, AllocationStatusChoice, AllocationUser
 from coldfront.core.project.models import Project
 from coldfront.core.test_helpers.factories import (
     AAttributeTypeFactory,

--- a/coldfront/core/allocation/tests/test_views.py
+++ b/coldfront/core/allocation/tests/test_views.py
@@ -18,11 +18,7 @@ from coldfront.core.allocation.models import (
     AllocationAttributeChangeRequest,
     AllocationChangeRequest,
 )
-from coldfront.core.project.models import (
-    Project,
-    ProjectUser,
-    ProjectUserRoleChoice,
-)
+from coldfront.core.project.models import Project, ProjectUser, ProjectUserRoleChoice
 from coldfront.core.test_helpers import utils
 from coldfront.core.test_helpers.factories import (
     AllocationAttributeFactory,

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -457,21 +457,11 @@ class AllocationListView(LoginRequiredMixin, ListView):
                 self.request.user.is_superuser or self.request.user.has_perm("allocation.can_view_all_allocations")
             ):
                 allocations = (
-                    Allocation.objects.select_related(
-                        "project",
-                        "project__pi",
-                        "status",
-                    )
-                    .all()
-                    .order_by(order_by)
+                    Allocation.objects.select_related("project", "project__pi", "status").all().order_by(order_by)
                 )
             else:
                 allocations = (
-                    Allocation.objects.select_related(
-                        "project",
-                        "project__pi",
-                        "status",
-                    )
+                    Allocation.objects.select_related("project", "project__pi", "status")
                     .filter(
                         Q(project__status__name__in=["New", "Active"])
                         & Q(project__projectuser__status__name__in=["Active"])
@@ -532,11 +522,7 @@ class AllocationListView(LoginRequiredMixin, ListView):
 
         else:
             allocations = (
-                Allocation.objects.select_related(
-                    "project",
-                    "project__pi",
-                    "status",
-                )
+                Allocation.objects.select_related("project", "project__pi", "status")
                 .filter(
                     Q(allocationuser__user=self.request.user)
                     & Q(allocationuser__status__name__in=["PendingEULA", "Active"])
@@ -1441,10 +1427,7 @@ class AllocationInvoiceDetailView(LoginRequiredMixin, UserPassesTestMixin, Templ
 class AllocationAddInvoiceNoteView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     model = AllocationUserNote
     template_name = "allocation/allocation_add_invoice_note.html"
-    fields = (
-        "is_private",
-        "note",
-    )
+    fields = ("is_private", "note")
 
     def test_func(self):
         """UserPassesTestMixin Tests"""
@@ -1483,10 +1466,7 @@ class AllocationAddInvoiceNoteView(LoginRequiredMixin, UserPassesTestMixin, Crea
 class AllocationUpdateInvoiceNoteView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     model = AllocationUserNote
     template_name = "allocation/allocation_update_invoice_note.html"
-    fields = (
-        "is_private",
-        "note",
-    )
+    fields = ("is_private", "note")
 
     def test_func(self):
         """UserPassesTestMixin Tests"""
@@ -2105,13 +2085,9 @@ class AllocationAttributeEditView(LoginRequiredMixin, UserPassesTestMixin, FormV
             return render(request, self.template_name, context)
 
         AllocAttrChangeFormsetFactory = formset_factory(
-            self.formset_class,
-            max_num=len(allocation_attributes_to_change),
+            self.formset_class, max_num=len(allocation_attributes_to_change)
         )
-        formset = AllocAttrChangeFormsetFactory(
-            initial=allocation_attributes_to_change,
-            prefix="attributeform",
-        )
+        formset = AllocAttrChangeFormsetFactory(initial=allocation_attributes_to_change, prefix="attributeform")
         context["formset"] = formset
         context["attributes"] = allocation_attributes_to_change
         return render(request, self.template_name, context)
@@ -2127,13 +2103,10 @@ class AllocationAttributeEditView(LoginRequiredMixin, UserPassesTestMixin, FormV
             return ok_redirect
 
         AllocAttrChangeFormsetFactory = formset_factory(
-            self.formset_class,
-            max_num=len(allocation_attributes_to_change),
+            self.formset_class, max_num=len(allocation_attributes_to_change)
         )
         formset = AllocAttrChangeFormsetFactory(
-            request.POST,
-            initial=allocation_attributes_to_change,
-            prefix="attributeform",
+            request.POST, initial=allocation_attributes_to_change, prefix="attributeform"
         )
         if not formset.is_valid():
             attribute_errors = ""
@@ -2161,9 +2134,7 @@ class AllocationAttributeEditView(LoginRequiredMixin, UserPassesTestMixin, FormV
             allocation_attribute.value = value
             allocation_attribute.save()
             allocation_attribute_changed.send(
-                sender=self.__class__,
-                attribute_pk=allocation_attribute.pk,
-                allocation_pk=pk,
+                sender=self.__class__, attribute_pk=allocation_attribute.pk, allocation_pk=pk
             )
 
         return ok_redirect

--- a/coldfront/core/field_of_science/admin.py
+++ b/coldfront/core/field_of_science/admin.py
@@ -9,13 +9,6 @@ from coldfront.core.field_of_science.models import FieldOfScience
 
 @admin.register(FieldOfScience)
 class FieldOfScienceAdmin(admin.ModelAdmin):
-    list_display = (
-        "description",
-        "is_selectable",
-        "parent_id",
-        "fos_nsf_id",
-        "fos_nsf_abbrev",
-        "directorate_fos_id",
-    )
+    list_display = ("description", "is_selectable", "parent_id", "fos_nsf_id", "fos_nsf_abbrev", "directorate_fos_id")
     list_filter = ("is_selectable",)
     search_fields = ["description"]

--- a/coldfront/core/field_of_science/migrations/0002_alter_fieldofscience_description.py
+++ b/coldfront/core/field_of_science/migrations/0002_alter_fieldofscience_description.py
@@ -14,8 +14,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterField(
-            model_name="fieldofscience",
-            name="description",
-            field=models.CharField(max_length=255, unique=True),
+            model_name="fieldofscience", name="description", field=models.CharField(max_length=255, unique=True)
         ),
     ]

--- a/coldfront/core/grant/admin.py
+++ b/coldfront/core/grant/admin.py
@@ -15,11 +15,7 @@ class GrantFundingAgencyChoiceAdmin(admin.ModelAdmin):
 
 @admin.register(Grant)
 class GrantAdmin(SimpleHistoryAdmin):
-    readonly_fields = (
-        "project",
-        "created",
-        "modified",
-    )
+    readonly_fields = ("project", "created", "modified")
     fields = (
         "project",
         "title",

--- a/coldfront/core/grant/migrations/0002_auto_20230406_1310.py
+++ b/coldfront/core/grant/migrations/0002_auto_20230406_1310.py
@@ -14,13 +14,9 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterField(
-            model_name="grantfundingagency",
-            name="name",
-            field=models.CharField(max_length=255, unique=True),
+            model_name="grantfundingagency", name="name", field=models.CharField(max_length=255, unique=True)
         ),
         migrations.AlterField(
-            model_name="grantstatuschoice",
-            name="name",
-            field=models.CharField(max_length=64, unique=True),
+            model_name="grantstatuschoice", name="name", field=models.CharField(max_length=64, unique=True)
         ),
     ]

--- a/coldfront/core/grant/migrations/0003_alter_historicalgrant_options_and_more.py
+++ b/coldfront/core/grant/migrations/0003_alter_historicalgrant_options_and_more.py
@@ -26,9 +26,7 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.AlterField(
-            model_name="grant",
-            name="direct_funding",
-            field=coldfront.core.grant.models.MoneyField(max_length=100),
+            model_name="grant", name="direct_funding", field=coldfront.core.grant.models.MoneyField(max_length=100)
         ),
         migrations.AlterField(
             model_name="grant",
@@ -48,9 +46,7 @@ class Migration(migrations.Migration):
             field=coldfront.core.grant.models.MoneyField(max_length=100),
         ),
         migrations.AlterField(
-            model_name="historicalgrant",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalgrant", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
             model_name="historicalgrant",

--- a/coldfront/core/grant/models.py
+++ b/coldfront/core/grant/models.py
@@ -113,24 +113,16 @@ class Grant(TimeStampedModel):
     """
 
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
-    title = models.CharField(
-        validators=[MinLengthValidator(3), MaxLengthValidator(255)],
-        max_length=255,
-    )
+    title = models.CharField(validators=[MinLengthValidator(3), MaxLengthValidator(255)], max_length=255)
     grant_number = models.CharField(
-        "Grant Number from funding agency",
-        validators=[MinLengthValidator(3), MaxLengthValidator(255)],
-        max_length=255,
+        "Grant Number from funding agency", validators=[MinLengthValidator(3), MaxLengthValidator(255)], max_length=255
     )
     ROLE_CHOICES = (
         ("PI", "Principal Investigator (PI)"),
         ("CoPI", "Co-Principal Investigator (CoPI)"),
         ("SP", "Senior Personnel (SP)"),
     )
-    role = models.CharField(
-        max_length=10,
-        choices=ROLE_CHOICES,
-    )
+    role = models.CharField(max_length=10, choices=ROLE_CHOICES)
 
     grant_pi_full_name = models.CharField("Grant PI Full Name", max_length=255, blank=True)
     funding_agency = models.ForeignKey(GrantFundingAgency, on_delete=models.CASCADE)

--- a/coldfront/core/grant/tests/tests.py
+++ b/coldfront/core/grant/tests/tests.py
@@ -9,11 +9,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from coldfront.core.grant.models import Grant
-from coldfront.core.test_helpers.factories import (
-    GrantFundingAgencyFactory,
-    GrantStatusChoiceFactory,
-    ProjectFactory,
-)
+from coldfront.core.test_helpers.factories import GrantFundingAgencyFactory, GrantStatusChoiceFactory, ProjectFactory
 
 
 class TestGrant(TestCase):

--- a/coldfront/core/portal/admin.py
+++ b/coldfront/core/portal/admin.py
@@ -8,14 +8,6 @@ from django.contrib.admin.models import LogEntry
 
 @admin.register(LogEntry)
 class LogEntryAdmin(admin.ModelAdmin):
-    list_display = (
-        "content_type",
-        "user",
-        "action_time",
-        "object_id",
-        "object_repr",
-        "action_flag",
-        "change_message",
-    )
+    list_display = ("content_type", "user", "action_time", "object_id", "object_repr", "action_flag", "change_message")
 
     search_fields = ["user__username", "user__first_name", "user__last_name"]

--- a/coldfront/core/project/admin.py
+++ b/coldfront/core/project/admin.py
@@ -45,30 +45,9 @@ class ProjectUserStatusChoiceAdmin(admin.ModelAdmin):
 
 @admin.register(ProjectUser)
 class ProjectUserAdmin(SimpleHistoryAdmin):
-    fields_change = (
-        "user",
-        "project",
-        "role",
-        "status",
-        "created",
-        "modified",
-    )
-    readonly_fields_change = (
-        "user",
-        "project",
-        "created",
-        "modified",
-    )
-    list_display = (
-        "pk",
-        "project_title",
-        "PI",
-        "User",
-        "role",
-        "status",
-        "created",
-        "modified",
-    )
+    fields_change = ("user", "project", "role", "status", "created", "modified")
+    readonly_fields_change = ("user", "project", "created", "modified")
+    list_display = ("pk", "project_title", "PI", "User", "role", "status", "created", "modified")
     list_filter = ("role", "status")
     search_fields = ["user__username", "user__first_name", "user__last_name"]
     raw_id_fields = ("user", "project")
@@ -136,10 +115,7 @@ class ProjectUserMessageInline(admin.TabularInline):
 class ProjectAttributeInLine(admin.TabularInline):
     model = ProjectAttribute
     extra = 0
-    fields = (
-        "proj_attr_type",
-        "value",
-    )
+    fields = ("proj_attr_type", "value")
 
 
 @admin.register(AttributeType)
@@ -188,24 +164,8 @@ class UsageValueFilter(admin.SimpleListFilter):
 @admin.register(ProjectAttribute)
 class ProjectAttributeAdmin(SimpleHistoryAdmin):
     readonly_fields_change = ("proj_attr_type", "created", "modified", "project_title")
-    fields_change = (
-        "project_title",
-        "proj_attr_type",
-        "value",
-        "created",
-        "modified",
-    )
-    list_display = (
-        "pk",
-        "project",
-        "pi",
-        "project_status",
-        "proj_attr_type",
-        "value",
-        "usage",
-        "created",
-        "modified",
-    )
+    fields_change = ("project_title", "proj_attr_type", "value", "created", "modified")
+    list_display = ("pk", "project", "pi", "project_status", "proj_attr_type", "value", "usage", "created", "modified")
     inlines = [
         ProjectAttributeUsageInline,
     ]
@@ -287,21 +247,10 @@ class ValueFilter(admin.SimpleListFilter):
 
 @admin.register(ProjectAttributeUsage)
 class ProjectAttributeUsageAdmin(SimpleHistoryAdmin):
-    list_display = (
-        "project_attribute",
-        "project",
-        "project_pi",
-        "value",
-    )
+    list_display = ("project_attribute", "project", "project_pi", "value")
     readonly_fields = ("project_attribute",)
-    fields = (
-        "project_attribute",
-        "value",
-    )
-    list_filter = (
-        "project_attribute__proj_attr_type",
-        ValueFilter,
-    )
+    fields = ("project_attribute", "value")
+    list_filter = ("project_attribute__proj_attr_type", ValueFilter)
 
     def project(self, obj):
         return obj.project_attribute.project.title
@@ -312,20 +261,8 @@ class ProjectAttributeUsageAdmin(SimpleHistoryAdmin):
 
 @admin.register(Project)
 class ProjectAdmin(SimpleHistoryAdmin):
-    fields_change = (
-        "title",
-        "pi",
-        "description",
-        "status",
-        "requires_review",
-        "force_review",
-        "created",
-        "modified",
-    )
-    readonly_fields_change = (
-        "created",
-        "modified",
-    )
+    fields_change = ("title", "pi", "description", "status", "requires_review", "force_review", "created", "modified")
+    readonly_fields_change = ("created", "modified")
     list_display = ("pk", "title", "PI", "created", "modified", "status")
     search_fields = [
         "pi__username",

--- a/coldfront/core/project/migrations/0002_projectusermessage_is_private.py
+++ b/coldfront/core/project/migrations/0002_projectusermessage_is_private.py
@@ -14,8 +14,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name="projectusermessage",
-            name="is_private",
-            field=models.BooleanField(default=True),
+            model_name="projectusermessage", name="is_private", field=models.BooleanField(default=True)
         ),
     ]

--- a/coldfront/core/project/migrations/0004_auto_20230406_1133.py
+++ b/coldfront/core/project/migrations/0004_auto_20230406_1133.py
@@ -14,18 +14,12 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterField(
-            model_name="projectstatuschoice",
-            name="name",
-            field=models.CharField(max_length=64, unique=True),
+            model_name="projectstatuschoice", name="name", field=models.CharField(max_length=64, unique=True)
         ),
         migrations.AlterField(
-            model_name="projectuserrolechoice",
-            name="name",
-            field=models.CharField(max_length=64, unique=True),
+            model_name="projectuserrolechoice", name="name", field=models.CharField(max_length=64, unique=True)
         ),
         migrations.AlterField(
-            model_name="projectuserstatuschoice",
-            name="name",
-            field=models.CharField(max_length=64, unique=True),
+            model_name="projectuserstatuschoice", name="name", field=models.CharField(max_length=64, unique=True)
         ),
     ]

--- a/coldfront/core/project/migrations/0005_alter_historicalproject_options_and_more.py
+++ b/coldfront/core/project/migrations/0005_alter_historicalproject_options_and_more.py
@@ -70,47 +70,28 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.AddField(
-            model_name="historicalproject",
-            name="project_code",
-            field=models.CharField(blank=True, max_length=10),
+            model_name="historicalproject", name="project_code", field=models.CharField(blank=True, max_length=10)
         ),
         migrations.AddField(
-            model_name="project",
-            name="project_code",
-            field=models.CharField(blank=True, max_length=10),
+            model_name="project", name="project_code", field=models.CharField(blank=True, max_length=10)
         ),
         migrations.AlterField(
-            model_name="historicalproject",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalproject", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
-            model_name="historicalprojectattribute",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalprojectattribute", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
-            model_name="historicalprojectattributetype",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalprojectattributetype", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
-            model_name="historicalprojectattributeusage",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalprojectattributeusage", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
-            model_name="historicalprojectreview",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalprojectreview", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
-            model_name="historicalprojectuser",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalprojectuser", name="history_date", field=models.DateTimeField(db_index=True)
         ),
-        migrations.AlterUniqueTogether(
-            name="project",
-            unique_together={("title", "pi")},
-        ),
+        migrations.AlterUniqueTogether(name="project", unique_together={("title", "pi")}),
     ]

--- a/coldfront/core/project/migrations/0006_historicalproject_institution_project_institution.py
+++ b/coldfront/core/project/migrations/0006_historicalproject_institution_project_institution.py
@@ -19,8 +19,6 @@ class Migration(migrations.Migration):
             field=models.CharField(blank=True, default="None", max_length=80),
         ),
         migrations.AddField(
-            model_name="project",
-            name="institution",
-            field=models.CharField(blank=True, default="None", max_length=80),
+            model_name="project", name="institution", field=models.CharField(blank=True, default="None", max_length=80)
         ),
     ]

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -85,21 +85,11 @@ class Project(TimeStampedModel):
 We do not have information about your research. Please provide a detailed description of your work and update your field of science. Thank you!
         """
 
-    title = models.CharField(
-        max_length=255,
-    )
-    pi = models.ForeignKey(
-        User,
-        on_delete=models.CASCADE,
-    )
+    title = models.CharField(max_length=255)
+    pi = models.ForeignKey(User, on_delete=models.CASCADE)
     description = models.TextField(
         default=DEFAULT_DESCRIPTION,
-        validators=[
-            MinLengthValidator(
-                10,
-                "The project description must be > 10 characters.",
-            )
-        ],
+        validators=[MinLengthValidator(10, "The project description must be > 10 characters.")],
     )
 
     field_of_science = models.ForeignKey(FieldOfScience, on_delete=models.CASCADE, default=FieldOfScience.DEFAULT_PK)

--- a/coldfront/core/project/tests/tests.py
+++ b/coldfront/core/project/tests/tests.py
@@ -8,15 +8,8 @@ from unittest.mock import patch
 from django.core.exceptions import ValidationError
 from django.test import TestCase, TransactionTestCase
 
-from coldfront.core.project.models import (
-    Project,
-    ProjectAttribute,
-    ProjectAttributeType,
-)
-from coldfront.core.project.utils import (
-    determine_automated_institution_choice,
-    generate_project_code,
-)
+from coldfront.core.project.models import Project, ProjectAttribute, ProjectAttributeType
+from coldfront.core.project.utils import determine_automated_institution_choice, generate_project_code
 from coldfront.core.test_helpers.factories import (
     FieldOfScienceFactory,
     PAttributeTypeFactory,
@@ -180,16 +173,11 @@ class TestProjectAttribute(TestCase):
         project_attr_types = [("Project ID", "Text"), ("Account Number", "Int")]
         for atype in project_attr_types:
             ProjectAttributeTypeFactory(
-                name=atype[0],
-                attribute_type=PAttributeTypeFactory(name=atype[1]),
-                has_usage=False,
-                is_unique=True,
+                name=atype[0], attribute_type=PAttributeTypeFactory(name=atype[1]), has_usage=False, is_unique=True
             )
         cls.project = ProjectFactory()
         cls.new_attr = ProjectAttributeFactory(
-            proj_attr_type=ProjectAttributeType.objects.get(name="Account Number"),
-            project=cls.project,
-            value=1243,
+            proj_attr_type=ProjectAttributeType.objects.get(name="Account Number"), project=cls.project, value=1243
         )
 
     def test_unique_attrs_one_per_project(self):
@@ -226,10 +214,7 @@ class TestProjectCode(TransactionTestCase):
         """Helper method to create a project and a project code with a specific prefix and padding"""
         # Project Creation
         project = Project.objects.create(
-            title=title,
-            pi=self.user,
-            status=self.status,
-            field_of_science=self.field_of_science,
+            title=title, pi=self.user, status=self.status, field_of_science=self.field_of_science
         )
 
         project.project_code = generate_project_code(project_code, project.pk, project_code_padding)
@@ -291,10 +276,7 @@ class TestInstitution(TestCase):
         """Helper method to create a project and assign a institution value based on the argument passed"""
         # Project Creation
         project = Project.objects.create(
-            title=title,
-            pi=self.user,
-            status=self.status,
-            field_of_science=self.field_of_science,
+            title=title, pi=self.user, status=self.status, field_of_science=self.field_of_science
         )
 
         if institution_dict:

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -23,10 +23,7 @@ from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 
-from coldfront.core.allocation.models import (
-    Allocation,
-    AllocationStatusChoice,
-)
+from coldfront.core.allocation.models import Allocation, AllocationStatusChoice
 from coldfront.core.allocation.utils import generate_guauge_data_from_usage
 from coldfront.core.grant.models import Grant
 from coldfront.core.project.forms import (
@@ -53,11 +50,7 @@ from coldfront.core.project.models import (
     ProjectUserRoleChoice,
     ProjectUserStatusChoice,
 )
-from coldfront.core.project.signals import (
-    project_archive,
-    project_new,
-    project_update,
-)
+from coldfront.core.project.signals import project_archive, project_new, project_update
 from coldfront.core.project.utils import determine_automated_institution_choice, generate_project_code
 from coldfront.core.publication.models import Publication
 from coldfront.core.research_output.models import ResearchOutput
@@ -251,11 +244,7 @@ class ProjectListView(LoginRequiredMixin, ListView):
                 self.request.user.is_superuser or self.request.user.has_perm("project.can_view_all_projects")
             ):
                 projects = (
-                    Project.objects.select_related(
-                        "pi",
-                        "field_of_science",
-                        "status",
-                    )
+                    Project.objects.select_related("pi", "field_of_science", "status")
                     .filter(
                         status__name__in=[
                             "New",
@@ -266,11 +255,7 @@ class ProjectListView(LoginRequiredMixin, ListView):
                 )
             else:
                 projects = (
-                    Project.objects.select_related(
-                        "pi",
-                        "field_of_science",
-                        "status",
-                    )
+                    Project.objects.select_related("pi", "field_of_science", "status")
                     .filter(
                         Q(
                             status__name__in=[
@@ -306,11 +291,7 @@ class ProjectListView(LoginRequiredMixin, ListView):
 
         else:
             projects = (
-                Project.objects.select_related(
-                    "pi",
-                    "field_of_science",
-                    "status",
-                )
+                Project.objects.select_related("pi", "field_of_science", "status")
                 .filter(
                     Q(
                         status__name__in=[
@@ -403,11 +384,7 @@ class ProjectArchivedListView(LoginRequiredMixin, ListView):
                 self.request.user.is_superuser or self.request.user.has_perm("project.can_view_all_projects")
             ):
                 projects = (
-                    Project.objects.prefetch_related(
-                        "pi",
-                        "field_of_science",
-                        "status",
-                    )
+                    Project.objects.prefetch_related("pi", "field_of_science", "status")
                     .filter(
                         status__name__in=[
                             "Archived",
@@ -417,11 +394,7 @@ class ProjectArchivedListView(LoginRequiredMixin, ListView):
                 )
             else:
                 projects = (
-                    Project.objects.prefetch_related(
-                        "pi",
-                        "field_of_science",
-                        "status",
-                    )
+                    Project.objects.prefetch_related("pi", "field_of_science", "status")
                     .filter(
                         Q(
                             status__name__in=[
@@ -448,11 +421,7 @@ class ProjectArchivedListView(LoginRequiredMixin, ListView):
 
         else:
             projects = (
-                Project.objects.prefetch_related(
-                    "pi",
-                    "field_of_science",
-                    "status",
-                )
+                Project.objects.prefetch_related("pi", "field_of_science", "status")
                 .filter(
                     Q(
                         status__name__in=[
@@ -865,15 +834,8 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
         formset = formset(request.POST, initial=matches, prefix="userform")
 
         initial_data = self.get_initial_data(project_obj)
-        allocation_formset = formset_factory(
-            ProjectAddUsersToAllocationForm,
-            max_num=len(initial_data),
-        )
-        allocation_formset = allocation_formset(
-            request.POST,
-            initial=initial_data,
-            prefix="allocationform",
-        )
+        allocation_formset = formset_factory(ProjectAddUsersToAllocationForm, max_num=len(initial_data))
+        allocation_formset = allocation_formset(request.POST, initial=initial_data, prefix="allocationform")
 
         added_users_count = 0
         if formset.is_valid() and allocation_formset.is_valid():

--- a/coldfront/core/publication/admin.py
+++ b/coldfront/core/publication/admin.py
@@ -10,10 +10,7 @@ from coldfront.core.publication.models import Publication, PublicationSource
 
 @admin.register(PublicationSource)
 class PublicationSourceAdmin(SimpleHistoryAdmin):
-    list_display = (
-        "name",
-        "url",
-    )
+    list_display = ("name", "url")
 
 
 @admin.register(Publication)

--- a/coldfront/core/publication/migrations/0003_auto_20200104_1700.py
+++ b/coldfront/core/publication/migrations/0003_auto_20200104_1700.py
@@ -14,13 +14,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterField(
-            model_name="publicationsource",
-            name="name",
-            field=models.CharField(max_length=255, unique=True),
+            model_name="publicationsource", name="name", field=models.CharField(max_length=255, unique=True)
         ),
-        migrations.AlterField(
-            model_name="publicationsource",
-            name="url",
-            field=models.URLField(blank=True, null=True),
-        ),
+        migrations.AlterField(model_name="publicationsource", name="url", field=models.URLField(blank=True, null=True)),
     ]

--- a/coldfront/core/publication/migrations/0005_alter_historicalpublication_options_and_more.py
+++ b/coldfront/core/publication/migrations/0005_alter_historicalpublication_options_and_more.py
@@ -23,8 +23,6 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.AlterField(
-            model_name="historicalpublication",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalpublication", name="history_date", field=models.DateTimeField(db_index=True)
         ),
     ]

--- a/coldfront/core/publication/models.py
+++ b/coldfront/core/publication/models.py
@@ -45,10 +45,7 @@ class Publication(TimeStampedModel):
     journal = models.CharField(max_length=1024)
     unique_id = models.CharField(max_length=255, null=True, blank=True)
     source = models.ForeignKey(PublicationSource, on_delete=models.CASCADE)
-    STATUS_CHOICES = (
-        ("Active", "Active"),
-        ("Archived", "Archived"),
-    )
+    STATUS_CHOICES = (("Active", "Active"), ("Archived", "Archived"))
     status = models.CharField(max_length=16, choices=STATUS_CHOICES, default="Active")
     history = HistoricalRecords()
 

--- a/coldfront/core/publication/tests/tests.py
+++ b/coldfront/core/publication/tests/tests.py
@@ -14,13 +14,8 @@ from django.test import TestCase
 import coldfront.core.publication
 from coldfront.core.publication.models import Publication
 from coldfront.core.publication.views import PublicationSearchResultView
-from coldfront.core.test_helpers.decorators import (
-    makes_remote_requests,
-)
-from coldfront.core.test_helpers.factories import (
-    ProjectFactory,
-    PublicationSourceFactory,
-)
+from coldfront.core.test_helpers.decorators import makes_remote_requests
+from coldfront.core.test_helpers.factories import ProjectFactory, PublicationSourceFactory
 
 
 class TestPublication(TestCase):

--- a/coldfront/core/research_output/admin.py
+++ b/coldfront/core/research_output/admin.py
@@ -15,14 +15,8 @@ class ResearchOutputAdmin(SimpleHistoryAdmin):
     list_display = [
         field.name for field in ResearchOutput._meta.get_fields() if field.name not in _research_output_fields_for_end
     ] + _research_output_fields_for_end
-    list_filter = (
-        "project",
-        "created_by",
-    )
-    ordering = (
-        "project",
-        "-created",
-    )
+    list_filter = ("project", "created_by")
+    ordering = ("project", "-created")
 
     # display the noneditable fields on the "change" form
     readonly_fields = [field.name for field in ResearchOutput._meta.get_fields() if not field.editable]

--- a/coldfront/core/research_output/migrations/0002_alter_historicalresearchoutput_options_and_more.py
+++ b/coldfront/core/research_output/migrations/0002_alter_historicalresearchoutput_options_and_more.py
@@ -23,8 +23,6 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.AlterField(
-            model_name="historicalresearchoutput",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalresearchoutput", name="history_date", field=models.DateTimeField(db_index=True)
         ),
     ]

--- a/coldfront/core/research_output/models.py
+++ b/coldfront/core/research_output/models.py
@@ -24,9 +24,7 @@ class ResearchOutput(TimeStampedModel):
     # core fields
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
     title = models.CharField(max_length=128, blank=True)
-    description = models.TextField(
-        validators=[MinLengthValidator(3)],
-    )
+    description = models.TextField(validators=[MinLengthValidator(3)])
 
     # auxiliary fields
     created_by = models.ForeignKey(

--- a/coldfront/core/research_output/tests/tests.py
+++ b/coldfront/core/research_output/tests/tests.py
@@ -8,10 +8,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from coldfront.core.research_output.models import ResearchOutput
-from coldfront.core.test_helpers.factories import (
-    ProjectFactory,
-    UserFactory,
-)
+from coldfront.core.test_helpers.factories import ProjectFactory, UserFactory
 
 
 class TestResearchOutput(TestCase):

--- a/coldfront/core/research_output/views.py
+++ b/coldfront/core/research_output/views.py
@@ -91,10 +91,7 @@ class ResearchOutputDeleteResearchOutputsView(
 
         num_deletions, _ = project_research_outputs.filter(pk__in=posted_research_output_pks).delete()
 
-        msg = "Deleted {} research output{} from project.".format(
-            num_deletions,
-            "" if num_deletions == 1 else "s",
-        )
+        msg = "Deleted {} research output{} from project.".format(num_deletions, "" if num_deletions == 1 else "s")
         messages.success(request, msg)
 
         return HttpResponseRedirect(reverse("project-detail", kwargs={"pk": project_obj.pk}))

--- a/coldfront/core/resource/admin.py
+++ b/coldfront/core/resource/admin.py
@@ -16,26 +16,14 @@ from coldfront.core.resource.models import (
 
 @admin.register(AttributeType)
 class AttributeTypeAdmin(admin.ModelAdmin):
-    list_display = (
-        "name",
-        "created",
-        "modified",
-    )
+    list_display = ("name", "created", "modified")
     search_fields = ("name",)
 
 
 @admin.register(ResourceType)
 class ResourceTypeAdmin(admin.ModelAdmin):
-    list_display = (
-        "name",
-        "description",
-        "created",
-        "modified",
-    )
-    search_fields = (
-        "name",
-        "description",
-    )
+    list_display = ("name", "description", "created", "modified")
+    search_fields = ("name", "description")
 
 
 @admin.register(ResourceAttributeType)
@@ -50,11 +38,7 @@ class ResourceAttributeTypeAdmin(SimpleHistoryAdmin):
         "created",
         "modified",
     )
-    search_fields = (
-        "name",
-        "attribute_type__name",
-        "resource_type__name",
-    )
+    search_fields = ("name", "attribute_type__name", "resource_type__name")
     list_filter = ("attribute_type__name", "name", "is_required", "is_unique_per_resource", "is_value_unique")
 
     def attribute_type_name(self, obj):
@@ -63,10 +47,7 @@ class ResourceAttributeTypeAdmin(SimpleHistoryAdmin):
 
 class ResourceAttributeInline(admin.TabularInline):
     model = ResourceAttribute
-    fields_change = (
-        "resource_attribute_type",
-        "value",
-    )
+    fields_change = ("resource_attribute_type", "value")
     extra = 0
 
     def get_fields(self, request, obj):
@@ -128,14 +109,7 @@ class ResourceAdmin(SimpleHistoryAdmin):
 
 @admin.register(ResourceAttribute)
 class ResourceAttributeAdmin(SimpleHistoryAdmin):
-    list_display = (
-        "pk",
-        "resource_name",
-        "value",
-        "resource_attribute_type_name",
-        "created",
-        "modified",
-    )
+    list_display = ("pk", "resource_name", "value", "resource_attribute_type_name", "created", "modified")
     search_fields = ("resource__name", "resource_attribute_type__name", "value")
     list_filter = ("resource_attribute_type__name",)
 

--- a/coldfront/core/resource/migrations/0002_auto_20191017_1141.py
+++ b/coldfront/core/resource/migrations/0002_auto_20191017_1141.py
@@ -13,14 +13,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
-            model_name="historicalresourceattribute",
-            name="value",
-            field=models.TextField(),
-        ),
-        migrations.AlterField(
-            model_name="resourceattribute",
-            name="value",
-            field=models.TextField(),
-        ),
+        migrations.AlterField(model_name="historicalresourceattribute", name="value", field=models.TextField()),
+        migrations.AlterField(model_name="resourceattribute", name="value", field=models.TextField()),
     ]

--- a/coldfront/core/resource/migrations/0003_alter_historicalresource_options_and_more.py
+++ b/coldfront/core/resource/migrations/0003_alter_historicalresource_options_and_more.py
@@ -50,24 +50,16 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.AlterField(
-            model_name="historicalresource",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalresource", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
-            model_name="historicalresourceattribute",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalresourceattribute", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
-            model_name="historicalresourceattributetype",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalresourceattributetype", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
-            model_name="historicalresourcetype",
-            name="history_date",
-            field=models.DateTimeField(db_index=True),
+            model_name="historicalresourcetype", name="history_date", field=models.DateTimeField(db_index=True)
         ),
         migrations.AlterField(
             model_name="resource",

--- a/coldfront/core/test_helpers/factories.py
+++ b/coldfront/core/test_helpers/factories.py
@@ -23,14 +23,10 @@ from coldfront.core.allocation.models import (
     AllocationUserNote,
     AllocationUserStatusChoice,
 )
-from coldfront.core.allocation.models import (
-    AttributeType as AAttributeType,
-)
+from coldfront.core.allocation.models import AttributeType as AAttributeType
 from coldfront.core.field_of_science.models import FieldOfScience
 from coldfront.core.grant.models import GrantFundingAgency, GrantStatusChoice
-from coldfront.core.project.models import (
-    AttributeType as PAttributeType,
-)
+from coldfront.core.project.models import AttributeType as PAttributeType
 from coldfront.core.project.models import (
     Project,
     ProjectAttribute,

--- a/coldfront/core/user/admin.py
+++ b/coldfront/core/user/admin.py
@@ -9,12 +9,7 @@ from coldfront.core.user.models import UserProfile
 
 @admin.register(UserProfile)
 class UserProfileAdmin(admin.ModelAdmin):
-    list_display = (
-        "username",
-        "first_name",
-        "last_name",
-        "is_pi",
-    )
+    list_display = ("username", "first_name", "last_name", "is_pi")
     list_filter = ("is_pi",)
     search_fields = ["user__username", "user__first_name", "user__last_name"]
 

--- a/coldfront/core/utils/mail.py
+++ b/coldfront/core/utils/mail.py
@@ -109,11 +109,7 @@ def send_allocation_admin_email(allocation_obj, subject, template_name, url_path
     ctx["resource"] = resource_name
     ctx["url"] = url
 
-    send_admin_email_template(
-        f"{subject}: {pi_name} - {resource_name}",
-        template_name,
-        ctx,
-    )
+    send_admin_email_template(f"{subject}: {pi_name} - {resource_name}", template_name, ctx)
 
 
 def send_allocation_customer_email(allocation_obj, subject, template_name, url_path="", domain_url=""):

--- a/coldfront/core/utils/management/commands/load_test_data.py
+++ b/coldfront/core/utils/management/commands/load_test_data.py
@@ -212,35 +212,23 @@ class Command(BaseCommand):
         AttributeType.objects.get_or_create(name="Int")
 
         ProjectAttributeType.objects.get_or_create(
-            attribute_type=AttributeType.objects.get(name="Text"),
-            name="Project ID",
-            is_private=False,
+            attribute_type=AttributeType.objects.get(name="Text"), name="Project ID", is_private=False
         )
 
         ProjectAttributeType.objects.get_or_create(
-            attribute_type=AttributeType.objects.get(name="Int"),
-            name="Account Number",
-            is_private=True,
+            attribute_type=AttributeType.objects.get(name="Int"), name="Account Number", is_private=True
         )
 
         ProjectAttribute.objects.get_or_create(
-            proj_attr_type=ProjectAttributeType.objects.get(name="Project ID"),
-            project=project_obj,
-            value=1242021,
+            proj_attr_type=ProjectAttributeType.objects.get(name="Project ID"), project=project_obj, value=1242021
         )
 
         ProjectAttribute.objects.get_or_create(
-            proj_attr_type=ProjectAttributeType.objects.get(name="Account Number"),
-            project=project_obj,
-            value=1756522,
+            proj_attr_type=ProjectAttributeType.objects.get(name="Account Number"), project=project_obj, value=1756522
         )
 
         univ_hpc = Resource.objects.get(name="University HPC")
-        for scavanger in (
-            "Chemistry-scavenger",
-            "Physics-scavenger",
-            "Industry-scavenger",
-        ):
+        for scavanger in ("Chemistry-scavenger", "Physics-scavenger", "Industry-scavenger"):
             resource_obj = Resource.objects.get(name=scavanger)
             univ_hpc.linked_resources.add(resource_obj)
             univ_hpc.save()

--- a/coldfront/plugins/api/serializers.py
+++ b/coldfront/plugins/api/serializers.py
@@ -13,16 +13,7 @@ from coldfront.core.resource.models import Resource
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
-        fields = (
-            "id",
-            "username",
-            "first_name",
-            "last_name",
-            "is_active",
-            "is_superuser",
-            "is_staff",
-            "date_joined",
-        )
+        fields = ("id", "username", "first_name", "last_name", "is_active", "is_superuser", "is_staff", "date_joined")
 
 
 class ResourceSerializer(serializers.ModelSerializer):
@@ -42,14 +33,7 @@ class AllocationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Allocation
-        fields = (
-            "id",
-            "project",
-            "resource",
-            "status",
-            "allocation_users",
-            "allocation_attributes",
-        )
+        fields = ("id", "project", "resource", "status", "allocation_users", "allocation_attributes")
 
     def get_allocation_users(self, obj):
         request = self.context.get("request", None)

--- a/coldfront/plugins/auto_compute_allocation/signals.py
+++ b/coldfront/plugins/auto_compute_allocation/signals.py
@@ -19,7 +19,4 @@ logger = logging.getLogger(__name__)
 def project_new_auto_compute_allocation(sender, **kwargs):
     project_obj = kwargs.get("project_obj")
     # Add a compute allocation
-    async_task(
-        "coldfront.plugins.auto_compute_allocation.tasks.add_auto_compute_allocation",
-        project_obj,
-    )
+    async_task("coldfront.plugins.auto_compute_allocation.tasks.add_auto_compute_allocation", project_obj)

--- a/coldfront/plugins/auto_compute_allocation/tasks.py
+++ b/coldfront/plugins/auto_compute_allocation/tasks.py
@@ -40,17 +40,11 @@ def add_auto_compute_allocation(project_obj):
     # if project_code not enabled or None or empty, print appropriate message and stop
     if not hasattr(project_obj, "project_code"):
         logger.info("Enable project_code to use the auto_compute_allocation plugin")
-        logger.info(
-            "Additional message - this issue was encountered with project pk %s",
-            {project_obj.pk},
-        )
+        logger.info("Additional message - this issue was encountered with project pk %s", {project_obj.pk})
         return None
     if project_obj.project_code in [None, ""]:
         logger.info("None or empty project_code value encountered, please run the project code management command")
-        logger.info(
-            "Additional message - this issue was encountered with project pk %s",
-            {project_obj.pk},
-        )
+        logger.info("Additional message - this issue was encountered with project pk %s", {project_obj.pk})
         return None
 
     project_code = project_obj.project_code
@@ -97,9 +91,7 @@ def add_auto_compute_allocation(project_obj):
     try:
         # add the slurm account name
         allocation_auto_compute_attribute_create(
-            allocation_attribute_type_obj_slurm_account_name,
-            allocation_obj,
-            local_slurm_account_name,
+            allocation_attribute_type_obj_slurm_account_name, allocation_obj, local_slurm_account_name
         )
     except Exception as e:
         logger.error("Failed to add slurm account name to auto_compute_allocation: %s", e)
@@ -109,9 +101,7 @@ def add_auto_compute_allocation(project_obj):
         fairshare_value = "Fairshare=parent"
         # use generic function
         allocation_auto_compute_attribute_create(
-            allocation_attribute_type_obj_slurm_user_specs,
-            allocation_obj,
-            fairshare_value,
+            allocation_attribute_type_obj_slurm_user_specs, allocation_obj, fairshare_value
         )
     except Exception as e:
         logger.error("Failed to add fairshare value to auto_compute_allocation: %s", e)
@@ -121,26 +111,20 @@ def add_auto_compute_allocation(project_obj):
         if AUTO_COMPUTE_ALLOCATION_ACCELERATOR_HOURS > 0:
             accelerator_hours_quantity = AUTO_COMPUTE_ALLOCATION_ACCELERATOR_HOURS
             allocation_auto_compute_attribute_create(
-                allocation_attribute_type_obj_accelerator_hours,
-                allocation_obj,
-                accelerator_hours_quantity,
+                allocation_attribute_type_obj_accelerator_hours, allocation_obj, accelerator_hours_quantity
             )
         # 1b) add core hours non-training project - for gauge to appear
         if AUTO_COMPUTE_ALLOCATION_CORE_HOURS > 0:
             core_hours_quantity = AUTO_COMPUTE_ALLOCATION_CORE_HOURS
             allocation_auto_compute_attribute_create(
-                allocation_attribute_type_obj_core_hours,
-                allocation_obj,
-                core_hours_quantity,
+                allocation_attribute_type_obj_core_hours, allocation_obj, core_hours_quantity
             )
         # 1c) add slurm attrs non-training project
         if len(AUTO_COMPUTE_ALLOCATION_SLURM_ATTR_TUPLE) > 0:
             for slurm_attr in AUTO_COMPUTE_ALLOCATION_SLURM_ATTR_TUPLE:
                 new_slurm_attr = slurm_attr.replace(";", ",").replace("'", "")
                 allocation_auto_compute_attribute_create(
-                    allocation_attribute_type_obj_slurm_specs,
-                    allocation_obj,
-                    new_slurm_attr,
+                    allocation_attribute_type_obj_slurm_specs, allocation_obj, new_slurm_attr
                 )
 
     if project_obj.field_of_science.description == "Training":
@@ -148,26 +132,20 @@ def add_auto_compute_allocation(project_obj):
         if AUTO_COMPUTE_ALLOCATION_ACCELERATOR_HOURS_TRAINING > 0:
             accelerator_hours_quantity = AUTO_COMPUTE_ALLOCATION_ACCELERATOR_HOURS_TRAINING
             allocation_auto_compute_attribute_create(
-                allocation_attribute_type_obj_accelerator_hours,
-                allocation_obj,
-                accelerator_hours_quantity,
+                allocation_attribute_type_obj_accelerator_hours, allocation_obj, accelerator_hours_quantity
             )
         # 2b) add core hours training project - for gauge to appear
         if AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING > 0:
             core_hours_quantity = AUTO_COMPUTE_ALLOCATION_CORE_HOURS_TRAINING
             allocation_auto_compute_attribute_create(
-                allocation_attribute_type_obj_core_hours,
-                allocation_obj,
-                core_hours_quantity,
+                allocation_attribute_type_obj_core_hours, allocation_obj, core_hours_quantity
             )
         # 2c) add slurm attrs training project
         if len(AUTO_COMPUTE_ALLOCATION_SLURM_ATTR_TUPLE_TRAINING) > 0:
             for slurm_attr in AUTO_COMPUTE_ALLOCATION_SLURM_ATTR_TUPLE_TRAINING:
                 new_slurm_attr = slurm_attr.replace(";", ",").replace("'", "")
                 allocation_auto_compute_attribute_create(
-                    allocation_attribute_type_obj_slurm_specs,
-                    allocation_obj,
-                    new_slurm_attr,
+                    allocation_attribute_type_obj_slurm_specs, allocation_obj, new_slurm_attr
                 )
 
     if AUTO_COMPUTE_ALLOCATION_FAIRSHARE_INSTITUTION:

--- a/coldfront/plugins/auto_compute_allocation/utils.py
+++ b/coldfront/plugins/auto_compute_allocation/utils.py
@@ -78,9 +78,7 @@ def allocation_auto_compute(project_obj, project_code):
 def allocation_auto_compute_pi(project_obj, allocation_obj):
     """Method to add the PI to the auto_compute allocation - not other users, as they won't exist on project creation"""
     allocation_user_obj = AllocationUser.objects.create(
-        allocation=allocation_obj,
-        user=project_obj.pi,
-        status=AllocationUserStatusChoice.objects.get(name="Active"),
+        allocation=allocation_obj, user=project_obj.pi, status=AllocationUserStatusChoice.objects.get(name="Active")
     )
     return allocation_user_obj
 
@@ -88,9 +86,7 @@ def allocation_auto_compute_pi(project_obj, allocation_obj):
 def allocation_auto_compute_attribute_create(allocation_attribute_type_obj, allocation_obj, allocation_value):
     """generic method to add allocation attribute types and corresponding values"""
     allocation_attribute_obj = AllocationAttribute.objects.create(
-        allocation=allocation_obj,
-        allocation_attribute_type=allocation_attribute_type_obj,
-        value=allocation_value,
+        allocation=allocation_obj, allocation_attribute_type=allocation_attribute_type_obj, value=allocation_value
     )
     return allocation_attribute_obj
 
@@ -99,20 +95,14 @@ def allocation_auto_compute_fairshare_institution(project_obj, allocation_obj):
     """method to add an institutional fair share value for slurm association - slurm specs"""
     if not hasattr(project_obj, "institution"):
         logger.info("Enable institution feature to set per institution fairshare in the auto_compute_allocation plugin")
-        logger.info(
-            "Additional message - this issue was encountered with project pk %s",
-            {project_obj.pk},
-        )
+        logger.info("Additional message - this issue was encountered with project pk %s", {project_obj.pk})
         return None
     if project_obj.institution in [None, "", "None"]:
         logger.info(
             "None or empty institution value encountered, an institution value is required to set per institution fairshare in the auto_compute_allocation plugin - value found was %s",
             {project_obj.institution},
         )
-        logger.info(
-            "Additional message - this issue was encountered with project pk",
-            {project_obj.pk},
-        )
+        logger.info("Additional message - this issue was encountered with project pk", {project_obj.pk})
         return None
 
     # get the format for the fairshare institution
@@ -122,7 +112,5 @@ def allocation_auto_compute_fairshare_institution(project_obj, allocation_obj):
     fairshare_value = f"Fairshare={fairshare_institution}"
 
     AllocationAttribute.objects.create(
-        allocation=allocation_obj,
-        allocation_attribute_type=allocation_attribute_type_obj,
-        value=fairshare_value,
+        allocation=allocation_obj, allocation_attribute_type=allocation_attribute_type_obj, value=fairshare_value
     )

--- a/coldfront/plugins/project_openldap/management/commands/project_openldap_check_setup.py
+++ b/coldfront/plugins/project_openldap/management/commands/project_openldap_check_setup.py
@@ -9,10 +9,7 @@ from django.core.management.base import BaseCommand
 from ldap3.core.exceptions import LDAPException
 
 from coldfront.core.utils.common import import_from_settings
-from coldfront.plugins.project_openldap.utils import (
-    PROJECT_OPENLDAP_BIND_USER,
-    ldapsearch_check_ou,
-)
+from coldfront.plugins.project_openldap.utils import PROJECT_OPENLDAP_BIND_USER, ldapsearch_check_ou
 
 """ Coldfront project_openldap plugin - django management command -  project_openldap_check_setup.py """
 
@@ -37,18 +34,8 @@ class Command(BaseCommand):
     help = "Check settings for project_openldap plugin"
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "-a",
-            "--all",
-            help="Check both imports and ldapsearch work",
-            action="store_true",
-        )
-        parser.add_argument(
-            "-i",
-            "--imports",
-            help="Check all imports for the plugin",
-            action="store_true",
-        )
+        parser.add_argument("-a", "--all", help="Check both imports and ldapsearch work", action="store_true")
+        parser.add_argument("-i", "--imports", help="Check all imports for the plugin", action="store_true")
         parser.add_argument("-l", "--ldapsearch", help="Check search to OpenLDAP", action="store_true")
 
     def check_env_var_existence(self, name, expected_value, required=True):

--- a/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py
+++ b/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py
@@ -8,10 +8,7 @@ import logging
 
 from django.core.management.base import BaseCommand, CommandError
 
-from coldfront.core.project.models import (
-    Project,
-    ProjectUser,
-)
+from coldfront.core.project.models import Project, ProjectUser
 
 # OpenLDAP (ldap3) connections formed in utils.py
 from coldfront.core.utils.common import import_from_settings
@@ -66,22 +63,12 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "-a",
-            "--all",
-            help="Check all OpenLDAP projects against Coldfront-django",
-            action="store_true",
+            "-a", "--all", help="Check all OpenLDAP projects against Coldfront-django", action="store_true"
         )
-        parser.add_argument(
-            "-p",
-            "--projectgroup",
-            help="Check specific group in OpenLDAP against Coldfront-django",
-        )
+        parser.add_argument("-p", "--projectgroup", help="Check specific group in OpenLDAP against Coldfront-django")
         parser.add_argument("-s", "--sync", help="Sync changes to OpenLDAP", action="store_true")
         parser.add_argument(
-            "-z",
-            "--writearchive",
-            help="Enable writing to the OpenLDAP archive OU",
-            action="store_true",
+            "-z", "--writearchive", help="Enable writing to the OpenLDAP archive OU", action="store_true"
         )
         parser.add_argument(
             "-d",
@@ -90,16 +77,10 @@ class Command(BaseCommand):
             action="store_true",
         )
         parser.add_argument(
-            "-x",
-            "--skiparchived",
-            help="Skip projects with archived status in Coldfront",
-            action="store_true",
+            "-x", "--skiparchived", help="Skip projects with archived status in Coldfront", action="store_true"
         )
         parser.add_argument(
-            "-e",
-            "--skipnewactive",
-            help="Skip projects with New or Active status in Coldfront",
-            action="store_true",
+            "-e", "--skipnewactive", help="Skip projects with New or Active status in Coldfront", action="store_true"
         )
 
     def local_get_project_by_code(self, project_group):
@@ -163,10 +144,7 @@ class Command(BaseCommand):
                 # create posixgroup
                 self.stdout.write(f"Adding OpenLDAP project archive posixgroup entry - DN: {archive_posixgroup_dn}")
                 add_posixgroup_to_openldap(
-                    archive_posixgroup_dn,
-                    archive_openldap_posixgroup_description,
-                    archive_gid,
-                    write=True,
+                    archive_posixgroup_dn, archive_openldap_posixgroup_description, archive_gid, write=True
                 )
             except Exception as e:
                 self.stdout.write(f"Exception adding {archive_posixgroup_dn} to OpenLDAP: {e}")
@@ -221,14 +199,7 @@ class Command(BaseCommand):
                             f"Exception removing {project.project_code}, DN: {project_ou_dn} in OpenLDAP: {e}"
                         )
 
-    def handle_description_update(
-        self,
-        project,
-        project_dn="",
-        archive_dn="",
-        sync=False,
-        write_to_archive=False,
-    ):
+    def handle_description_update(self, project, project_dn="", archive_dn="", sync=False, write_to_archive=False):
         new_description = construct_project_posixgroup_description(project)  # supply project_obj
 
         if project.status.name in ["New", "Active"]:
@@ -452,11 +423,7 @@ class Command(BaseCommand):
                 # project is in project OU not archive OU - DNs supplied - apart from relative, generated in function
                 if ldapsearch_project_result and not ldapsearch_project_result_archive:
                     self.handle_project_in_openldap_but_not_archive(
-                        project,
-                        project_ou_dn,
-                        project_archive_dn,
-                        sync,
-                        write_to_archive,
+                        project, project_ou_dn, project_archive_dn, sync, write_to_archive
                     )
                     return
                 # project is not in project OU, not in achive OU - supply DN to show expected DN - others generated in function
@@ -545,24 +512,13 @@ class Command(BaseCommand):
         # 5) If sought update the OpenLDAP description for the project
         # finally update the OpenLDAP description if requested, will not check, will update regardless
         if update_description:
-            self.handle_description_update(
-                project,
-                project_dn,
-                project_archive_dn,
-                sync,
-                write_to_archive,
-            )
+            self.handle_description_update(project, project_dn, project_archive_dn, sync, write_to_archive)
         # 5) -- END ---
 
     """ Main loop to loop every Coldfront django project pk """
 
     def loop_all_projects(
-        self,
-        sync=False,
-        write_to_archive=False,
-        update_description=False,
-        skip_archived=False,
-        skip_newactive=False,
+        self, sync=False, write_to_archive=False, update_description=False, skip_archived=False, skip_newactive=False
     ):
         projects = Project.objects.filter(status__name__in=["New", "Active", "Archived"]).order_by("id")
 
@@ -574,12 +530,7 @@ class Command(BaseCommand):
             if hasattr(project, "project_code") and project.project_code:
                 project_code = project.project_code
                 self.sync_check_project(
-                    project_code,
-                    sync,
-                    write_to_archive,
-                    update_description,
-                    skip_archived,
-                    skip_newactive,
+                    project_code, sync, write_to_archive, update_description, skip_archived, skip_newactive
                 )
             else:
                 # won't continue to process so self.stdout.write seperator here
@@ -646,11 +597,7 @@ class Command(BaseCommand):
 
         if self.all:
             self.loop_all_projects(
-                self.sync,
-                self.write_archive,
-                self.update_description,
-                self.skip_archived,
-                self.skip_newactive,
+                self.sync, self.write_archive, self.update_description, self.skip_archived, self.skip_newactive
             )
 
         if not self.filter_group and not self.all:

--- a/coldfront/plugins/project_openldap/tasks.py
+++ b/coldfront/plugins/project_openldap/tasks.py
@@ -45,17 +45,11 @@ def add_project(project_obj):
     # if project_code not enabled or None or empty, print appropriate message and bail out to avoid adding it to OpenLDAP
     if not hasattr(project_obj, "project_code"):
         logger.info("Enable project_code to use the project_openldap plugin to add projects into OpenLDAP")
-        logger.info(
-            "Additional message - this issue was encountered with project pk %s",
-            {project_obj.pk},
-        )
+        logger.info("Additional message - this issue was encountered with project pk %s", {project_obj.pk})
         return None
     if project_obj.project_code in [None, ""]:
         logger.WARNING("None or empty project_code value encountered, please run the project code management command")
-        logger.WARNING(
-            "Additional message - this issue was encountered with project pk %s",
-            {project_obj.pk},
-        )
+        logger.WARNING("Additional message - this issue was encountered with project pk %s", {project_obj.pk})
         return None
 
     # 1) first make the OU for the project
@@ -72,10 +66,7 @@ def add_project(project_obj):
 
     logger.info("Adding OpenLDAP project posixgroup entry - DN: %s", posixgroup_dn)
     logger.info("Adding OpenLDAP project posixgroup entry - GID: %s", gid_int)
-    logger.info(
-        "Adding OpenLDAP project posixgroup entry - description: %s",
-        openldap_posixgroup_description,
-    )
+    logger.info("Adding OpenLDAP project posixgroup entry - description: %s", openldap_posixgroup_description)
 
     add_posixgroup_to_openldap(posixgroup_dn, openldap_posixgroup_description, gid_int)
 

--- a/coldfront/plugins/project_openldap/utils.py
+++ b/coldfront/plugins/project_openldap/utils.py
@@ -116,11 +116,7 @@ def add_per_project_ou_to_openldap(project_obj, dn, openldap_ou_description, wri
     try:
         project_code_str = project_obj.project_code
         ou = f"{project_code_str}"
-        conn.add(
-            dn,
-            ["top", "organizationalUnit"],
-            {"ou": ou, "description": openldap_ou_description},
-        )
+        conn.add(dn, ["top", "organizationalUnit"], {"ou": ou, "description": openldap_ou_description})
     except Exception as exc_log:
         logger.error("Project OU: DN to write...")
         logger.error(f"dn - {dn}")
@@ -142,11 +138,7 @@ def add_posixgroup_to_openldap(dn, openldap_description, gid_int, write=True):
         return None
 
     try:
-        conn.add(
-            dn,
-            "posixGroup",
-            {"description": openldap_description, "gidNumber": gid_int},
-        )
+        conn.add(dn, "posixGroup", {"description": openldap_description, "gidNumber": gid_int})
     except Exception as exc_log:
         logger.error("Project posixgroup: DN to write...")
         logger.error(f"dn - {dn}")
@@ -384,9 +376,7 @@ def construct_project_posixgroup_description(project_obj):
         # if title is too long shorten
         if len(project_obj.title) > PROJECT_OPENLDAP_DESCRIPTION_TITLE_LENGTH:
             truncated_title = textwrap.shorten(
-                project_obj.title,
-                PROJECT_OPENLDAP_DESCRIPTION_TITLE_LENGTH,
-                placeholder="...",
+                project_obj.title, PROJECT_OPENLDAP_DESCRIPTION_TITLE_LENGTH, placeholder="..."
             )
             title = truncated_title
         else:

--- a/coldfront/plugins/slurm/associations.py
+++ b/coldfront/plugins/slurm/associations.py
@@ -144,13 +144,7 @@ class SlurmCluster(SlurmBase):
 
     def write(self, out):
         self._write(out, "# ColdFront Allocation Slurm associations dump {}\n".format(datetime.datetime.now().date()))
-        self._write(
-            out,
-            "Cluster - '{}':{}\n".format(
-                self.name,
-                self.format_specs(),
-            ),
-        )
+        self._write(out, "Cluster - '{}':{}\n".format(self.name, self.format_specs()))
         if "root" in self.accounts:
             self.accounts["root"].write(out)
         else:
@@ -216,13 +210,7 @@ class SlurmAccount(SlurmBase):
 
     def write(self, out):
         if self.name != "root":
-            self._write(
-                out,
-                "Account - '{}':{}\n".format(
-                    self.name,
-                    self.format_specs(),
-                ),
-            )
+            self._write(out, "Account - '{}':{}\n".format(self.name, self.format_specs()))
 
     def write_users(self, out):
         self._write(out, "Parent - '{}'\n".format(self.name))
@@ -246,10 +234,4 @@ class SlurmUser(SlurmBase):
         return SlurmUser(name, specs=parts[1:])
 
     def write(self, out):
-        self._write(
-            out,
-            "User - '{}':{}\n".format(
-                self.name,
-                self.format_specs(),
-            ),
-        )
+        self._write(out, "User - '{}':{}\n".format(self.name, self.format_specs()))

--- a/coldfront/plugins/xdmod/management/commands/xdmod_usage.py
+++ b/coldfront/plugins/xdmod/management/commands/xdmod_usage.py
@@ -74,13 +74,9 @@ class Command(BaseCommand):
         )
 
         if self.fetch_expired:
-            allocations = allocations.filter(
-                ~Q(status__name="Active"),
-            )
+            allocations = allocations.filter(~Q(status__name="Active"))
         else:
-            allocations = allocations.filter(
-                status__name="Active",
-            )
+            allocations = allocations.filter(status__name="Active")
 
         if self.filter_user:
             allocations = allocations.filter(project__pi__username=self.filter_user)
@@ -179,13 +175,9 @@ class Command(BaseCommand):
         )
 
         if self.fetch_expired:
-            allocations = allocations.filter(
-                ~Q(status__name="Active"),
-            )
+            allocations = allocations.filter(~Q(status__name="Active"))
         else:
-            allocations = allocations.filter(
-                status__name="Active",
-            )
+            allocations = allocations.filter(status__name="Active")
 
         if self.filter_user:
             allocations = allocations.filter(project__pi__username=self.filter_user)
@@ -276,9 +268,7 @@ class Command(BaseCommand):
 
         allocations = (
             Allocation.objects.prefetch_related("project", "resources", "allocationattribute_set", "allocationuser_set")
-            .filter(
-                status__name="Active",
-            )
+            .filter(status__name="Active")
             .filter(
                 allocationattribute__allocation_attribute_type__name__in=[
                     XDMOD_ACCOUNT_ATTRIBUTE_NAME,
@@ -374,9 +364,7 @@ class Command(BaseCommand):
 
         allocations = (
             Allocation.objects.prefetch_related("project", "resources", "allocationattribute_set", "allocationuser_set")
-            .filter(
-                status__name="Active",
-            )
+            .filter(status__name="Active")
             .filter(
                 allocationattribute__allocation_attribute_type__name__in=[
                     XDMOD_CLOUD_PROJECT_ATTRIBUTE_NAME,


### PR DESCRIPTION
A pet peeve of mine with tools like `black` and `ruff` is that the formatter is happy to convert
```
[foo, bar]
```

into 
```
[
    foo,
    bar,
]
```

but then, once that it done, it will refuse to convert back again due to the trailing comma.

So I removed all trailing commas (`,\n(\s*)\)` -> `\n$1)`) and let `ruff` condense these lines again.