### PR TITLE
Center Summary bugfix

### DIFF
--- a/coldfront/core/portal/views.py
+++ b/coldfront/core/portal/views.py
@@ -166,17 +166,16 @@ def center_summary(request):
     total_grants_by_agency = sorted(total_grants_by_agency, key=operator.itemgetter(1), reverse=True)
     grants_agency_chart_data = generate_total_grants_by_agency_chart_data(total_grants_by_agency)
     context["grants_agency_chart_data"] = grants_agency_chart_data
-    context["grants_total"] = intcomma(
-        int(sum(map(float, Grant.objects.values_list("total_amount_awarded", flat=True))))
-    )
+    sum_agg = Sum("total_amount_awarded", default=0)
+    context["grants_total"] = intcomma(int(Grant.objects.aggregate(sum_agg)["total_amount_awarded__sum"]))
     context["grants_total_pi_only"] = intcomma(
-        int(sum(map(float, Grant.objects.filter(role="PI").values_list("total_amount_awarded", flat=True))))
+        int(Grant.objects.filter(role="PI").aggregate(sum_agg)["total_amount_awarded__sum"])
     )
     context["grants_total_copi_only"] = intcomma(
-        int(sum(map(float, Grant.objects.filter(role="CoPI").values_list("total_amount_awarded", flat=True))))
+        int(Grant.objects.filter(role="CoPI").aggregate(sum_agg)["total_amount_awarded__sum"])
     )
     context["grants_total_sp_only"] = intcomma(
-        int(sum(map(float, Grant.objects.filter(role="SP").values_list("total_amount_awarded", flat=True))))
+        int(Grant.objects.filter(role="SP").aggregate(sum_agg)["total_amount_awarded__sum"])
     )
 
     return render(request, "portal/center_summary.html", context)


### PR DESCRIPTION
Fixes `unsupported operand type(s) for +: 'int' and 'str'` when accessing `/center-summary`

```py
sum(list(Grant.objects.values_list("total_amount_awarded", flat=True)))
```
fails because `values_list()` returns strings despite the field being a float. [SO Thread](https://stackoverflow.com/questions/53976929/floatfield-returns-str-object-instead-of-float-in-django) and the [ticket](https://code.djangoproject.com/ticket/12401#comment:10) it references.

~This fix uses Python's [`map`](https://docs.python.org/3/library/functions.html#map) function to turn all the strings in the list to floats before summing them.~

This fix uses Django's aggregations to calculate the sum.