### PR TITLE
Batch commands when syncing FreeIPA.

### DIFF
--- a/coldfront/plugins/freeipa/management/commands/freeipa_expire_users.py
+++ b/coldfront/plugins/freeipa/management/commands/freeipa_expire_users.py
@@ -14,7 +14,7 @@ from ipalib import api
 
 from coldfront.core.allocation.models import AllocationUser
 from coldfront.core.utils.mail import build_link
-from coldfront.plugins.freeipa.utils import CLIENT_KTNAME, FREEIPA_NOOP
+from coldfront.plugins.freeipa.utils import CLIENT_KTNAME, FREEIPA_NOOP, ipa_bootstrap
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +118,8 @@ class Command(BaseCommand):
                         "expire_date": expire_date,
                         "allocation_id": allocation.id,
                     }
+
+        ipa_bootstrap()
 
         # Print users whose latest allocation expiration date GTE 365 days and active in FreeIPA
         for key in expired_allocation_users.keys():

--- a/coldfront/plugins/freeipa/tasks.py
+++ b/coldfront/plugins/freeipa/tasks.py
@@ -16,6 +16,7 @@ from coldfront.plugins.freeipa.utils import (
     AlreadyMemberError,
     NotMemberError,
     check_ipa_group_error,
+    ipa_bootstrap,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ def add_user_group(allocation_user_pk):
         return
 
     os.environ["KRB5_CLIENT_KTNAME"] = CLIENT_KTNAME
+    ipa_bootstrap()
     for g in groups:
         if FREEIPA_NOOP:
             logger.warning(
@@ -104,6 +106,7 @@ def remove_user_group(allocation_user_pk):
         return
 
     os.environ["KRB5_CLIENT_KTNAME"] = CLIENT_KTNAME
+    ipa_bootstrap()
     for g in groups:
         if FREEIPA_NOOP:
             logger.warning(

--- a/coldfront/plugins/freeipa/utils.py
+++ b/coldfront/plugins/freeipa/utils.py
@@ -29,14 +29,15 @@ class NotMemberError(ApiError):
     pass
 
 
-try:
-    os.environ["KRB5_CLIENT_KTNAME"] = CLIENT_KTNAME
-    api.bootstrap()
-    api.finalize()
-    api.Backend.rpcclient.connect()
-except Exception as e:
-    logger.error("Failed to initialze FreeIPA lib: %s", e)
-    raise ImproperlyConfigured("Failed to initialze FreeIPA: {0}".format(e))
+def ipa_bootstrap():
+    try:
+        os.environ["KRB5_CLIENT_KTNAME"] = CLIENT_KTNAME
+        api.bootstrap(context="client", in_server=False)
+        api.finalize()
+        api.Backend.rpcclient.connect()
+    except Exception as e:
+        logger.error("Failed to initialze FreeIPA lib: %s", e)
+        raise ImproperlyConfigured("Failed to initialze FreeIPA: {0}".format(e))
 
 
 def check_ipa_group_error(res):


### PR DESCRIPTION
When syncing unix groups with FreeIPA, the group_remove_member and group_add_member commands are submitted to the IPA server separately per user. This patch modifies the FreeIPA sync command to leverage the batch command from the IPA API which can be used to send commands in the same API request. Currently the batch size is hard coded to 100 which should be sufficent. In the future consider making this a CLI arg.

See here: https://freeipa.readthedocs.io/en/latest/api/basic_usage.html#batch-operations

We have also been experiencing random failures on IPA API calls, for example:

```
ipa: ERROR: connect to 'https://ipa-server/ipa/json': EOF occurred in violation of protocol (_ssl.c:2427)
```

It appears this may be caused by running the IPA API bootstrapping when utils.py was imported instead of right before making an API call.  This patch adds a helper function for more control over when to bootstrap the IPA API.