### PR TITLE
Allow project managers to view allocations associated with the project

### DIFF
--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -191,8 +191,11 @@ class ProjectDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
                                 "Active",
                             ]
                         )
-                        & Q(allocationuser__user=self.request.user)
-                        & Q(allocationuser__status__name__in=["Active", "PendingEULA"])
+                        & (
+                            Q(allocationuser__user=self.request.user)
+                            & Q(allocationuser__status__name__in=["Active", "PendingEULA"])
+                        )
+                        | Q(project__projectuser__role__name="Manager")
                     )
                     .distinct()
                     .order_by("-end_date")


### PR DESCRIPTION
## Description

Per discussion in the recent Coldfront community conversation, this PR allows a Manager for a project to view the Allocations associated with the project. Note that this allows a manager to also edit the allocations since anyone with `ProjectPermisson.MANAGER` is implicitly assigned `AllocationPermission.MANAGER`.

## Component

- [x] Projects
- [x] Allocations
