### PR TITLE
Patched Dockerfile to correct uv version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt install -y \
         libglib2.0-dev \
         libsasl2-dev
 
-COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.9.13 /uv /bin/uv
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ publish-url = "https://test.pypi.org/legacy/"
 explicit = true
 
 [tool.uv]
-required-version = ">=0.9.13"
+required-version = ">=0.9.13" # Make sure this version matches what is in the Dockerfile
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Bumped the uv version in the Dockerfile to match what is in pyproject.toml. Added comment to pyproject.toml to remind maintinainers to update the Dockerfile uv version.

Without this the Dockerfile will not build. 