### PR TITLE
fix Q filter for allocations in ProjectDetailView

### DIFF
--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -180,10 +180,12 @@ class ProjectDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
                             ]
                         )
                         & (
-                            Q(allocationuser__user=self.request.user)
-                            & Q(allocationuser__status__name__in=["Active", "PendingEULA"])
+                            (
+                                Q(allocationuser__user=self.request.user)
+                                & Q(allocationuser__status__name__in=["Active", "PendingEULA"])
+                            )
+                            | Q(project__projectuser__role__name="Manager")
                         )
-                        | Q(project__projectuser__role__name="Manager")
                     )
                     .distinct()
                     .order_by("-end_date")


### PR DESCRIPTION
Fix a regression introduced in https://github.com/coldfront/coldfront/pull/913

Without the extra parenthesis, the last OR applies to all the previous filters :(