### PR TITLE
Fixed flaky Allocation test due to Factory not creating a unique new value

### DIFF
--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -322,7 +322,7 @@ class AllocationModelStrTests(TestCase):
         """When the project associated with this allocation changes the str should change"""
         original_string = str(self.allocation)
 
-        new_project = ProjectFactory()
+        new_project = ProjectFactory(pi=UserFactory(first_name="Unique Name"))
         self.allocation.project = new_project
         self.allocation.save()
 


### PR DESCRIPTION
Fixed problem where django_get_or_create fails to create a fully unique deep project. Forces ProjectFactory in test_project_changed_changes_str to create a unique pi.

Fixes #851