### PR TITLE
fix: Remove the resource_type search field from the admin page

### DIFF
--- a/coldfront/core/resource/admin.py
+++ b/coldfront/core/resource/admin.py
@@ -53,7 +53,6 @@ class ResourceAttributeTypeAdmin(SimpleHistoryAdmin):
     search_fields = (
         "name",
         "attribute_type__name",
-        "resource_type__name",
     )
     list_filter = ("attribute_type__name", "name", "is_required", "is_unique_per_resource", "is_value_unique")
 


### PR DESCRIPTION
This fixes an error when using the search funtion on the admin page for resource attribute types.
```
django.core.exceptions.FieldError: Cannot resolve keyword 'resource_type' into field. Choices are: allocationattributetype, attribute_type, attribute_type_id, created, description, id, is_required, is_unique_per_resource, is_value_unique, modified, name, resourceattribute
```
