### PR TITLE
Migrate to custom user and group auth models.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - "docs/**"
     branches:
       - main
+      - develop
 
 jobs:
   build:

--- a/coldfront/config/auth.py
+++ b/coldfront/config/auth.py
@@ -8,6 +8,9 @@ from coldfront.config.env import ENV
 # ------------------------------------------------------------------------------
 # ColdFront default authentication settings
 # ------------------------------------------------------------------------------
+
+AUTH_USER_MODEL = "users.User"
+
 AUTHENTICATION_BACKENDS += [
     "django.contrib.auth.backends.ModelBackend",
 ]

--- a/coldfront/config/base.py
+++ b/coldfront/config/base.py
@@ -81,6 +81,7 @@ INSTALLED_APPS += [
     "coldfront.core.grant",
     "coldfront.core.publication",
     "coldfront.core.research_output",
+    "coldfront.users",
 ]
 
 # ------------------------------------------------------------------------------

--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -6,8 +6,8 @@ import datetime
 import logging
 from enum import Enum
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
@@ -479,7 +479,7 @@ class AllocationAdminNote(TimeStampedModel):
     """
 
     allocation = models.ForeignKey(Allocation, on_delete=models.CASCADE)
-    author = models.ForeignKey(User, on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     note = models.TextField()
 
     def __str__(self):
@@ -497,7 +497,7 @@ class AllocationUserNote(TimeStampedModel):
     """
 
     allocation = models.ForeignKey(Allocation, on_delete=models.CASCADE)
-    author = models.ForeignKey(User, on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     is_private = models.BooleanField(default=True)
     note = models.TextField()
 
@@ -713,7 +713,7 @@ class AllocationUser(TimeStampedModel):
     """
 
     allocation = models.ForeignKey(Allocation, on_delete=models.CASCADE)
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     status = models.ForeignKey(
         AllocationUserStatusChoice, on_delete=models.CASCADE, verbose_name="Allocation User Status"
     )
@@ -749,7 +749,7 @@ class AllocationAccount(TimeStampedModel):
         name (str):
     """
 
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     name = models.CharField(max_length=64, unique=True)
 
     def __str__(self):

--- a/coldfront/core/allocation/tests/test_models.py
+++ b/coldfront/core/allocation/tests/test_models.py
@@ -8,7 +8,7 @@ import datetime
 import sys
 from unittest.mock import patch
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
@@ -292,7 +292,7 @@ class AllocationModelStrTests(TestCase):
 
     def test_project_pi_name_updated_changes_str(self):
         """Test that if the name of the PI is updated that the str changes"""
-        pi: User = self.allocation.project.pi
+        pi: get_user_model() = self.allocation.project.pi
         new_username: str = "This is a new username!"
         pi.username = new_username
         pi.save()
@@ -304,7 +304,7 @@ class AllocationModelStrTests(TestCase):
 
     def test_parent_resource_changed_changes_str(self):
         """When the original parent resource is removed and replaced with another the str changes"""
-        original_pi: User = self.allocation.project.pi
+        original_pi: get_user_model() = self.allocation.project.pi
 
         original_string = str(self.allocation)
 

--- a/coldfront/core/allocation/tests/test_views.py
+++ b/coldfront/core/allocation/tests/test_views.py
@@ -8,7 +8,7 @@ from http import HTTPStatus
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
@@ -54,7 +54,7 @@ class AllocationViewBaseTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Test Data setup for all allocation view tests."""
-        pi_user: User = UserFactory()
+        pi_user: get_user_model() = UserFactory()
         pi_user.userprofile.is_pi = True
         AllocationStatusChoiceFactory(name="New")
         AllocationUserStatusChoiceFactory(name="Removed")
@@ -63,12 +63,12 @@ class AllocationViewBaseTest(TestCase):
         cls.allocation.resources.add(ResourceFactory(name="holylfs07/tier1"))
         # create allocation user that belongs to project
         allocation_user = AllocationUserFactory(allocation=cls.allocation)
-        cls.allocation_user: User = allocation_user.user
+        cls.allocation_user: get_user_model() = allocation_user.user
         ProjectUserFactory(project=cls.project, user=allocation_user.user)
         # create project user that isn't an allocationuser
         proj_nonallocation_user: ProjectUser = ProjectUserFactory(project=cls.project)
         cls.proj_nonallocation_user = proj_nonallocation_user.user
-        cls.admin_user: User = UserFactory(is_staff=True, is_superuser=True)
+        cls.admin_user: get_user_model() = UserFactory(is_staff=True, is_superuser=True)
         manager_role: ProjectUserRoleChoice = ProjectUserRoleChoiceFactory(name="Manager")
         ProjectUserFactory(user=pi_user, project=cls.project, role=manager_role)
         cls.pi_user = pi_user

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -5,8 +5,8 @@
 import datetime
 from enum import Enum
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import MinLengthValidator
 from django.db import models
@@ -90,7 +90,7 @@ We do not have information about your research. Please provide a detailed descri
         max_length=255,
     )
     pi = models.ForeignKey(
-        User,
+        settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
     )
     description = models.TextField(
@@ -366,7 +366,7 @@ class ProjectAdminComment(TimeStampedModel):
     """
 
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
-    author = models.ForeignKey(User, on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     comment = models.TextField()
 
     def __str__(self):
@@ -384,7 +384,7 @@ class ProjectUserMessage(TimeStampedModel):
     """
 
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
-    author = models.ForeignKey(User, on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     is_private = models.BooleanField(default=True)
     message = models.TextField()
 
@@ -488,7 +488,7 @@ class ProjectUser(TimeStampedModel):
         enable_notifications (bool): indicates whether or not the user should enable notifications
     """
 
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
     role = models.ForeignKey(ProjectUserRoleChoice, on_delete=models.CASCADE)
     status = models.ForeignKey(ProjectUserStatusChoice, on_delete=models.CASCADE, verbose_name="Status")

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -7,9 +7,9 @@ import logging
 from django import forms
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.contrib.auth.models import User
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Q
@@ -874,7 +874,7 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
                     added_users_count += 1
 
                     # Will create local copy of user if not already present in local database
-                    user_obj, created = User.objects.get_or_create(username=user_form_data.get("username"))
+                    user_obj, created = get_user_model().objects.get_or_create(username=user_form_data.get("username"))
                     if created:
                         user_obj.first_name = user_form_data.get("first_name")
                         user_obj.last_name = user_form_data.get("last_name")
@@ -991,7 +991,7 @@ class ProjectRemoveUsersView(LoginRequiredMixin, UserPassesTestMixin, TemplateVi
                 if user_form_data["selected"]:
                     remove_users_count += 1
 
-                    user_obj = User.objects.get(username=user_form_data.get("username"))
+                    user_obj = get_user_model().objects.get(username=user_form_data.get("username"))
 
                     if project_obj.pi == user_obj:
                         continue

--- a/coldfront/core/research_output/models.py
+++ b/coldfront/core/research_output/models.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from django.contrib.auth.models import User
+from django.conf import settings
 from django.core.validators import MinLengthValidator
 from django.db import models
 from model_utils.models import TimeStampedModel
@@ -30,7 +30,7 @@ class ResearchOutput(TimeStampedModel):
 
     # auxiliary fields
     created_by = models.ForeignKey(
-        User,
+        settings.AUTH_USER_MODEL,
         editable=False,
         on_delete=models.SET_NULL,  # don't want to remove the entry when author user is deleted
         null=True,

--- a/coldfront/core/resource/migrations/0004_alter_resource_allowed_groups.py
+++ b/coldfront/core/resource/migrations/0004_alter_resource_allowed_groups.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("resource", "0003_alter_historicalresource_options_and_more"),
+        ("users", "0003_group"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="resource",
+            name="allowed_groups",
+            field=models.ManyToManyField(blank=True, to="users.group"),
+        ),
+    ]

--- a/coldfront/core/resource/models.py
+++ b/coldfront/core/resource/models.py
@@ -4,13 +4,14 @@
 
 from datetime import datetime
 
-from django.contrib.auth.models import Group, User
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from model_utils.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
 
 import coldfront.core.attribute_expansion as attribute_expansion
+from coldfront.users.models import Group
 
 
 class AttributeType(TimeStampedModel):
@@ -139,7 +140,7 @@ class Resource(TimeStampedModel):
     is_allocatable = models.BooleanField(default=True)
     requires_payment = models.BooleanField(default=False)
     allowed_groups = models.ManyToManyField(Group, blank=True)
-    allowed_users = models.ManyToManyField(User, blank=True)
+    allowed_users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True)
     linked_resources = models.ManyToManyField("self", blank=True)
     history = HistoricalRecords()
     objects = ResourceManager()

--- a/coldfront/core/test_helpers/factories.py
+++ b/coldfront/core/test_helpers/factories.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import factory
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
@@ -80,7 +80,7 @@ for provider in [ColdfrontProvider, field_of_science_provider]:
 
 class UserFactory(DjangoModelFactory):
     class Meta:
-        model = User
+        model = get_user_model()
         django_get_or_create = ("username",)
 
     first_name = factory.Faker("first_name")

--- a/coldfront/core/user/models.py
+++ b/coldfront/core/user/models.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from django.contrib.auth.models import User
+from django.conf import settings
 from django.db import models
 
 
@@ -14,5 +14,5 @@ class UserProfile(models.Model):
         user (User): represents the Django User model
     """
 
-    user = models.OneToOneField(User, on_delete=models.CASCADE)
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     is_pi = models.BooleanField(default=False)

--- a/coldfront/core/user/signals.py
+++ b/coldfront/core/user/signals.py
@@ -2,19 +2,19 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from coldfront.core.user.models import UserProfile
 
 
-@receiver(post_save, sender=User)
+@receiver(post_save, sender=get_user_model())
 def create_user_profile(sender, instance, created, **kwargs):
     if created:
         UserProfile.objects.create(user=instance)
 
 
-@receiver(post_save, sender=User)
+@receiver(post_save, sender=get_user_model())
 def save_user_profile(sender, instance, **kwargs):
     instance.userprofile.save()

--- a/coldfront/core/user/utils.py
+++ b/coldfront/core/user/utils.py
@@ -5,7 +5,7 @@
 import abc
 import logging
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.utils.module_loading import import_string
 
@@ -46,7 +46,8 @@ class LocalUserSearch(UserSearch):
         size_limit = 50
         if user_search_string and search_by == "all_fields":
             entries = (
-                User.objects.filter(
+                get_user_model()
+                .objects.filter(
                     Q(username__icontains=user_search_string)
                     | Q(first_name__icontains=user_search_string)
                     | Q(last_name__icontains=user_search_string)
@@ -57,9 +58,9 @@ class LocalUserSearch(UserSearch):
             )
 
         elif user_search_string and search_by == "username_only":
-            entries = User.objects.filter(username=user_search_string, is_active=True)
+            entries = get_user_model().objects.filter(username=user_search_string, is_active=True)
         else:
-            entries = User.objects.all()[:size_limit]
+            entries = get_user_model().objects.all()[:size_limit]
 
         users = []
         for idx, user in enumerate(entries, 1):

--- a/coldfront/core/user/views.py
+++ b/coldfront/core/user/views.py
@@ -5,10 +5,10 @@
 import logging
 
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.contrib.auth import logout as auth_logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.contrib.auth.models import User
 from django.contrib.auth.views import LogoutView
 from django.db.models import BooleanField, Prefetch
 from django.db.models.expressions import ExpressionWrapper, F, Q
@@ -56,7 +56,7 @@ class UserProfile(TemplateView):
         context = super().get_context_data(**kwargs)
 
         if viewed_username:
-            viewed_user = get_object_or_404(User, username=viewed_username)
+            viewed_user = get_object_or_404(get_user_model(), username=viewed_username)
         else:
             viewed_user = self.request.user
 
@@ -88,7 +88,7 @@ class UserProjectsManagersView(ListView):
 
         # get_queryset does not get kwargs, so we need to store it off here
         if viewed_username:
-            self.viewed_user = get_object_or_404(User, username=viewed_username)
+            self.viewed_user = get_object_or_404(get_user_model(), username=viewed_username)
         else:
             self.viewed_user = self.request.user
 

--- a/coldfront/core/utils/management/commands/load_test_data.py
+++ b/coldfront/core/utils/management/commands/load_test_data.py
@@ -6,7 +6,7 @@ import datetime
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
 from coldfront.core.allocation.models import (
@@ -158,19 +158,19 @@ class Command(BaseCommand):
             first_name, last_name = user.split()
             username = first_name[0].lower() + last_name.lower().strip()
             email = username + "@example.com"
-            User.objects.get_or_create(
+            get_user_model().objects.get_or_create(
                 first_name=first_name.strip(),
                 last_name=last_name.strip(),
                 username=username.strip(),
                 email=email.strip(),
             )
 
-        admin_user, _ = User.objects.get_or_create(username="admin")
+        admin_user, _ = get_user_model().objects.get_or_create(username="admin")
         admin_user.is_superuser = True
         admin_user.is_staff = True
         admin_user.save()
 
-        for user in User.objects.all():
+        for user in get_user_model().objects.all():
             user.set_password("test1234")
             user.save()
 
@@ -193,11 +193,11 @@ class Command(BaseCommand):
             )
 
         resource_obj = Resource.objects.get(name="server-cgray")
-        resource_obj.allowed_users.add(User.objects.get(username="cgray"))
+        resource_obj.allowed_users.add(get_user_model().objects.get(username="cgray"))
         resource_obj = Resource.objects.get(name="server-sfoster")
-        resource_obj.allowed_users.add(User.objects.get(username="sfoster"))
+        resource_obj.allowed_users.add(get_user_model().objects.get(username="sfoster"))
 
-        pi1 = User.objects.get(username="cgray")
+        pi1 = get_user_model().objects.get(username="cgray")
         pi1.userprofile.is_pi = True
         pi1.save()
         project_obj, _ = Project.objects.get_or_create(
@@ -416,7 +416,7 @@ class Command(BaseCommand):
             allocation=allocation_obj, user=pi1, status=AllocationUserStatusChoice.objects.get(name="Active")
         )
 
-        pi2 = User.objects.get(username="sfoster")
+        pi2 = get_user_model().objects.get(username="sfoster")
         pi2.userprofile.is_pi = True
         pi2.save()
         project_obj, _ = Project.objects.get_or_create(

--- a/coldfront/plugins/freeipa/management/commands/freeipa_check.py
+++ b/coldfront/plugins/freeipa/management/commands/freeipa_check.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 import dbus
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from ipalib import api
 
@@ -306,7 +306,7 @@ class Command(BaseCommand):
         infopipe_obj = bus.get_object("org.freedesktop.sssd.infopipe", "/org/freedesktop/sssd/infopipe")
         self.ifp = dbus.Interface(infopipe_obj, dbus_interface="org.freedesktop.sssd.infopipe")
 
-        users = User.objects.filter(is_active=True)
+        users = get_user_model().objects.filter(is_active=True)
         logger.info("Processing %s active users", len(users))
 
         self.filter_user = ""

--- a/coldfront/plugins/mokey_oidc/auth.py
+++ b/coldfront/plugins/mokey_oidc/auth.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from django.contrib.auth.models import Group
+from coldront.users.models import Group
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
 from coldfront.core.utils.common import import_from_settings

--- a/coldfront/users/__init__.py
+++ b/coldfront/users/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/coldfront/users/admin.py
+++ b/coldfront/users/admin.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from django.contrib import admin
+from django.contrib.auth.admin import GroupAdmin, UserAdmin
+
+from .models import Group, User
+
+
+class ColdFrontUserAdmin(UserAdmin):
+    model = User
+    list_display = ["username", "email", "first_name", "last_name", "is_staff"]
+    search_fields = ["username"]
+
+
+class ColdFrontGroupAdmin(GroupAdmin):
+    model = Group
+    list_display = ["name", "description"]
+    search_fields = ["name"]
+
+
+admin.site.register(User, ColdFrontUserAdmin)
+admin.site.register(Group, ColdFrontGroupAdmin)

--- a/coldfront/users/apps.py
+++ b/coldfront/users/apps.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    name = "coldfront.users"

--- a/coldfront/users/migrations/0001_initial.py
+++ b/coldfront/users/migrations/0001_initial.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import django.contrib.auth.models
+import django.contrib.auth.validators
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        ("auth", "0012_alter_user_first_name_max_length"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="User",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("password", models.CharField(max_length=128, verbose_name="password")),
+                ("last_login", models.DateTimeField(blank=True, null=True, verbose_name="last login")),
+                (
+                    "is_superuser",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Designates that this user has all permissions without explicitly assigning them.",
+                        verbose_name="superuser status",
+                    ),
+                ),
+                (
+                    "username",
+                    models.CharField(
+                        error_messages={"unique": "A user with that username already exists."},
+                        help_text="Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.",
+                        max_length=150,
+                        unique=True,
+                        validators=[django.contrib.auth.validators.UnicodeUsernameValidator()],
+                        verbose_name="username",
+                    ),
+                ),
+                ("first_name", models.CharField(blank=True, max_length=150, verbose_name="first name")),
+                ("last_name", models.CharField(blank=True, max_length=150, verbose_name="last name")),
+                ("email", models.EmailField(blank=True, max_length=254, verbose_name="email address")),
+                (
+                    "is_staff",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Designates whether the user can log into this admin site.",
+                        verbose_name="staff status",
+                    ),
+                ),
+                (
+                    "is_active",
+                    models.BooleanField(
+                        default=True,
+                        help_text="Designates whether this user should be treated as active. Unselect this instead of deleting accounts.",
+                        verbose_name="active",
+                    ),
+                ),
+                ("date_joined", models.DateTimeField(default=django.utils.timezone.now, verbose_name="date joined")),
+                (
+                    "groups",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="The groups this user belongs to. A user will get all permissions granted to each of their groups.",
+                        related_name="user_set",
+                        related_query_name="user",
+                        to="auth.group",
+                        verbose_name="groups",
+                    ),
+                ),
+                (
+                    "user_permissions",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="Specific permissions for this user.",
+                        related_name="user_set",
+                        related_query_name="user",
+                        to="auth.permission",
+                        verbose_name="user permissions",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "user",
+                "verbose_name_plural": "users",
+                "db_table": "auth_user",
+                "ordering": ("username",),
+            },
+            managers=[
+                ("objects", django.contrib.auth.models.UserManager()),
+            ],
+        ),
+    ]

--- a/coldfront/users/migrations/0002_alter_user_table.py
+++ b/coldfront/users/migrations/0002_alter_user_table.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AlterModelTable(
+            name="user",
+            table=None,
+        ),
+    ]

--- a/coldfront/users/migrations/0003_group.py
+++ b/coldfront/users/migrations/0003_group.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import django.contrib.auth.models
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("auth", "0012_alter_user_first_name_max_length"),
+        ("users", "0002_alter_user_table"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Group",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("name", models.CharField(max_length=150, unique=True, verbose_name="name")),
+                ("description", models.CharField(blank=True, max_length=200, verbose_name="description")),
+                (
+                    "permissions",
+                    models.ManyToManyField(
+                        blank=True,
+                        related_name="groups",
+                        related_query_name="group",
+                        to="auth.permission",
+                        verbose_name="permissions",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "group",
+                "verbose_name_plural": "groups",
+                "ordering": ("name",),
+            },
+            managers=[
+                ("objects", django.contrib.auth.models.GroupManager()),
+            ],
+        ),
+        migrations.RunSQL(
+            sql="INSERT INTO users_group (id, name, description) SELECT id, name, '' AS description FROM auth_group;",
+        ),
+        migrations.AlterField(
+            model_name="user",
+            name="groups",
+            field=models.ManyToManyField(
+                blank=True, related_name="users", related_query_name="user", to="users.group", verbose_name="groups"
+            ),
+        ),
+        migrations.RunSQL(
+            sql="DELETE from auth_group",
+        ),
+    ]

--- a/coldfront/users/migrations/__init__.py
+++ b/coldfront/users/migrations/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/coldfront/users/models/__init__.py
+++ b/coldfront/users/models/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from .users import Group, User
+
+__all__ = ("User", "Group")

--- a/coldfront/users/models/users.py
+++ b/coldfront/users/models/users.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: (C) ColdFront Authors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.contrib.auth.models import (
+    GroupManager,
+    Permission,
+    PermissionsMixin,
+    UserManager,
+)
+from django.contrib.auth.validators import UnicodeUsernameValidator
+from django.core.mail import send_mail
+from django.db import models
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+
+
+class User(AbstractBaseUser, PermissionsMixin):
+    """
+    ColdFront User model
+    """
+
+    username_validator = UnicodeUsernameValidator()
+
+    username = models.CharField(
+        _("username"),
+        max_length=150,
+        unique=True,
+        help_text=_("Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only."),
+        validators=[username_validator],
+        error_messages={
+            "unique": _("A user with that username already exists."),
+        },
+    )
+    first_name = models.CharField(_("first name"), max_length=150, blank=True)
+    last_name = models.CharField(_("last name"), max_length=150, blank=True)
+    email = models.EmailField(_("email address"), blank=True)
+    is_staff = models.BooleanField(
+        _("staff status"),
+        default=False,
+        help_text=_("Designates whether the user can log into this admin site."),
+    )
+    is_active = models.BooleanField(
+        _("active"),
+        default=True,
+        help_text=_(
+            "Designates whether this user should be treated as active. Unselect this instead of deleting accounts."
+        ),
+    )
+    date_joined = models.DateTimeField(_("date joined"), default=timezone.now)
+    groups = models.ManyToManyField(
+        to="users.Group", verbose_name=_("groups"), blank=True, related_name="users", related_query_name="user"
+    )
+
+    objects = UserManager()
+
+    EMAIL_FIELD = "email"
+    USERNAME_FIELD = "username"
+    REQUIRED_FIELDS = ["email"]
+
+    class Meta:
+        ordering = ("username",)
+        verbose_name = _("user")
+        verbose_name_plural = _("users")
+
+    def clean(self):
+        super().clean()
+        self.email = self.__class__.objects.normalize_email(self.email)
+
+    def get_full_name(self):
+        """
+        Return the first_name plus the last_name, with a space in between.
+        """
+        full_name = "%s %s" % (self.first_name, self.last_name)
+        return full_name.strip()
+
+    def get_short_name(self):
+        """Return the short name for the user."""
+        return self.first_name
+
+    def email_user(self, subject, message, from_email=None, **kwargs):
+        """Send an email to this user."""
+        send_mail(subject, message, from_email, [self.email], **kwargs)
+
+
+class Group(models.Model):
+    """
+    ColdFront Group model.
+    """
+
+    name = models.CharField(verbose_name=_("name"), max_length=150, unique=True)
+    description = models.CharField(verbose_name=_("description"), max_length=200, blank=True)
+
+    # Replicate legacy Django permissions support from stock Group model
+    # to ensure authentication backend compatibility
+    permissions = models.ManyToManyField(
+        Permission, verbose_name=_("permissions"), blank=True, related_name="groups", related_query_name="group"
+    )
+
+    objects = GroupManager()
+
+    class Meta:
+        ordering = ("name",)
+        verbose_name = _("group")
+        verbose_name_plural = _("groups")
+
+    def __str__(self):
+        return self.name
+
+    def natural_key(self):
+        return (self.name,)

--- a/docs/pages/howto/importing.md
+++ b/docs/pages/howto/importing.md
@@ -295,7 +295,7 @@ following python file `import-alloc-users.py`:
 
 ```python
 from django.db.models import Q
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model()
 from coldfront.core.project.models import Project
 from coldfront.core.allocation.models import (
                                           Allocation,
@@ -304,7 +304,7 @@ from coldfront.core.allocation.models import (
 
 
 status = AllocationUserStatusChoice.objects.get(name="Active")
-piuser = User.objects.get(username="cgray")
+piuser = get_user_model().objects.get(username="cgray")
 project = Project.objects.get(
                     title="Angular momentum in QGP holography",
                     pi=piuser)

--- a/docs/pages/upgrading.md
+++ b/docs/pages/upgrading.md
@@ -3,6 +3,21 @@
 This document describes upgrading ColdFront. New releases of ColdFront may
 introduce breaking changes so please refer to this document before upgrading.
 
+## [v2.0.0](https://github.com/coldfront/coldfront/releases/tag/v2.0.0)
+
+!!! warning "Backup your database"
+    This release contains a migration to a new custom user model. Please backup
+    your database and test before going into production.
+    
+After upgrading run the following commands in order:
+
+```
+$ uv run coldfront dbshell < scripts/upgrade-v2.2.2-user-model.sql
+$ uv run coldfront migrate
+$ uv run coldfront collectstatic
+```
+
+
 ## [v1.1.7](https://github.com/coldfront/coldfront/releases/tag/v1.1.7)
 
 This release upgrades to [django-q2](https://github.com/django-q2/django-q2)

--- a/scripts/upgrade-v2.0.0-user-model.sql
+++ b/scripts/upgrade-v2.0.0-user-model.sql
@@ -1,0 +1,6 @@
+-- SPDX-FileCopyrightText: (C) ColdFront Authors
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+INSERT INTO django_migrations (app, name, applied) VALUES ('users', '0001_initial', CURRENT_TIMESTAMP);
+UPDATE django_content_type SET app_label = 'users' WHERE app_label = 'auth' and model = 'user';


### PR DESCRIPTION
Fixes #884. We did not start off the project with a custom user model and this commit attempts to rectify that. Moving to a custom user model mid-project can be challenging so the steps we took are detailed below in case any issues creep up:

- Replaced all direct imports of `User`, i.e. `django.contrib.auth.models import User` with `get_user_model()` in code and `settings.AUTH_USER_MODEL` in models.

- Created new django `users` app which defines custom models for User and Group, which are based on django.contrib.auth

- Defined custom user model in settings `AUTH_USER_MODEL`

- We want to preserve all data so under the hood we will essentially just rename the `auth_user` table to `users_user` via migrations. Our new User model is identical to the default django one but in a new app. Because existing migrations depend on `auth.User` we need to trick django into thinking the initial migration of our `users` app is already there by inserting some records using `coldfront run dbshell`. The two sql statements are defined in `scripts/upgrade-v2.0.0-user-model.sql`. Running these is required before running the migrations.

- Django does not have an equivalent base group model so we create our own and copy all data from `auth_group` to `users_group` via a migration.