### PR TITLE
AttributeError: 'NoneType' object has no attribute 'view_name'

### DIFF
--- a/coldfront/core/utils/templatetags/common_tags.py
+++ b/coldfront/core/utils/templatetags/common_tags.py
@@ -97,9 +97,9 @@ def navbar_active_item(menu_item, request):
             "grant-report",
         ],
     }
-    view_name = request.resolver_match.view_name
-
-    if menu_item in view_map:
-        if view_name in view_map[menu_item]:
-            return "active"
+    if request != "" and request.resolver_match is not None:
+        view_name = request.resolver_match.view_name
+        if menu_item in view_map:
+            if view_name in view_map[menu_item]:
+                return "active"
     return ""


### PR DESCRIPTION
When I try to load the Django admin interface I get a crash.

```
AttributeError: 'NoneType' object has no attribute 'view_name'
...
AttributeError: 'str' object has no attribute 'resolver_match'
...
AttributeError: 'str' object has no attribute 'resolver_match'
...
AttributeError: 'str' object has no attribute 'resolver_match'
```

This one traceback is over 1000 lines: [error.log](https://github.com/user-attachments/files/25266297/error.log)