### PR TITLE
project_openldap: fix exception handlers

### DIFF
--- a/coldfront/plugins/project_openldap/management/commands/project_openldap_check_setup.py
+++ b/coldfront/plugins/project_openldap/management/commands/project_openldap_check_setup.py
@@ -173,8 +173,8 @@ class Command(BaseCommand):
                             f"FAILURE ldapsearch CANT find {PROJECT_OPENLDAP_OU}: {ldapsearch_check_project_ou_result} using bind user {PROJECT_OPENLDAP_BIND_USER}"
                         )
                     )
-            except LDAPException:
-                self.stdout.write(self.style.WARNING(f"ERROR WITH LDAPSEARCH: {LDAPException}"))
+            except LDAPException as e:
+                self.stdout.write(self.style.WARNING(f"ERROR WITH LDAPSEARCH: {e}"))
 
         self.stdout.write(self.style.SUCCESS("---------------------------------------------------"))
 
@@ -199,8 +199,8 @@ class Command(BaseCommand):
                             f"FAILURE ldapsearch CANT find {PROJECT_OPENLDAP_ARCHIVE_OU}: {ldapsearch_check_project_ou_result} using bind user {PROJECT_OPENLDAP_BIND_USER}"
                         )
                     )
-            except LDAPException:
-                self.stdout.write(self.style.WARNING(f"ERROR WITH LDAPSEARCH: {LDAPException}"))
+            except LDAPException as e:
+                self.stdout.write(self.style.WARNING(f"ERROR WITH LDAPSEARCH: {e}"))
 
         self.stdout.write(self.style.SUCCESS("---------------------------------------------------"))
 


### PR DESCRIPTION
before:

```
---------------------------------------------------
 Test ldapsearch
---------------------------------------------------

---------------------------------------------------
 LDAP SEARCH
 ou=projects,ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu is set to ou=projects,ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu
 ldapsearch...
ERROR WITH LDAPSEARCH: <class 'ldap3.core.exceptions.LDAPException'>
---------------------------------------------------
---------------------------------------------------
```

after:

```
---------------------------------------------------
 Test ldapsearch
---------------------------------------------------

---------------------------------------------------
 LDAP SEARCH
 ou=projects,ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu is set to ou=projects,ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu
 ldapsearch...
ERROR WITH LDAPSEARCH: {'result': 32, 'description': 'noSuchObject', 'dn': 'ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu', 'message': '', 'referrals': None, 'type': 'searchResDone'}
---------------------------------------------------
---------------------------------------------------
```