### PR TITLE
project_openldap: allow failed searches

### DIFF
--- a/coldfront/plugins/project_openldap/utils.py
+++ b/coldfront/plugins/project_openldap/utils.py
@@ -10,6 +10,7 @@ from typing import Any, Tuple
 
 from ldap3 import ALL_ATTRIBUTES, BASE, MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE, Connection, Server, Tls
 from ldap3.core.exceptions import LDAPException
+from ldap3.core.results import RESULT_NO_SUCH_ATTRIBUTE, RESULT_NO_SUCH_OBJECT, RESULT_SUCCESS
 from ldap3.utils.log import ERROR, set_library_log_detail_level
 
 from coldfront.core.utils.common import import_from_settings
@@ -297,7 +298,7 @@ def _ldap_write_wrapper(func, *args, write=True, **kwargs) -> bool:
         return False
     finally:
         conn.unbind()
-    if conn.result["result"] != 0:
+    if conn.result["result"] != RESULT_SUCCESS:
         logger.error("LDAP operation failed!", stack_info=True, extra=logger_extra_data)
         return False
     return True
@@ -307,7 +308,7 @@ def _ldap_read_wrapper(func, *args, **kwargs) -> Tuple[Connection, Any]:
     """
     * inserts an `ldap3.Connection` as the 1st argument to `func`
         * `func` should probably be a method of `ldap3.Connection` whose 1st argument is `self`
-    * raises `LDAPException` if the ldap3.Connection cannot be established or if the ldap3.Result code is nonzero
+    * raises `LDAPException` if the ldap3.Connection cannot be established or if the ldap3.Result code is unexpected
     * returns (ldap3.Connection, whatever `func` returns)
         * you should probably inspect the `entries` attributes of the `ldap3.Connection`
     """
@@ -322,6 +323,6 @@ def _ldap_read_wrapper(func, *args, **kwargs) -> Tuple[Connection, Any]:
         output = func(conn, *args, **kwargs)
     finally:
         conn.unbind()
-    if conn.result["result"] != 0:
+    if conn.result["result"] not in [RESULT_SUCCESS, RESULT_NO_SUCH_OBJECT, RESULT_NO_SUCH_ATTRIBUTE]:
         raise LDAPException(conn.result)
     return conn, output


### PR DESCRIPTION
before:

```
Syncing ALL OpenLDAP groups with ColdFront
--------------------
processing Project PROJ0002

Traceback (most recent call last):
  File "/srv/simon/./manage.py", line 8, in <module>
    sys.exit(manage())
             ^^^^^^^^
  File "/srv/simon/coldfront/coldfront/__init__.py", line 16, in manage
    execute_from_command_line(sys.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 420, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 464, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 648, in handle
    self.loop_all_projects(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 576, in loop_all_projects
    self.sync_check_project(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 434, in sync_check_project
    ldapsearch_project_result = ldapsearch_check_project_dn(project_dn)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 148, in ldapsearch_check_project_dn
    _, success = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 326, in _ldap_read_wrapper
    raise LDAPException(conn.result)
ldap3.core.exceptions.LDAPException: {'result': 32, 'description': 'noSuchObject', 'dn': 'ou=projects,ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu', 'message': '', 'referrals': None, 'type': 'searchResDone'}
```

after:

```
Syncing ALL OpenLDAP groups with ColdFront
--------------------
processing Project PROJ0002

search project OU result: False
search project archive OU result: N/A - PROJECT_OPENLDAP_ARCHIVE_OU is not set
Project DN for PROJ0002 is MISSING from OpenLDAP - SYNC is False - WILL NOT WRITE TO OpenLDAP
```