### PR TITLE
project_openldap: fix logger

### DIFF
--- a/coldfront/plugins/project_openldap/utils.py
+++ b/coldfront/plugins/project_openldap/utils.py
@@ -283,22 +283,22 @@ def _ldap_write_wrapper(func, *args, write=True, **kwargs) -> bool:
     """
     logger_extra_data = dict(funcname=func.__name__, args=args, kwargs=kwargs)
     if write:
-        logger.info("dry run, skipping...", stack_info=True, extra=logger_extra_data)
+        logger.info(f"dry run, skipping... - {logger_extra_data}")
         return True
     try:
         conn = Connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD, auto_bind=True)
     except LDAPException:
-        logger.exception("Failed to open LDAP connection", exc_info=True, extra=logger_extra_data)
+        logger.exception(f"Failed to open LDAP connection - {logger_extra_data}", exc_info=True)
         return False
     try:
         func(conn, *args, **kwargs)
     except Exception:
-        logger.exception("An unexpected exception occurred!", exc_info=True, extra=logger_extra_data)
+        logger.exception(f"An unexpected exception occurred! - {logger_extra_data}", exc_info=True)
         return False
     finally:
         conn.unbind()
     if conn.result["result"] != 0:
-        logger.error("LDAP operation failed!", stack_info=True, extra=logger_extra_data)
+        logger.error(f"LDAP operation failed! - {logger_extra_data}")
         return False
     return True
 


### PR DESCRIPTION
[Currently these don't work because you're not allowed to have a key `args` in your `extra` dict.](https://github.com/Delgan/loguru/issues/271)

<details>

```
Traceback (most recent call last):
  File "/srv/simon/./manage.py", line 8, in <module>
    sys.exit(manage())
             ^^^^^^^^
  File "/srv/simon/coldfront/coldfront/__init__.py", line 16, in manage
    execute_from_command_line(sys.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 420, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 464, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 649, in handle
    self.loop_all_projects(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 577, in loop_all_projects
    self.sync_check_project(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 486, in sync_check_project
    self.handle_missing_project_in_openldap_new_active(project, sync)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 117, in handle_missing_project_in_openldap_new_active
    add_project(project)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/tasks.py", line 72, in add_project
    add_per_project_ou_to_openldap(project_obj, ou_dn, openldap_ou_description)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 91, in add_per_project_ou_to_openldap
    _ldap_write_wrapper(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 292, in _ldap_write_wrapper
    logger.info("dry run, skipping...", stack_info=True, extra=logger_extra_data)
  File "/usr/lib/python3.12/logging/__init__.py", line 1539, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python3.12/logging/__init__.py", line 1682, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 1656, in makeRecord
    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
KeyError: "Attempt to overwrite 'args' in LogRecord"
```

</details>

[The `extra` kwarg doesn't work like I thought it does.](https://stackoverflow.com/questions/58657285/how-does-loggings-extra-argument-work)

I also removed `stack_info` because it's ugly and not really necessary.

<details>

```
Stack (most recent call last):
  File "/srv/simon/./manage.py", line 8, in <module>
    sys.exit(manage())
  File "/srv/simon/coldfront/coldfront/__init__.py", line 16, in manage
    execute_from_command_line(sys.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 420, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 464, in execute
    output = self.handle(*args, **options)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 649, in handle
    self.loop_all_projects(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 577, in loop_all_projects
    self.sync_check_project(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 486, in sync_check_project
    self.handle_missing_project_in_openldap_new_active(project, sync)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 117, in handle_missing_project_in_openldap_new_active
    add_project(project)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/tasks.py", line 89, in add_project
    add_members_to_openldap_posixgroup(posixgroup_dn, [project_obj.pi.username])
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 70, in add_members_to_openldap_posixgroup
    _ldap_write_wrapper(Connection.modify, dn, {"memberUid": [(MODIFY_ADD, list_memberuids)]}, write=write)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 292, in _ldap_write_wrapper
    logger.info("dry run, skipping...", stack_info=True, extra=logger_extra_data)
```

</details>