### PR TITLE
project_openldap: fix entries

### DIFF
--- a/coldfront/plugins/project_openldap/utils.py
+++ b/coldfront/plugins/project_openldap/utils.py
@@ -165,10 +165,10 @@ def ldapsearch_get_posixgroup_memberuids(dn):
     * raises `LDAPException` if the `ldap3.Connection` cannot be established or if the `ldap3.Result` code is nonzero
     * raises `KeyError` if the `entries` attribute of the `ldap3.Connection` is empty
     """
-    conn, _ = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE, attributes=ALL_ATTRIBUTES)
-    if len(conn.entries) == 0:
+    entries, _ = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE, attributes=ALL_ATTRIBUTES)
+    if len(entries) == 0:
         raise KeyError(dn)
-    return conn.entries
+    return entries
 
 
 def ldapsearch_get_description(dn):
@@ -177,10 +177,10 @@ def ldapsearch_get_description(dn):
     * raises `LDAPException` if the `ldap3.Connection` cannot be established or if the `ldap3.Result` code is nonzero
     * raises `KeyError` if the `entries` attribute of the `ldap3.Connection` is empty
     """
-    conn, _ = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE, attributes=["description"])
-    if len(conn.entries) == 0:
+    entries, _ = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE, attributes=["description"])
+    if len(entries) == 0:
         raise KeyError(dn)
-    return conn.entries
+    return entries
 
 
 """
@@ -303,13 +303,12 @@ def _ldap_write_wrapper(func, *args, write=True, **kwargs) -> bool:
     return True
 
 
-def _ldap_read_wrapper(func, *args, **kwargs) -> Tuple[Connection, Any]:
+def _ldap_read_wrapper(func, *args, **kwargs) -> Tuple[list, Any]:
     """
     * inserts an `ldap3.Connection` as the 1st argument to `func`
         * `func` should probably be a method of `ldap3.Connection` whose 1st argument is `self`
     * raises `LDAPException` if the ldap3.Connection cannot be established or if the ldap3.Result code is nonzero
-    * returns (ldap3.Connection, whatever `func` returns)
-        * you should probably inspect the `entries` attributes of the `ldap3.Connection`
+    * returns (ldap3.Connection.entries, whatever `func` returns)
     """
     conn = Connection(
         server,
@@ -320,8 +319,9 @@ def _ldap_read_wrapper(func, *args, **kwargs) -> Tuple[Connection, Any]:
     )
     try:
         output = func(conn, *args, **kwargs)
+        entries = conn.entries.copy()
     finally:
         conn.unbind()
     if conn.result["result"] != 0:
         raise LDAPException(conn.result)
-    return conn, output
+    return entries, output


### PR DESCRIPTION
after `Connection.unbind()`, `entries` is overwritten.