### PR TITLE
project_openldap: bugfixes

### DIFF
--- a/coldfront/plugins/project_openldap/management/commands/project_openldap_check_setup.py
+++ b/coldfront/plugins/project_openldap/management/commands/project_openldap_check_setup.py
@@ -173,8 +173,8 @@ class Command(BaseCommand):
                             f"FAILURE ldapsearch CANT find {PROJECT_OPENLDAP_OU}: {ldapsearch_check_project_ou_result} using bind user {PROJECT_OPENLDAP_BIND_USER}"
                         )
                     )
-            except LDAPException:
-                self.stdout.write(self.style.WARNING(f"ERROR WITH LDAPSEARCH: {LDAPException}"))
+            except LDAPException as e:
+                self.stdout.write(self.style.WARNING(f"ERROR WITH LDAPSEARCH: {e}"))
 
         self.stdout.write(self.style.SUCCESS("---------------------------------------------------"))
 
@@ -199,8 +199,8 @@ class Command(BaseCommand):
                             f"FAILURE ldapsearch CANT find {PROJECT_OPENLDAP_ARCHIVE_OU}: {ldapsearch_check_project_ou_result} using bind user {PROJECT_OPENLDAP_BIND_USER}"
                         )
                     )
-            except LDAPException:
-                self.stdout.write(self.style.WARNING(f"ERROR WITH LDAPSEARCH: {LDAPException}"))
+            except LDAPException as e:
+                self.stdout.write(self.style.WARNING(f"ERROR WITH LDAPSEARCH: {e}"))
 
         self.stdout.write(self.style.SUCCESS("---------------------------------------------------"))
 

--- a/coldfront/plugins/project_openldap/utils.py
+++ b/coldfront/plugins/project_openldap/utils.py
@@ -8,8 +8,9 @@ import logging
 import textwrap
 from typing import Any, Tuple
 
-from ldap3 import ALL_ATTRIBUTES, BASE, MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE, Connection, Server, Tls
+from ldap3 import BASE, MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE, Connection, Server, Tls
 from ldap3.core.exceptions import LDAPException
+from ldap3.core.results import RESULT_NO_SUCH_ATTRIBUTE, RESULT_NO_SUCH_OBJECT, RESULT_SUCCESS
 from ldap3.utils.log import ERROR, set_library_log_detail_level
 
 from coldfront.core.utils.common import import_from_settings
@@ -165,10 +166,10 @@ def ldapsearch_get_posixgroup_memberuids(dn):
     * raises `LDAPException` if the `ldap3.Connection` cannot be established or if the `ldap3.Result` code is nonzero
     * raises `KeyError` if the `entries` attribute of the `ldap3.Connection` is empty
     """
-    conn, _ = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE, attributes=ALL_ATTRIBUTES)
-    if len(conn.entries) == 0:
+    entries, _ = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE, attributes=["memberUid"])
+    if len(entries) == 0:
         raise KeyError(dn)
-    return conn.entries
+    return entries
 
 
 def ldapsearch_get_description(dn):
@@ -177,10 +178,10 @@ def ldapsearch_get_description(dn):
     * raises `LDAPException` if the `ldap3.Connection` cannot be established or if the `ldap3.Result` code is nonzero
     * raises `KeyError` if the `entries` attribute of the `ldap3.Connection` is empty
     """
-    conn, _ = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE, attributes=["description"])
-    if len(conn.entries) == 0:
+    entries, _ = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE, attributes=["description"])
+    if len(entries) == 0:
         raise KeyError(dn)
-    return conn.entries
+    return entries
 
 
 """
@@ -282,34 +283,33 @@ def _ldap_write_wrapper(func, *args, write=True, **kwargs) -> bool:
     * returns `True` if skipped or successful, `False` if failed
     """
     logger_extra_data = dict(funcname=func.__name__, args=args, kwargs=kwargs)
-    if write:
-        logger.info("dry run, skipping...", stack_info=True, extra=logger_extra_data)
+    if not write:
+        logger.info(f"dry run, skipping... - {logger_extra_data}")
         return True
     try:
         conn = Connection(server, PROJECT_OPENLDAP_BIND_USER, PROJECT_OPENLDAP_BIND_PASSWORD, auto_bind=True)
     except LDAPException:
-        logger.exception("Failed to open LDAP connection", exc_info=True, extra=logger_extra_data)
+        logger.exception(f"Failed to open LDAP connection - {logger_extra_data}", exc_info=True)
         return False
     try:
         func(conn, *args, **kwargs)
     except Exception:
-        logger.exception("An unexpected exception occurred!", exc_info=True, extra=logger_extra_data)
+        logger.exception(f"An unexpected exception occurred! - {logger_extra_data}", exc_info=True)
         return False
     finally:
         conn.unbind()
-    if conn.result["result"] != 0:
-        logger.error("LDAP operation failed!", stack_info=True, extra=logger_extra_data)
+    if conn.result["result"] != RESULT_SUCCESS:
+        logger.error(f"LDAP operation failed! - {logger_extra_data}")
         return False
     return True
 
 
-def _ldap_read_wrapper(func, *args, **kwargs) -> Tuple[Connection, Any]:
+def _ldap_read_wrapper(func, *args, **kwargs) -> Tuple[list, Any]:
     """
     * inserts an `ldap3.Connection` as the 1st argument to `func`
         * `func` should probably be a method of `ldap3.Connection` whose 1st argument is `self`
-    * raises `LDAPException` if the ldap3.Connection cannot be established or if the ldap3.Result code is nonzero
-    * returns (ldap3.Connection, whatever `func` returns)
-        * you should probably inspect the `entries` attributes of the `ldap3.Connection`
+    * raises `LDAPException` if the ldap3.Connection cannot be established or if the ldap3.Result code is unexpected
+    * returns (ldap3.Connection.entries, whatever `func` returns)
     """
     conn = Connection(
         server,
@@ -320,8 +320,9 @@ def _ldap_read_wrapper(func, *args, **kwargs) -> Tuple[Connection, Any]:
     )
     try:
         output = func(conn, *args, **kwargs)
+        entries = conn.entries.copy()
     finally:
         conn.unbind()
-    if conn.result["result"] != 0:
+    if conn.result["result"] not in [RESULT_SUCCESS, RESULT_NO_SUCH_OBJECT, RESULT_NO_SUCH_ATTRIBUTE]:
         raise LDAPException(conn.result)
-    return conn, output
+    return entries, output


### PR DESCRIPTION
This should all have been included in https://github.com/coldfront/coldfront/pull/825. I wasn't ready for it to be merged, I should have marked it as draft.

## Fix `entries`

after Connection.unbind(), entries is overwritten.

## Fix Backwards Conditional

## Fix Logger

[Currently these don't work because you're not allowed to have a key `args` in your `extra` dict](https://github.com/Delgan/loguru/issues/271)

<details><summary>traceback:</summary>

```
Traceback (most recent call last):
  File "/srv/simon/./manage.py", line 8, in <module>
    sys.exit(manage())
             ^^^^^^^^
  File "/srv/simon/coldfront/coldfront/__init__.py", line 16, in manage
    execute_from_command_line(sys.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 420, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 464, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 649, in handle
    self.loop_all_projects(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 577, in loop_all_projects
    self.sync_check_project(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 486, in sync_check_project
    self.handle_missing_project_in_openldap_new_active(project, sync)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 117, in handle_missing_project_in_openldap_new_active
    add_project(project)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/tasks.py", line 72, in add_project
    add_per_project_ou_to_openldap(project_obj, ou_dn, openldap_ou_description)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 91, in add_per_project_ou_to_openldap
    _ldap_write_wrapper(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 292, in _ldap_write_wrapper
    logger.info("dry run, skipping...", stack_info=True, extra=logger_extra_data)
  File "/usr/lib/python3.12/logging/__init__.py", line 1539, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python3.12/logging/__init__.py", line 1682, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 1656, in makeRecord
    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
KeyError: "Attempt to overwrite 'args' in LogRecord"
```

</details>

[The `extra` kwarg doesn't work like I thought it does.](https://stackoverflow.com/questions/58657285/how-does-loggings-extra-argument-work)

<details><summary>I also removed `stack_info` because it's ugly and not really necessary.</summary>

```
Stack (most recent call last):
  File "/srv/simon/./manage.py", line 8, in <module>
    sys.exit(manage())
  File "/srv/simon/coldfront/coldfront/__init__.py", line 16, in manage
    execute_from_command_line(sys.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 420, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 464, in execute
    output = self.handle(*args, **options)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 649, in handle
    self.loop_all_projects(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 577, in loop_all_projects
    self.sync_check_project(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 486, in sync_check_project
    self.handle_missing_project_in_openldap_new_active(project, sync)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 117, in handle_missing_project_in_openldap_new_active
    add_project(project)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/tasks.py", line 89, in add_project
    add_members_to_openldap_posixgroup(posixgroup_dn, [project_obj.pi.username])
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 70, in add_members_to_openldap_posixgroup
    _ldap_write_wrapper(Connection.modify, dn, {"memberUid": [(MODIFY_ADD, list_memberuids)]}, write=write)
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 292, in _ldap_write_wrapper
    logger.info("dry run, skipping...", stack_info=True, extra=logger_extra_data)
```

</details>

## Allow Failed Searches

<details><summary>before:</summary>

```
Syncing ALL OpenLDAP groups with ColdFront
--------------------
processing Project PROJ0002

Traceback (most recent call last):
  File "/srv/simon/./manage.py", line 8, in <module>
    sys.exit(manage())
             ^^^^^^^^
  File "/srv/simon/coldfront/coldfront/__init__.py", line 16, in manage
    execute_from_command_line(sys.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 420, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/srv/simon/venv/lib/python3.12/site-packages/django/core/management/base.py", line 464, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 648, in handle
    self.loop_all_projects(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 576, in loop_all_projects
    self.sync_check_project(
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/management/commands/project_openldap_sync.py", line 434, in sync_check_project
    ldapsearch_project_result = ldapsearch_check_project_dn(project_dn)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 148, in ldapsearch_check_project_dn
    _, success = _ldap_read_wrapper(Connection.search, dn, "(objectclass=posixGroup)", BASE)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/srv/simon/coldfront/coldfront/plugins/project_openldap/utils.py", line 326, in _ldap_read_wrapper
    raise LDAPException(conn.result)
ldap3.core.exceptions.LDAPException: {'result': 32, 'description': 'noSuchObject', 'dn': 'ou=projects,ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu', 'message': '', 'referrals': None, 'type': 'searchResDone'}
```

</details>

<details><summary>after:</summary>

```
Syncing ALL OpenLDAP groups with ColdFront
--------------------
processing Project PROJ0002

search project OU result: False
search project archive OU result: N/A - PROJECT_OPENLDAP_ARCHIVE_OU is not set
Project DN for PROJ0002 is MISSING from OpenLDAP - SYNC is False - WILL NOT WRITE TO OpenLDAP
```

</details>

## Fix Exception Handlers

This one is actually unrelated to https://github.com/coldfront/coldfront/pull/825, but an easy fix.

<details><summary>before:</summary>

```
---------------------------------------------------
 Test ldapsearch
---------------------------------------------------

---------------------------------------------------
 LDAP SEARCH
 ou=projects,ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu is set to ou=projects,ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu
 ldapsearch...
ERROR WITH LDAPSEARCH: <class 'ldap3.core.exceptions.LDAPException'>
---------------------------------------------------
---------------------------------------------------
```

</details>

<details><summary>after:</summary>

```
---------------------------------------------------
 Test ldapsearch
---------------------------------------------------

---------------------------------------------------
 LDAP SEARCH
 ou=projects,ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu is set to ou=projects,ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu
 ldapsearch...
ERROR WITH LDAPSEARCH: {'result': 32, 'description': 'noSuchObject', 'dn': 'ou=coldfront,dc=unity,dc=rc,dc=umass,dc=edu', 'message': '', 'referrals': None, 'type': 'searchResDone'}
---------------------------------------------------
---------------------------------------------------
```

</details>

## Fix Attribute Not Found

I was worried that when querying for `attributes=["memberUid"]`, that an entry with no members would be omitted completely. So I used `attributes=ALL_ATTRIBUTES` to ensure that no entry could be omitted. `["memberUid"]` actually worked fine, and `ALL_ATTRIBUTES` was broken because the `memberUid` attribute could now be omitted.