### PR TITLE
Add support for subpaths

### DIFF
--- a/coldfront/config/auth.py
+++ b/coldfront/config/auth.py
@@ -13,7 +13,7 @@ AUTHENTICATION_BACKENDS += [
 ]
 
 LOGIN_URL = "/user/login"
-LOGIN_REDIRECT_URL = "/"
+LOGIN_REDIRECT_URL = "home"
 LOGOUT_REDIRECT_URL = ENV.str("LOGOUT_REDIRECT_URL", LOGIN_URL)
 
 SU_LOGIN_CALLBACK = "coldfront.core.utils.common.su_login_callback"

--- a/coldfront/config/auth.py
+++ b/coldfront/config/auth.py
@@ -12,12 +12,12 @@ AUTHENTICATION_BACKENDS += [
     "django.contrib.auth.backends.ModelBackend",
 ]
 
-LOGIN_URL = "/user/login"
+LOGIN_URL = "user/login"
 LOGIN_REDIRECT_URL = "home"
 LOGOUT_REDIRECT_URL = ENV.str("LOGOUT_REDIRECT_URL", LOGIN_URL)
 
 SU_LOGIN_CALLBACK = "coldfront.core.utils.common.su_login_callback"
-SU_LOGOUT_REDIRECT_URL = "/admin/auth/user/"
+SU_LOGOUT_REDIRECT_URL = "admin/auth/user/"
 
 SESSION_COOKIE_AGE = ENV.int("SESSION_INACTIVITY_TIMEOUT", default=60 * 60)
 SESSION_SAVE_EVERY_REQUEST = True

--- a/coldfront/config/base.py
+++ b/coldfront/config/base.py
@@ -149,7 +149,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap5"
 
 SETTINGS_EXPORT = []
 
-STATIC_URL = "/static/"
+STATIC_URL = "static/"
 
 DJANGO_VITE = {
     "default": {

--- a/coldfront/core/allocation/templates/allocation/allocation_list.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_list.html
@@ -77,9 +77,9 @@ Allocation List
       <tbody>
         {% for allocation in allocation_list %}
           <tr>
-            <td><a href="/allocation/{{allocation.id}}/">{{ allocation.id }}</a></td>
+            <td><a href="{% url 'allocation-detail' allocation.pk %}">{{ allocation.id }}</a></td>
             <td class="text-nowrap"><a
-                href="/project/{{allocation.project.id}}/">{{ allocation.project.title|truncatechars:50 }}</a></td>
+                href="{% url 'project-detail' allocation.project.pk %}">{{ allocation.project.title|truncatechars:50 }}</a></td>
             <td class="text-nowrap">{{allocation.project.pi.first_name}} {{allocation.project.pi.last_name}}
               ({{allocation.project.pi.username}})</td>
             <td class="text-nowrap">{{ allocation.get_parent_resource }}</td>

--- a/coldfront/core/portal/templates/portal/center_summary.html
+++ b/coldfront/core/portal/templates/portal/center_summary.html
@@ -67,7 +67,7 @@ Center Summary
   <div class="card-header">
     <i class="fas fa-flask" aria-hidden="true"></i> Active Allocations and Users by Field of Science
   </div>
-  <div id="allocation-by-fos" class="card-body" hx-get="/allocation-by-fos" hx-trigger="load">
+  <div id="allocation-by-fos" class="card-body" hx-get="{% url 'allocation-by-fos' %}" hx-trigger="load">
     <div class="text-center">
       <button type="button" class="btn btn-primary"><i class="fas fa-sync fa-spin fa-fw" aria-hidden="true"></i> Getting Data <span
           class="visually-hidden">...</span></button>
@@ -91,7 +91,7 @@ Center Summary
                 <canvas id="resource-summary-chart"></canvas>
             </div>
         </div>
-        <div id="allocation-summary" class="col" hx-get="/allocation-summary" hx-trigger="load">
+        <div id="allocation-summary" class="col" hx-get="{% url 'allocation-summary' %}" hx-trigger="load">
             <div class="text-center">
               <button type="button" class="btn btn-primary"><i class="fas fa-sync fa-spin fa-fw" aria-hidden="true"></i> Getting Data <span
                   class="visually-hidden">...</span></button>

--- a/coldfront/core/project/templates/project/project_archived_list.html
+++ b/coldfront/core/project/templates/project/project_archived_list.html
@@ -77,9 +77,9 @@ Project List
         {% for project in project_list %}
           <tr>
             {% if project.project_code %}
-                <td><a href="/project/{{project.id}}/">{{ project.project_code }}</a></td>
+                <td><a href="{% url 'project-detail' project.id %}">{{ project.project_code }}</a></td>
             {% else %}
-                <td><a href="/project/{{project.id}}/">{{ project.id }}</a></td>
+                <td><a href="{% url 'project-detail' project.id %}">{{ project.id }}</a></td>
             {% endif %}
             <td>{{ project.pi.username }}</td>
             <td><strong>Title: </strong> {{ project.title }}

--- a/coldfront/core/project/templates/project/project_list.html
+++ b/coldfront/core/project/templates/project/project_list.html
@@ -84,9 +84,9 @@ Project List
         {% for project in project_list %}
           <tr>
             {% if project.project_code %}
-                <td><a href="/project/{{project.id}}/">{{ project.project_code }}</a></td>
+                <td><a href="{% url 'project-detail' project.pk %}">{{ project.project_code }}</a></td>
             {% else %}
-                <td><a href="/project/{{project.id}}/">{{ project.id }}</a></td>
+                <td><a href="{% url 'project-detail' project.pk %}">{{ project.id }}</a></td>
             {% endif %}
             <td>{{ project.pi.username }}</td>
             <td>{{ project.title }}</td>

--- a/coldfront/core/resource/templates/resource_list.html
+++ b/coldfront/core/resource/templates/resource_list.html
@@ -67,7 +67,7 @@ Resource List
       <tbody>
         {% for resource in resource_list %}
           <tr>
-            <td><a href="/resource/{{resource.id}}/">{{ resource.id }}</a></td>
+            <td><a href="{% url 'resource-detail' resource.pk %}">{{ resource.id }}</a></td>
             <td>{{ resource }}</td>
             <td>{{ resource.parent_resource }}</td>
             <td>{{ resource.resource_type.name }}</td>

--- a/coldfront/core/test_helpers/utils.py
+++ b/coldfront/core/test_helpers/utils.py
@@ -41,7 +41,7 @@ def test_logged_out_redirect_to_login(test_case, page):
     # log out, in case already logged in
     test_case.client.logout()
     response = test_case.client.get(page)
-    test_case.assertRedirects(response, f"/user/login?next={page}")
+    test_case.assertRedirects(response, f"user/login?next={page}")
 
 
 def test_redirect(test_case, page):

--- a/coldfront/core/user/templates/user/user_search_home.html
+++ b/coldfront/core/user/templates/user/user_search_home.html
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     $.ajax({
-        url : "/user/user-search-results/", // the endpoint
+        url : "{% url 'user-search-results' %}", // the endpoint
         type : "POST", // http method
         data : {
           q : q,

--- a/coldfront/static/src/charts/allocationChart.ts
+++ b/coldfront/static/src/charts/allocationChart.ts
@@ -9,7 +9,7 @@ import type { ChartData, ChartDataItem } from './data';
 export function initAllocationChart(): void {
   renderChart(
     'allocation-summary-chart',
-    '/portal/data/allocation-by-status',
+    'portal/data/allocation-by-status',
     createAllocationChart
   );
 }

--- a/coldfront/static/src/charts/grantChart.ts
+++ b/coldfront/static/src/charts/grantChart.ts
@@ -7,7 +7,7 @@ import { renderChart, ColorPalette } from './data';
 import type { ChartData, ChartDataItem } from './data';
 
 export function initGrantChart(): void {
-  renderChart('grant-summary-chart', '/grant/data/summary', createGrantChart);
+  renderChart('grant-summary-chart', 'grant/data/summary', createGrantChart);
 }
 
 function createGrantChart(

--- a/coldfront/static/src/charts/publicationChart.ts
+++ b/coldfront/static/src/charts/publicationChart.ts
@@ -9,7 +9,7 @@ import type { ChartData, ChartDataItem } from './data';
 export function initPubChart(): void {
   renderChart(
     'pubs-by-year-chart',
-    '/publication/data/by-year',
+    'publication/data/by-year',
     createPubChart
   );
 }

--- a/coldfront/static/src/charts/resourceChart.ts
+++ b/coldfront/static/src/charts/resourceChart.ts
@@ -9,7 +9,7 @@ import type { ChartData, ChartDataItem } from './data';
 export function initResourceChart(): void {
   renderChart(
     'resource-summary-chart',
-    '/portal/data/resource-by-type',
+    'portal/data/resource-by-type',
     createResourceChart
   );
 }

--- a/coldfront/static/vite.config.js
+++ b/coldfront/static/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     plugins: [eslint()],
-    base: "static/", // This should match django settings.STATIC_URL
+    base: "", // This should match django settings.STATIC_URL
     build: {
       // Where Vite will save its output files.
       // This should be added to django settings.STATICFILES_DIRS

--- a/coldfront/static/vite.config.js
+++ b/coldfront/static/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     plugins: [eslint()],
-    base: "/static", // This should match django settings.STATIC_URL
+    base: "static/", // This should match django settings.STATIC_URL
     build: {
       // Where Vite will save its output files.
       // This should be added to django settings.STATICFILES_DIRS

--- a/coldfront/templates/common/authorized_navbar.html
+++ b/coldfront/templates/common/authorized_navbar.html
@@ -12,7 +12,7 @@
     <div class="navbar-collapse collapse" id="navbar-main">
       <ul class="navbar-nav">
         <li id="navbar-home" class="nav-item">
-          <a class="nav-link {% navbar_active_item 'home' request %}" href="/">Home</a>
+          <a class="nav-link {% navbar_active_item 'home' request %}" href="{% url 'home' %}">Home</a>
         </li>
         <li id="navbar-center-summary" class="nav-item">
           <a class="nav-link {% navbar_active_item 'center-summary' request %}" href="{% url 'center-summary' %}">Center Summary</a>

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -3,7 +3,7 @@
 <li id="navbar-admin" class="nav-item dropdown">
   <a class="nav-link dropdown-toggle {% navbar_active_item 'admin' request %}" href="#" data-bs-toggle="dropdown">Admin</a>
   <div class="dropdown-menu">
-    <a class="dropdown-item" href="/admin">ColdFront Administration</a>
+    <a class="dropdown-item" href="admin">ColdFront Administration</a>
     <a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a>
     <a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a>
     <a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a>

--- a/coldfront/templates/common/navbar_brand.html
+++ b/coldfront/templates/common/navbar_brand.html
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row">
       <div class="col-6 col-md-2">
-        <a href="/"><img class="img-responsive banner-logo" src="{% static 'common/images/logo.png' %}" alt="Coldfront"></a>
+        <a href="{% url 'home' %}"><img class="img-responsive banner-logo" src="{% static 'common/images/logo.png' %}" alt="Coldfront"></a>
       </div>
       <div class="col-6 col-md-6">
         <h3 class="banner-name">{{ settings.CENTER_NAME }}</h3>

--- a/coldfront/templates/common/nonauthorized_navbar.html
+++ b/coldfront/templates/common/nonauthorized_navbar.html
@@ -11,7 +11,7 @@
     <div class="navbar-collapse collapse" id="navbar-main">
       <ul class="navbar-nav">
         <li id="navbar-home" class="nav-item">
-          <a class="nav-link {% navbar_active_item 'home' request %}" href="/">Home</a>
+          <a class="nav-link {% navbar_active_item 'home' request %}" href="{% url 'home' %}">Home</a>
         </li>
         <li id="navbar-center-summary" class="nav-item">
           <a class="nav-link {% navbar_active_item 'center-summary' request %}" href="{% url 'center-summary' %}">Center Summary</a>


### PR DESCRIPTION
This PR is supposed to add support for running Coldfront on a subpath using `FORCE_SCRIPT_NAME`, which we need for our center. There are two things still missing, that's why this is marked as draft: Docs, and Vite-generated assets.

Currently the `coldfront.css` is checked into the repo with static paths, but I would need to recreate these files with the `FORCE_SCRIPT_NAME` in front, probably on `collectstatic`. Unfortunately I have no experience with Vite; I would love it if anyone could point me into the right direction on how to wire this up.

Fixes https://github.com/coldfront/coldfront/issues/988.