### PR TITLE
bug: fix filter_options in get_user_emails() method

### DIFF
--- a/coldfront/core/allocation/models.py
+++ b/coldfront/core/allocation/models.py
@@ -459,7 +459,7 @@ class Allocation(TimeStampedModel):
         users = allocation_users.values_list("user", flat=True)
         filter_options = {
             "user__in": users,
-            "staus__name": "Active",
+            "status__name": "Active",
             "enable_notifications": True,
         }
 


### PR DESCRIPTION
Small typo in `Allocation.get_user_emails()`.

Before:

```py
        filter_options = {
            "user__in": users,
            "staus__name": "Active",
            "enable_notifications": True,
        }
```

After:

```py
        filter_options = {
            "user__in": users,
            "status__name": "Active",
            "enable_notifications": True,
        }
```